### PR TITLE
Support for reloading CSV maps

### DIFF
--- a/navit/binding/dbus/binding_dbus.c
+++ b/navit/binding/dbus/binding_dbus.c
@@ -1934,6 +1934,18 @@ request_vehicleprofile_attr_iter_destroy(DBusConnection *connection, DBusMessage
 	return request_attr_iter_destroy(connection, message, "vehicleprofile", (void (*)(struct attr_iter *))vehicleprofile_attr_iter_destroy);
 }
 
+static DBusHandlerResult
+request_map_reload(DBusConnection *connection, DBusMessage *message)
+{
+	struct map *map;
+	map=object_get_from_message(message, "map");
+	if (! map)
+		return dbus_error_invalid_object_path(connection, message);
+
+	map_reload(map);
+	return empty_reply(connection, message);
+}
+
 struct dbus_method {
 	char *path;
 	char *method;
@@ -1990,6 +2002,7 @@ struct dbus_method {
 	{".map",    "get_attr",            "s",       "attribute",                               "sv",  "attrname,value", request_map_get_attr},
 	{".map",    "set_attr",            "sv",      "attribute,value",                         "",   "",      request_map_set_attr},
 	{".map",    "dump",                "s",       "file",                                    "",   "",  request_map_dump},
+	{".map",    "reload",              "",        "",                                        "",   "",  request_map_reload},
 	{".mapset", "attr_iter",           "",        "",                                        "o",  "attr_iter",  request_mapset_attr_iter},
 	{".mapset", "attr_iter_destroy",   "o",       "attr_iter",                               "",   "",      request_mapset_attr_iter_destroy},
 	{".mapset", "get_attr",            "s",       "attribute",                               "sv",  "attrname,value", request_mapset_get_attr},

--- a/navit/map.c
+++ b/navit/map.c
@@ -732,6 +732,13 @@ map_rect_create_item(struct map_rect *mr, enum item_type type_)
 	}
 }
 
+void
+map_reload(struct map *map)
+{
+	if (map->meth.map_reload)
+		map->meth.map_reload(map->priv);
+}
+
 struct object_func map_func = {
 	attr_map,
 	(object_func_new)map_new,

--- a/navit/map.h
+++ b/navit/map.h
@@ -86,6 +86,7 @@ struct map_methods {
 	struct item *		(*map_rect_create_item)(struct map_rect_priv *mr, enum item_type type); /**< Function to create a new item in the map */
 	int			(*map_get_attr)(struct map_priv *priv, enum attr_type type, struct attr *attr);
         int			(*map_set_attr)(struct map_priv *priv, struct attr *attr);
+	void                    (*map_reload)(struct map_priv *priv);
 
 };
 
@@ -275,6 +276,7 @@ void map_dump_file(struct map *map, const char *file);
 void map_dump(struct map *map);
 void map_destroy_do(struct map *m);
 struct maps * maps_new(struct attr *parent, struct attr **attrs);
+void map_reload(struct map *m);
 /* end of prototypes */
 
 #ifdef __cplusplus

--- a/navit/map/binfile/binfile.c
+++ b/navit/map/binfile/binfile.c
@@ -2514,6 +2514,7 @@ static struct map_methods map_methods_binfile = {
 	NULL,
 	binmap_get_attr,
 	binmap_set_attr,
+	NULL,
 };
 
 static int

--- a/navit/map/csv/csv.c
+++ b/navit/map/csv/csv.c
@@ -49,7 +49,7 @@ csv_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode
 static struct item * csv_create_item(struct map_rect_priv *mr, enum item_type it_type);
 static void quadtree_item_free(void *mr, struct quadtree_item *qitem);
 static void quadtree_item_free_do(void *qitem);
-void map_reload_csv(struct map_priv* m);
+static void map_reload_csv(struct map_priv* m);
 
 
 struct quadtree_data
@@ -876,7 +876,6 @@ map_new_csv(struct map_methods *meth, struct attr **attrs, struct callback_list 
 	if(data) {
 	  struct file_wordexp *wexp;
 	  char **wexp_data;
-	  FILE *fp;
 	  wexp=file_wordexp_new(data->u.str);
 	  wexp_data=file_wordexp_get_array(wexp);
 	  dbg(lvl_debug,"map_new_csv %s\n", data->u.str);
@@ -892,14 +891,6 @@ map_new_csv(struct map_methods *meth, struct attr **attrs, struct callback_list 
 }
 
 static void
-map_reload_csv(struct map_priv* m)
-{
-	map_empty_csv(m);
-	map_init_csv(m);
-	map_parse_csv(m);
-}
-
-void
 map_reload_csv(struct map_priv* m)
 {
 	map_empty_csv(m);

--- a/navit/map/filter/filter.c
+++ b/navit/map/filter/filter.c
@@ -383,6 +383,7 @@ static struct map_methods map_methods_filter = {
 	NULL,
 	NULL,
 	map_filter_set_attr,
+	NULL,
 };
 
 

--- a/navit/map/garmin/garmin.c
+++ b/navit/map/garmin/garmin.c
@@ -920,6 +920,7 @@ static struct map_methods map_methods = {
 	gmap_search_new,
 	gmap_search_destroy,
 	NULL,
+	NULL,
 };
 
 static struct map_priv *

--- a/navit/map/garmin_img/garmin_img.c
+++ b/navit/map/garmin_img/garmin_img.c
@@ -1488,6 +1488,7 @@ static struct map_methods map_methods_garmin_img = {
 	map_rect_destroy_garmin_img,
 	map_rect_get_item_garmin_img,
 	map_rect_get_item_byid_garmin_img,
+	NULL,
 };
 
 static struct map_priv *

--- a/navit/map/mg/map.c
+++ b/navit/map/mg/map.c
@@ -562,6 +562,7 @@ static struct map_methods map_methods_mg = {
 	map_search_new_mg,
 	map_search_destroy_mg,
 	map_search_get_item_mg,
+	NULL,
 };
 
 

--- a/navit/map/shapefile/shapefile.c
+++ b/navit/map/shapefile/shapefile.c
@@ -633,6 +633,7 @@ static struct map_methods map_methods_shapefile = {
 	map_rect_destroy_shapefile,
 	map_rect_get_item_shapefile,
 	map_rect_get_item_byid_shapefile,
+	NULL,
 };
 
 static struct map_priv *

--- a/navit/map/textfile/textfile.c
+++ b/navit/map/textfile/textfile.c
@@ -346,6 +346,7 @@ static struct map_methods map_methods_textfile = {
 	map_rect_destroy_textfile,
 	map_rect_get_item_textfile,
 	map_rect_get_item_byid_textfile,
+	NULL,
 };
 
 static struct map_priv *


### PR DESCRIPTION
Navit contains some speed camera warning code. In order to identify the locations of speed cameras, the mapset is queried. The [Wiki suggests](http://wiki.navit-project.org/index.php/OSD#speed_cam) to make use of CSV files in the mapset in order to provide navit with the required information. This approach works well as long as the data in the CSV file doesn't change. If however the speed camera information is updated while navit is running, there was no way to reload the CSV file. This pull request addresses that issue by adding a function `map_reload()`, which is exposed via DBUS.