### PR TITLE
fix:build Cope with build fron non git tree but git present

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -9,6 +9,10 @@ if (GIT_EXECUTABLE)
       OUTPUT_VARIABLE VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE
    )
+   if(NOT VERSION)
+      message(STATUS "git found, but no git tree")
+      set(VERSION "0000")
+   endif()
 else()
    message(STATUS "git not found, cannot record git commit")
    set(VERSION "0000")


### PR DESCRIPTION
Tried to cmake navit (for rpm building) from tarball created from my fork. Since this is no git repository then, but git executable is present on the machine, getting git revision fails fatal. In detail the regex detecting "R" fails if VERSION is unset.
This small fix prevents it from failing and instead resorts to invalid (0000) revision. 