### PR TITLE
Concatenation of announcements now working

### DIFF
--- a/navit/navigation.c
+++ b/navit/navigation.c
@@ -127,6 +127,18 @@ static int sharp_turn_limit = 110;
  * Note that, depending on other conditions, even maneuvers whose delta exceeds the threshold may still be announced as (sharp) turns. */
 static int u_turn_limit = 165;
 
+/** Enum that defines the different states in announcing a turn.
+ *  These states are dependent on the current distance to the turn;
+ *  the distances are configured in navit.xml for every type of highway. */
+enum announcement_level {
+	level_connect = -2,
+	level_error   = -1,
+	level_now     = 0,
+	level_meters  = 1,
+	level_soon    = 2,
+	level_follow  = 3
+};
+
 enum gender {unknown, masculine, feminine, neuter};
 
 struct suffix {
@@ -786,38 +798,39 @@ navigation_set_announce(struct navigation *this_, enum item_type type, int *leve
 		dbg(lvl_debug,"street type %d out of range [%d,%d]", type, route_item_first, route_item_last);
 		return 0;
 	}
-	for (i = 0 ; i < 3 ; i++) 
+	for (i = 0 ; i < 3 ; i++)
 		this_->announce[type-route_item_first][i]=level[i];
 	return 1;
 }
 
-static int
+static enum announcement_level
 navigation_get_announce_level(struct navigation *this_, enum item_type type, int dist)
 {
-	int i;
+	enum announcement_level level;
 
 	if (type < route_item_first || type > route_item_last)
 	{
 		dbg(lvl_error," item outside routable range\n");
-		return -1;
+		return level_error;
 	}
-	for (i = 0 ; i < 3 ; i++) {
-		if (dist <= this_->announce[type-route_item_first][i])
-			return i;
+	for (level = level_now ; level < level_follow ; level++) {
+		if (dist <= this_->announce[type-route_item_first][level])
+			return level;
 	}
-	return i;
+	return level;
 }
 
 static int is_way_allowed(struct navigation *nav, struct navigation_way *way, int mode);
 
-static int
+static enum announcement_level
 navigation_get_announce_level_cmd(struct navigation *this_, struct navigation_itm *itm, struct navigation_command *cmd, int distance)
 {
-	int level2,level=navigation_get_announce_level(this_, itm->way.item.type, distance);
+	enum announcement_level level2,level=navigation_get_announce_level(this_, itm->way.item.type, distance);
 	if (this_->cmd_first->itm->prev) {
 		level2=navigation_get_announce_level(this_, cmd->itm->prev->way.item.type, distance);
-		if (level2 > level)
-			level=level2;
+		if (level2 > level) {
+			level = level2;
+		}
 	}
 	return level;
 }
@@ -3251,50 +3264,60 @@ navigation_cmd_get_exit_announce(struct navigation_command *this_, char *street_
  * in..., then turn right"
  */
 static char *
-show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd, enum attr_type type, int connect)
+show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd, enum attr_type type, enum announcement_level level)
 {
 
 	int distance=itm->dest_length-cmd->itm->dest_length;
 	char *d=NULL,*ret=NULL;
 	char *street_destination_announce=NULL;
-	int level;
 	int skip_roads = 0;
 	int count_roundabout;
 	struct navigation_itm *cur;
 	int tellstreetname = 0;
-	char * at = NULL;        /* Motorway junction name */
-	char * direction = NULL; /* The direction-dependent part of the maneuver */
+	char *at = NULL;        /* Motorway junction name */
+	char *direction = NULL; /* The direction-dependent part of the maneuver */
 	char *destination = NULL;
 	char *street_destination = NULL;
-	char * instruction = NULL;
-	char * strength = NULL;  /* Strength of the turn */
-
-	if (connect)
-		level = -2; /* level = -2 means "connect to another maneuver via 'then ...'" */
-	else
-		level = 1;
+	char *instruction = NULL;
+	char *strength = NULL;  /* Strength of turn like 'easily', 'strongly', etc. */
 
 
 	if (type != attr_navigation_long_exact)
 		distance=round_distance(distance);
-	if (type == attr_navigation_speech)
-	{
-		if (nav->turn_around && nav->turn_around == nav->turn_around_limit)
-		{
-			navigation_set_turnaround(nav, nav->turn_around_count+1);
-			return g_strdup(_("When possible, please turn around"));
+
+	if (type == attr_navigation_speech) {
+		if (nav->turn_around && nav->turn_around == nav->turn_around_limit) {
+			if (level == level_connect) {
+				return g_strdup(""); /* there is no ',then turn around' */
+			} else {
+				navigation_set_turnaround(nav, nav->turn_around_count+1);
+				return g_strdup(_("When possible, please turn around"));
+			}
 		}
 		navigation_set_turnaround(nav, 0);
-		if (!connect)
-			level=navigation_get_announce_level_cmd(nav, itm, cmd, distance-cmd->length);
 		dbg(lvl_debug,"distance=%d level=%d type=0x%x\n", distance, level, itm->way.item.type);
 	}
 
 
 	street_destination=select_announced_destinations(cmd);
 	if (street_destination)
-		/* TRANSLATORS: the argument is the destination to follow */
-		street_destination_announce=g_strdup_printf(_("towards %s"),street_destination);
+		if (level == level_connect) {
+			/* for the connected announcement suppress the destination, if this is the same as in the first part of the announcement */
+			if (cmd->prev) {
+				char *street_destination_previous = select_announced_destinations(cmd->prev);
+				if (street_destination_previous && strstr(street_destination_previous, street_destination)) { /* doesn't have any new information? */
+					street_destination_announce=g_strdup("");
+				} else {
+					/* TRANSLATORS: the argument is the destination to follow */
+					street_destination_announce=g_strdup_printf(_("towards %s"),street_destination);
+				}
+				g_free(street_destination_previous);
+			} else {
+				street_destination_announce=g_strdup_printf(_("towards %s"),street_destination);
+			}
+		} else {
+			street_destination_announce=g_strdup_printf(_("towards %s"),street_destination);
+		}
 	else street_destination_announce=g_strdup("");
 	g_free(street_destination);
 
@@ -3311,21 +3334,20 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 		}
 		switch (level)
 		{
-			case 3:
+			case level_follow:
 				d=get_distance_str(nav, distance, type, 1);
 				return g_strdup_printf(_("Follow the road for the next %s"), d);
-			case 2:
+			case level_soon:
 				return g_strdup(_("Enter the roundabout soon"));
-			case 1:
+			case level_meters:
 				d = get_distance_str(nav, distance, attr_navigation_short, 0);
 				/* TRANSLATORS: %s is the distance to the roundabout */
 				ret = g_strdup_printf(_("Enter the roundabout %s"), d);
 				g_free(d);
 				return ret;
-			case -2:
-				/* TRANSLATORS: first arg. is the manieth exit, second arg. is the destination to follow */
-				return g_strdup_printf(_("then leave the roundabout at the %1$s %2$s"), get_exit_count_str(count_roundabout),street_destination_announce);
-			case 0:
+			case level_connect:
+				return g_strdup(_("then enter the roundabout"));
+			case level_now:
 				/* TRANSLATORS: first arg. is the manieth exit, second arg. is the destination to follow */
 				return g_strdup_printf(_("Leave the roundabout at the %1$s %2$s"), get_exit_count_str(count_roundabout),street_destination_announce);
 		}
@@ -3337,20 +3359,23 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 		{
 			if(type == attr_navigation_speech)
 			{ /* In voice mode */
-			/* In Voice Mode only tell the street name in level 1 or in level 0 if level 1	was skipped */
-				if (level == 1)
+			/* In Voice Mode only tell the street name in level_meters or in level_ if level 1	was skipped */
+				if (level == level_meters)
 				{ /* we are close to the intersection */
 					cmd->itm->streetname_told = 1; /* remember to be checked when we turn */
 					tellstreetname = 1;	       /* Ok, so we tell the name of the street */
 				}
-				if (level == 0)
+				else if (level == level_now)
 				{
 					if(cmd->itm->streetname_told == 0) /* we are right at the intersection */
 						tellstreetname = 1;
 					else
 						cmd->itm->streetname_told = 0;  /* reset just in case we come to the same street again */
 				}
-
+				else if (level == level_connect)
+				{
+				  	tellstreetname = 1;
+				}
 			}
 			else
 				tellstreetname = 1;
@@ -3359,16 +3384,16 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 
 		switch (level)
 		{
-			case 2 :
+			case level_soon :
 				d=g_strdup(_("soon"));
 				break;
-			case 1 :
+			case level_meters :
 				d=get_distance_str(nav, distance, attr_navigation_short, 0);
 				break;
-			case 0 :
+			case level_now :
 				d=g_strdup(_("now"));
 				break;
-			case -2 :
+			case level_connect :
 				d=g_strdup(_("then"));
 				break;
 			default :
@@ -3387,8 +3412,8 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 			 /* interchange or exit announcement shall be a long distance information only.
 			    But if so, exit_label shall not be announced in case it is a substring 
 			    of destination info to avoid redundancy and not let the sentence become too long.
-			    Otherwise, if there is no additional destination info, just say it at level 1. */
-			if ((level == 2) || ((level == 1) && (!street_destination_announce && !destination)) || (type != attr_navigation_speech)) {
+			    Otherwise, if there is no additional destination info, just say it at level_meters. */
+			if ((level == level_soon) || ((level == level_meters) && (!street_destination_announce && !destination)) || (type != attr_navigation_speech)) {
 				exit_announce = navigation_cmd_get_exit_announce(cmd, street_destination_announce);
 			}
 
@@ -3397,16 +3422,16 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 				case mex_merge_left:
 				case mex_merge_right:
 					if (cmd->maneuver->merge_or_exit == mex_merge_right) {
-						if (level == -2)
+						if (level == level_connect)
 							/* TRANSLATORS: the arg. is the phrase 'onto ...'. Right merge, the stuff after | doesn't have to be included. */
-							instruction = g_strdup_printf(_("then merge%1$s|right"), d);
+							instruction = g_strdup_printf(_("then merge%1$s|right"), destination);
 						else
 							/* TRANSLATORS: the first arg. is distance, the second is the phrase 'onto ...'. Right merge, the stuff after | doesn't have to be included. */
 							instruction = g_strdup_printf(_("Merge %1$s%2$s|right"), d, destination);
 					} else {
-						if (level == -2)
+						if (level == level_connect)
 							/* TRANSLATORS: the arg. is the phrase 'onto ...'. Left merge, the stuff after | doesn't have to be included. */
-							instruction = g_strdup_printf(_("then merge%1$s|left"), d);
+							instruction = g_strdup_printf(_("then merge%1$s|left"), destination);
 						else
 							/* TRANSLATORS: the first arg. is distance, the second is the phrase 'onto ...'. Left merge, the stuff after | doesn't have to be included. */
 							instruction = g_strdup_printf(_("Merge %1$s%2$s|left"), d, destination);
@@ -3439,7 +3464,7 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 				at = g_strdup("");
 			switch (cmd->maneuver->type) {
 				case type_nav_straight :
-					if (level == -2)
+					if (level == level_connect)
 						/* TRANSLATORS: the arg. is where to do the maneuver */
 						instruction = g_strdup_printf(_("then continue straight%1$s"), at);
 					else
@@ -3447,7 +3472,7 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 						instruction = g_strdup_printf(_("Continue straight %1$s%2$s%3$s"), d, at, destination);
 					break;
 				case type_nav_keep_right :
-					if (level == -2)
+					if (level == level_connect)
 						/* TRANSLATORS: the arg. is where to do the maneuver */
 						instruction = g_strdup_printf(_("then keep right%1$s"), at);
 					else
@@ -3455,7 +3480,7 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 						instruction = g_strdup_printf(_("Keep right %1$s%2$s%3$s"), d, at, destination);
 					break;
 				case type_nav_keep_left :
-					if (level == -2)
+					if (level == level_connect)
 						/* TRANSLATORS: the arg. is where to do the maneuver */
 						instruction = g_strdup_printf(_("then keep left%1$s"), at);
 					else
@@ -3475,16 +3500,21 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 					case type_nav_right_3 :
 						/* TRANSLATORS: "right" as in "turn right" */
 						direction = g_strdup(_("right"));
-						if (level==-2 || level == 0)
-							skip_roads = count_possible_turns(nav,cmd->prev ? cmd->prev->itm : nav->first,cmd->itm,90);
+						if (level == level_now)
+							skip_roads = count_possible_turns(nav, cmd->prev ? cmd->prev->itm : nav->first, cmd->itm, 90);
+						else if (level == level_connect)
+							/* Robotaxi: todo - must tidy up skip_roads == -1 issue */
+							skip_roads = count_possible_turns(nav, itm->next ? itm->next : itm, cmd->itm, 90);
 						break;
 					case type_nav_left_1 :
 					case type_nav_left_2 :
 					case type_nav_left_3 :
 						/* TRANSLATORS: "left" as in "turn left" */
 						direction = g_strdup(_("left"));
-						if (level==-2 || level == 0)
-							skip_roads = count_possible_turns(nav,cmd->prev ? cmd->prev->itm : nav->first,cmd->itm,-90);
+						if (level == level_now)
+							skip_roads = count_possible_turns(nav, cmd->prev ? cmd->prev->itm : nav->first, cmd->itm, -90);
+						else if (level == level_connect)
+							skip_roads = count_possible_turns(nav, itm->next ? itm->next : itm, cmd->itm, -90);
 						break;
 					default:
 						direction = g_strdup("");
@@ -3505,22 +3535,28 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 						strength = g_strdup("");
 						break;
 					}
-					if (skip_roads) {
-						if (skip_roads < 6)
-							instruction = g_strdup_printf(_("Take the %1$s road to the %2$s"), get_count_str(skip_roads+1), direction);
-							/*and preserve skip_roads to signal we already have an instruction*/
-						else {
+					/* Robotaxi: todo - must tidy up skip_roads == -1 issue */
+					if (skip_roads > 0) {
+						if (skip_roads < 6) {
+							if (level == level_connect)
+								instruction = g_strdup_printf(_("then take the %1$s road to the %2$s"), get_count_str(skip_roads+1), direction);
+							else
+								instruction = g_strdup_printf(_("Take the %1$s road to the %2$s"), get_count_str(skip_roads+1), direction);
+							/*and preserve skip_roads to signal that we already have an instruction*/
+						} else {
 							g_free(d);
 							d=g_strdup_printf(_("after %i roads"),skip_roads);
 							skip_roads = 0; /*signal an instruction still has to be created*/
 						}
 					}
-					if (!skip_roads) /* cave: no else - may come from 'if (skip_roads)' above ! */
+					 /* cave: no else - may come from 'if (skip_roads)' above ! */
+					if (skip_roads <= 0) {
 						/* TRANSLATORS: the first arg. is strength, the second is direction, the third is distance, the fourth is destination  */
 						instruction = g_strdup_printf(_("Turn %1$s%2$s %3$s%4$s"), strength, direction, d, destination);
+					}
 					break;
 				case type_nav_turnaround_left:
-					if (level == -2)
+					if (level == level_connect)
 						/* TRANSLATORS: Left U-turn, the stuff after | doesn't have to be included. */
 						instruction = g_strdup(_("then make a U-turn|left"));
 					else
@@ -3528,7 +3564,7 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 						instruction = g_strdup_printf(_("Make a U-turn %1$s|left"), d);
 					break;
 				case type_nav_turnaround_right:
-					if (level == -2)
+					if (level == level_connect)
 						/* TRANSLATORS: Right U-turn, the stuff after | doesn't have to be included. */
 						instruction = g_strdup(_("then make a U-turn|right"));
 					else
@@ -3543,7 +3579,7 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 					 * in cases where relevant destination info is available.
 					 * Even if there is no driving command to be announced, in some cases
 					 * there is an overhead roadsign in preparation of an upcoming road-split,
-					 * and then we can give usefull info to the driver.
+					 * and then we can give useful info to the driver.
 					 *
 					 *  UNTESTED !
 					 *
@@ -3552,13 +3588,13 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 					break;
 				case type_nav_destination:
 					/* the old code used to clear the route destination when this was the only
-					 * instruction left. Was that usefull ?
+					 * instruction left. Was that useful ?
 					 * Should be tested with the old code what happens if the driver
 					 * 'overshoots' the destination and the route destination is already cleared.
 					 * I suppose it will now keep guiding the user to destination untill another one
 					 * is set or a 'stop navigation' action is done using the gui.
 					 */
-					if (level == -2)
+					if (level == level_connect)
 						instruction=g_strdup(_("then you have reached your destination."));
 					else
 						/* TRANSLATORS: the arg. is distance  */
@@ -3572,28 +3608,24 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 	}
 	switch (level)
 	{
-		case 3:
+		case level_follow:
 			d=get_distance_str(nav, distance, type, 1);
 			ret=g_strdup_printf(_("Follow the road for the next %s"), d);
 			break;
-		case 2:
+		case level_soon:
 			if (at) /* 'at' contains interchange or exit information that shall not be combined with street_destination_announce */
 				ret= g_strdup_printf(("%1$s %2$s"),instruction,"");
 			else
 				ret= g_strdup_printf(("%1$s %2$s"),instruction,street_destination_announce);
 			break;
-		case 1:
-			ret= g_strdup_printf(("%1$s %2$s"),instruction,street_destination_announce);
-			break;
-		case -2:
-			ret= g_strdup_printf(("%1$s %2$s"),instruction,street_destination_announce);
-			break;
-		case 0:
+		case level_meters:
+		case level_connect:
+		case level_now:
 			ret= g_strdup_printf(("%1$s %2$s"),instruction,street_destination_announce);
 			break;
 		default :
 			ret= g_strdup_printf(("%1$s %2$s"),instruction,street_destination_announce);
-			dbg(lvl_error,"unevaluated speech level\n");
+			dbg(lvl_error,"unevaluated announcement level\n");
 			break;
 	}
 
@@ -3632,77 +3664,63 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
 static char *
 show_next_maneuvers(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd, enum attr_type type)
 {
-	struct navigation_command *cur,*prev;
-	int distance=itm->dest_length-cmd->itm->dest_length;
-	int level, i, time;
-	int speech_time,time2nav;
-	char *ret,*old,*buf,*next;
+	int distance = itm->dest_length-cmd->itm->dest_length; // distance from e.g. current GPS position to next announced turn position
+	enum announcement_level level;
+	char *ret,*buf,*next;
+
 
 	if (type != attr_navigation_speech) {
-		return show_maneuver(nav, itm, cmd, type, 0); /* We accumulate maneuvers only in speech navigation */
+		return show_maneuver(nav, itm, cmd, type, level_meters); /* We only accumulate maneuvers in speech navigation */
 	}
 
-	level=navigation_get_announce_level(nav, itm->way.item.type, distance-cmd->length);
 
-	if (level > 1) {
-		return show_maneuver(nav, itm, cmd, type, 0); /* We accumulate maneuvers only if they are close */
+//////////////////////////////////////
+	level = navigation_get_announce_level_cmd(nav, itm, cmd, distance-cmd->length);
+//////////////////////////////////////
+	//level=navigation_get_announce_level(nav, itm->way.item.type, distance - cmd->length);
+
+	if (level > level_soon) {
+		/* suppress the 'follow the road..' announcement, if the next 'soon' announcement is just a few meters away, so just quit */
+		if ((distance - cmd->length) < (nav->announce[itm->way.item.type - route_item_first][2] + 2 * nav->announce[itm->way.item.type - route_item_first][0])) {
+			/* a few meters away is defined by two times the distance of the 'now'-distance. */
+			return g_strdup("");
+		}
 	}
-
-	if (cmd->itm->told) {
+	else if ((level == level_soon) && (itm->told == 1)) {
+		/* suppress the 'soon' announcement, if the last announcement already concatenated this, so just quit */
 		return g_strdup("");
 	}
-
-	ret = show_maneuver(nav, itm, cmd, type, 0);
-	time2nav = navigation_time(itm,cmd->itm->prev);
-	old = NULL;
-
-	cur = cmd->next;
-	prev = cmd;
-	i = 0;
-	while (cur && cur->itm) {
-		/* We don't merge more than 3 announcements... */
-		if (i > 1) { /* if you change this, please also change the value below, that is used to terminate the loop */
-			break;
+	else if ((level == level_meters) && (itm->told == 1)) {
+		/* suppress the 'in xx meters..' announcement, if the 'soon' announcement is just a few meters away, so just quit */
+		if ((distance - cmd->length) < (nav->announce[itm->way.item.type - route_item_first][1] + 2 * nav->announce[itm->way.item.type - route_item_first][0])) {
+			/* a few meters away is defined by two times the distance of the 'now'-distance. */
+			return g_strdup("");
 		}
-		
-		next = show_maneuver(nav,prev->itm, cur, type, 0);
-		if (nav->speech)
-			speech_time = speech_estimate_duration(nav->speech,next);
-		else
-			speech_time = -1;
-		g_free(next);
-
-		if (speech_time == -1) { /* user didn't set cps */
-			speech_time = 30; /* assume 3 seconds */
-		}
-
-		time = navigation_time(prev->itm,cur->itm->prev);
-
-		if (time >= (speech_time + 30)) { /* 3 seconds for understanding what has been said */
-			break;
-		}
-
-		old = ret;
-		buf = show_maneuver(nav, prev->itm, cur, type, 1);
-		ret = g_strdup_printf("%s, %s", old, buf);
-		g_free(buf);
-		if (nav->speech && speech_estimate_duration(nav->speech,ret) > time2nav) {
-			g_free(ret);
-			ret = old;
-			i = 2; /* This will terminate the loop */
-		} else {
-			g_free(old);
-		}
-
-		/* If the two maneuvers are *really* close, we shouldn't tell the second one again, because TTS won't be fast enough */
-		if (time <= speech_time) {
-			cur->itm->told = 1;
-		}
-
-		prev = cur;
-		cur = cur->next;
-		i++;
 	}
+
+	ret = show_maneuver(nav, itm, cmd, type, level);
+	
+	if (level > level_meters) {
+		return ret; /* We only concatenate maneuvers that are close each other, so quit here */ 
+	}
+
+	if (cmd->next && cmd->itm) {
+		// determine the level of the command that comes immediately after that.
+		enum announcement_level nextlevel = navigation_get_announce_level(nav, cmd->itm->way.item.type, cmd->itm->dest_length - cmd->next->itm->dest_length);
+
+		// If this level starts with 1 or 0 concatenate the following announcement to the current:
+		if (nextlevel <= level_soon) {
+			next = show_maneuver(nav, cmd->itm, cmd->next, type, level_connect);
+			if (*next != '\0') /* is the second announcement not an empty string? */
+			{
+				cmd->itm->told = 1;
+				buf = ret;
+				ret = g_strdup_printf("%s, %s", buf, next); // concatenate both announcements
+				g_free(buf);
+			}
+			g_free(next);
+		}
+        }
 
 	return ret;
 }
@@ -3716,7 +3734,7 @@ navigation_call_callbacks(struct navigation *this_, int force_speech)
 		return;
 	callback_list_call(this_->callback, 1, &p);
 	dbg(lvl_debug,"force_speech=%d turn_around=%d turn_around_limit=%d\n", force_speech, this_->turn_around, this_->turn_around_limit);
-	distance=round_distance(this_->first->dest_length-this_->cmd_first->itm->dest_length);
+	distance=this_->first->dest_length-this_->cmd_first->itm->dest_length;
 	if (this_->turn_around_limit && this_->turn_around == this_->turn_around_limit) {
 		dbg(lvl_debug,"distance=%d distance_turn=%d\n", distance, this_->distance_turn);
 		while (distance > this_->distance_turn) {

--- a/navit/navit.c
+++ b/navit/navit.c
@@ -1889,8 +1889,10 @@ navit_speak(struct navit *this_)
 	if (mr) {
 		while ((item=map_rect_get_item(mr)) && (item->type == type_nav_position || item->type == type_nav_none));
 		if (item && item_attr_get(item, attr_navigation_speech, &attr)) {
-			speech_say(this_->speech, attr.u.str);
-			navit_add_message(this_, attr.u.str);
+			if (*attr.u.str != '\0') {
+				speech_say(this_->speech, attr.u.str);
+				navit_add_message(this_, attr.u.str);
+			}
 			navit_textfile_debug_log(this_, "type=announcement label=\"%s\"", attr.u.str);
 		}
 		map_rect_destroy(mr);

--- a/po/de.po.in
+++ b/po/de.po.in
@@ -34,19 +34,21 @@
 # singesang https://launchpad.net/~singesang
 # spaetz https://launchpad.net/~spaetz
 # vsandre https://launchpad.net/~riedel-andre
-
 msgid ""
 msgstr ""
 "Project-Id-Version: navit 0.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2015-04-22 22:10+0000\n"
+"POT-Creation-Date: 2015-07-16 01:55+0000\n"
+"PO-Revision-Date: 2015-07-20 21:54+0000\n"
 "Last-Translator: Mathias Klein <ma_klein@gmx.de>\n"
 "Language-Team: Martin Schaller <martin-s@sourceforge.net>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Language: \n"
+"X-Launchpad-Export-Date: 2015-07-22 11:08+0000\n"
+"X-Generator: Launchpad (build 17628)\n"
+"Language: de\n"
 "X-Report-Errors: https://translations.launchpad.net/navit/trunk/+pots/navit\n"
 
 msgid "Running from source directory\n"
@@ -101,44 +103,20 @@ msgid "sixth exit"
 msgstr "sechsten Ausfahrt"
 
 #, c-format
-msgid "%d m"
-msgstr "%d m"
-
-#, c-format
-msgid "in %d m"
-msgstr "in %d m"
-
-#, c-format
 msgid "%d feet"
 msgstr "%d Fuss"
 
 #, c-format
 msgid "in %d feet"
-msgstr "in %d Fuss"
-
-#, c-format
-msgid "%d meters"
-msgstr "%d Meter"
-
-#, c-format
-msgid "in %d meters"
-msgstr "In %d Metern"
+msgstr "In %d Fuss"
 
 #, c-format
 msgid "%d.%d miles"
-msgstr "%d.%d Meilen"
+msgstr "%d,%d Meilen"
 
 #, c-format
 msgid "in %d.%d miles"
-msgstr "in %d.%d Meilen"
-
-#, c-format
-msgid "%d.%d kilometers"
-msgstr "%d,%d Kilometer"
-
-#, c-format
-msgid "in %d.%d kilometers"
-msgstr "In %d,%d Kilometern"
+msgstr "In %d,%d Meilen"
 
 #, c-format
 msgid "one mile"
@@ -149,8 +127,24 @@ msgstr[1] "%d Meilen"
 #, c-format
 msgid "in one mile"
 msgid_plural "in %d miles"
-msgstr[0] "in einer Meile"
-msgstr[1] "in %d Meilen"
+msgstr[0] "In einer Meile"
+msgstr[1] "In %d Meilen"
+
+#, c-format
+msgid "%d meters"
+msgstr "%d Meter"
+
+#, c-format
+msgid "in %d meters"
+msgstr "In %d Metern"
+
+#, c-format
+msgid "%d.%d kilometers"
+msgstr "%d,%d Kilometer"
+
+#, c-format
+msgid "in %d.%d kilometers"
+msgstr "In %d,%d Kilometern"
 
 #, c-format
 msgid "one kilometer"
@@ -167,51 +161,51 @@ msgstr[1] "In %d Kilometern"
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Systematic Street Name 3: Separator (Space if required), 4: Street Name
 #, c-format
 msgid "%1$sonto the %2$s%3$s%4$s"
-msgstr ""
+msgstr "%1$sauf die %2$s%3$s%4$s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name
 #, c-format
 msgid "%1$sonto %2$s"
-msgstr ""
+msgstr "%1$sauf die Straße %2$s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name. Masculine form. The stuff after | doesn't have to be included
 #, c-format
 msgid "%1$sonto %2$s|masculine form"
-msgstr ""
+msgstr "%1$sauf den %2$s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name. Feminine form. The stuff after | doesn't have to be included
 #, c-format
 msgid "%1$sonto %2$s|feminine form"
-msgstr ""
+msgstr "%1$sauf die %2$s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name. Neuter form. The stuff after | doesn't have to be included
 #, c-format
 msgid "%1$sonto %2$s|neuter form"
-msgstr ""
+msgstr "%1$sauf das %2$s"
 
 #. TRANSLATORS: motorway ramp refers to the slip road for entering a motorway.
 msgid "onto the motorway ramp"
-msgstr ""
+msgstr "auf die Auffahrt"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name 3: Separator (Space if required), 4: Systematic Street Name
 #, c-format
 msgid "%sinto %s%s%s"
-msgstr ""
+msgstr "%sauf die Straße %s%s%s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name 3: Separator (Space if required), 4: Systematic Street Name. Masculine form. The stuff after | doesn't have to be included
 #, c-format
 msgid "%sinto %s%s%s|masculine form"
-msgstr ""
+msgstr "%sauf den %s%s%s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name 3: Separator (Space if required), 4: Systematic Street Name. Feminine form. The stuff after | doesn't have to be included
 #, c-format
 msgid "%sinto %s%s%s|feminine form"
-msgstr ""
+msgstr "%sauf die %s%s%s"
 
 #. TRANSLATORS: Arguments: 1: Prefix (Space if required) 2: Street Name 3: Separator (Space if required), 4: Systematic Street Name. Neuter form. The stuff after | doesn't have to be included
 #, c-format
 msgid "%sinto %s%s%s|neuter form"
-msgstr ""
+msgstr "%sauf das %s%s%s"
 
 #. TRANSLATORS: gives the name of the next road to turn into (into the E17)
 #, c-format
@@ -225,7 +219,7 @@ msgstr "Wenn möglich, bitte wenden"
 #. TRANSLATORS: the argument is the destination to follow
 #, c-format
 msgid "towards %s"
-msgstr ""
+msgstr "Richtung %s"
 
 #, c-format
 msgid "Follow the road for the next %s"
@@ -237,17 +231,15 @@ msgstr "Demnächst in den Kreisverkehr einfahren"
 #. TRANSLATORS: %s is the distance to the roundabout
 #, c-format
 msgid "Enter the roundabout %s"
-msgstr ""
+msgstr "%s in den Kreisverkehr einfahren"
 
-#. TRANSLATORS: first arg. is the manieth exit, second arg. is the destination to follow
-#, c-format
-msgid "then leave the roundabout at the %1$s %2$s"
-msgstr ""
+msgid "then enter the roundabout"
+msgstr "dann in den Kreisverkehr einfahren"
 
 #. TRANSLATORS: first arg. is the manieth exit, second arg. is the destination to follow
 #, c-format
 msgid "Leave the roundabout at the %1$s %2$s"
-msgstr ""
+msgstr "Verlassen Sie den Kreisverkehr an der %1$s %2$s"
 
 msgid "soon"
 msgstr "Demnächst"
@@ -256,80 +248,80 @@ msgid "now"
 msgstr "Jetzt"
 
 msgid "then"
-msgstr ""
+msgstr "dann"
 
 #. TRANSLATORS: the arg. is the phrase 'onto ...'. Right merge, the stuff after | doesn't have to be included.
 #, c-format
 msgid "then merge%1$s|right"
-msgstr ""
+msgstr "dann%1$s auffahren"
 
 #. TRANSLATORS: the first arg. is distance, the second is the phrase 'onto ...'. Right merge, the stuff after | doesn't have to be included.
 #, c-format
 msgid "Merge %1$s%2$s|right"
-msgstr ""
+msgstr "Fahren Sie %1$s%2$s auf"
 
 #. TRANSLATORS: the arg. is the phrase 'onto ...'. Left merge, the stuff after | doesn't have to be included.
 #, c-format
 msgid "then merge%1$s|left"
-msgstr ""
+msgstr "dann%1$s auffahren"
 
 #. TRANSLATORS: the first arg. is distance, the second is the phrase 'onto ...'. Left merge, the stuff after | doesn't have to be included.
 #, c-format
 msgid "Merge %1$s%2$s|left"
-msgstr ""
+msgstr "Fahren Sie %1$s%2$s auf"
 
 msgid "on your left"
-msgstr ""
+msgstr "links"
 
 msgid "on your right"
-msgstr ""
+msgstr "rechts"
 
 #. TRANSLATORS: the first arg. is exit ref and/or name, the second is the direction of exit and the third is distance
 #, c-format
 msgid "Take exit %1$s %2$s %3$s"
-msgstr ""
+msgstr "%3$s nehmen Sie %2$s die Ausfahrt %1$s"
 
 #. TRANSLATORS: the first arg. is the direction of exit, the second is distance, the third is destination
 #, c-format
 msgid "Take the exit %1$s %2$s%3$s"
-msgstr ""
+msgstr "%2$s nehmen Sie %1$s die Ausfahrt %3$s"
 
 #. TRANSLATORS: as in "Keep right at interchange 42 Greenmond-West"
 msgid "at interchange"
-msgstr ""
+msgstr "am Autobahnknoten"
 
 msgid "at exit"
-msgstr ""
+msgstr "an der Ausfahrt"
 
 #. TRANSLATORS: the arg. is where to do the maneuver
 #, c-format
 msgid "then continue straight%1$s"
-msgstr ""
+msgstr "dann%1$s geradeaus fahren"
 
 #. TRANSLATORS: the first arg. is distance, the second is where to do the maneuver, the third is destination
 #, c-format
 msgid "Continue straight %1$s%2$s%3$s"
-msgstr ""
+msgstr "%1$s%2$s geradeaus fahren%3$s"
 
 #. TRANSLATORS: the arg. is where to do the maneuver
 #, c-format
 msgid "then keep right%1$s"
-msgstr ""
+msgstr "dann rechts halten%1$s"
 
 #. TRANSLATORS: the first arg. is distance, the second is where to do the maneuver, the third is destination
 #, c-format
 msgid "Keep right %1$s%2$s%3$s"
-msgstr ""
+msgstr "%1$s rechts halten%2$s%3$s"
 
 #. TRANSLATORS: the arg. is where to do the maneuver
 #, c-format
 msgid "then keep left%1$s"
-msgstr ""
+msgstr "dann links halten%1$s"
 
 #. TRANSLATORS: the first arg. is distance, the second is where to do the maneuver, the third is destination
 #, c-format
 msgid "Keep left %1$s%2$s%3$s"
-msgstr ""
+msgstr "%1$s links halten%2$s%3$s"
 
 #. TRANSLATORS: "right" as in "turn right"
 msgid "right"
@@ -347,9 +339,15 @@ msgstr "leicht "
 msgid "strongly "
 msgstr "scharf "
 
+
 #, c-format
 msgid "Take the %1$s road to the %2$s"
 msgstr "Die %1$s Straße %2$s abbiegen"
+
+#Robotaxi:
+#, c-format
+msgid "then take the %1$s road to the %2$s"
+msgstr "dann die %1$s Straße %2$s abbiegen"
 
 #, c-format
 msgid "after %i roads"
@@ -363,21 +361,21 @@ msgstr "%3$s %1$s%2$s abbiegen%4$s"
 
 #. TRANSLATORS: Left U-turn, the stuff after | doesn't have to be included.
 msgid "then make a U-turn|left"
-msgstr ""
+msgstr "dann wenden"
 
 #. TRANSLATORS: the arg. is distance. Left U-turn, the stuff after | doesn't have to be included.
 #, c-format
 msgid "Make a U-turn %1$s|left"
-msgstr ""
+msgstr "Wenden Sie %1$s"
 
 #. TRANSLATORS: Right U-turn, the stuff after | doesn't have to be included.
 msgid "then make a U-turn|right"
-msgstr ""
+msgstr "dann wenden"
 
 #. TRANSLATORS: the arg. is distance. Right U-turn, the stuff after | doesn't have to be included.
 #, c-format
 msgid "Make a U-turn %1$s|right"
-msgstr ""
+msgstr "Wenden Sie %1$s"
 
 #. An empty placeholder that we can use in the future for
 #. * some motorway commands that are now suppressed but we
@@ -392,7 +390,7 @@ msgstr ""
 #. *
 #. 
 msgid "follow"
-msgstr ""
+msgstr "folgen"
 
 msgid "then you have reached your destination."
 msgstr "dann haben Sie Ihr Ziel erreicht."
@@ -400,14 +398,14 @@ msgstr "dann haben Sie Ihr Ziel erreicht."
 #. TRANSLATORS: the arg. is distance
 #, c-format
 msgid "You have reached your destination %s"
-msgstr "Sie haben Ihr Ziel %s erreicht"
+msgstr "%s haben Sie Ihr Ziel erreicht"
 
 #. TRANSLATORS: Exit as a noun, as in "Exit 43 Greenmound-East"
 msgid "Interchange"
-msgstr ""
+msgstr "Autobahnknoten"
 
 msgid "Exit"
-msgstr ""
+msgstr "Ausfahrt"
 
 #. Android resource: @strings/position_popup_title
 msgid "Position"
@@ -1477,6 +1475,16 @@ msgid ""
 "\t-h: print this usage info and exit.\n"
 "\t-v: print the version and exit.\n"
 msgstr ""
+"navit Verwendung:\n"
+"navit [Option] [configfile]\n"
+"\t-c <Datei>: benutze <Datei> als Konfigurationsdatei, anstatt der "
+"Standardkonfigurationsdatei.\n"
+"\t-d <n>: setze den globalen debug-level auf <n> (0=Fehler, 1=Warnung, "
+"2=Info, 3=Debug).\n"
+"\tEinstellungen der Konfigurationsdatei werden weiterhin gültig sein, wenn "
+"sie einen höheren Wert angeben.\n"
+"\t-h: zeige diesen Hilfetext und beende.\n"
+"\t-v: zeige die Version und beende.\n"
 
 #. We have not found an existing config file from all possibilities
 msgid "No config file navit.xml, navit.xml.local found\n"
@@ -2074,6 +2082,9 @@ msgid ""
 "Please restart Navit after you attach an SD card or select a different map "
 "location."
 msgstr ""
+"Der Speicherpfad für die Karte ist nicht verfügbar.\n"
+"Setzen Sie eine SD Karte ein und starten Sie Navit erneut\n"
+"oder wählen Sie einen anderen Pfad aus."
 
 msgid "Downloaded maps"
 msgstr "Heruntergeladene Karten"
@@ -2095,6 +2106,8 @@ msgid ""
 "New location set to %s\n"
 "Restart Navit to apply the changes."
 msgstr ""
+"Karten-Speicherort ist %s\n"
+"Starten Sie Navit erneut."
 
 msgid "Whole Planet"
 msgstr "Ganze Welt"
@@ -2657,7 +2670,7 @@ msgstr "Sichern / Wiederherstellen"
 
 #. Android resource: @strings/optionsmenu_set_map_location
 msgid "Set map location"
-msgstr ""
+msgstr "Kartenort festlegen"
 
 #. Android resource: @strings/map_delete
 msgid "Delete this map?"
@@ -2745,7 +2758,7 @@ msgstr "Sicherungsverzeichnis konnte nicht erstellt werden"
 
 #. Android resource: @strings/backup_failed
 msgid "Backup failed"
-msgstr "Sicherung Fehlgeschlagen"
+msgstr "Sicherung fehlgeschlagen"
 
 #. Android resource: @strings/no_backup_found
 msgid "No backup found"
@@ -2797,3 +2810,6 @@ msgid ""
 "currently selected engine reports it is unable to speak in your language. "
 "Should we ask the system to show voice download dialog?"
 msgstr ""
+"Navit kann jede text-to-speech engine nutzen, die installiert ist. Die "
+"derzeit angewählte engine kann Ihre Sprache nicht wiedergeben. "
+"Soll das System den Voice-Download Dialog öffnen?"


### PR DESCRIPTION
Up to now the concatenation of turn announcements isn't implemented correctly.

Currently two announcements are only connected if the announcements are such close in a timely manner that they tend to get overlapped. In practice this hardly ever occurs.
In my view this is not the idea of concatenating turns. They shall be concatenated if the turns are close in a distance manner.

Hence, for me the criteria shall be like this:
- If two turns have a distance to each other that is less than the "level 2"-distance configured for the specific route item, (which stands for the "soon"-announcement), they shall be concatenated.
- The "soon" announcement for the second turn shall be suppressed in that case.
- Any announcement for the second turn from that concatenation down to "level 1" shall be suppressed, if (and only if) it would come too close to the preceding one.

Here is an example:
1.: "turn right soon"
2.: "in 250 meters turn right into the Riedlstraße, then turn left into the Marxstraße"
3.: "turn right into the Riedlstraße now, then turn left into the Marxstraße"
4.: ("turn left into the Marxstraße soon" will be suppressed, as well as "follow the road for the next xx meters")
5.: "in 250 meters turn left into the Marxstraße"  -> This may be suppressed, if the announcement no. 6 would come a few meters later. Navit would interrupt itself otherwise.
6.: "turn left into the Marxstraße now"

In such situations, in which many turns come close after the other this behavior sounds much less mechanic and for me it saves a bunch of nerves of the users because of annoying announcements.
Have fun!