### PR TITLE
Default settings tweaks

### DIFF
--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -3,7 +3,7 @@ if [[ "${CIRCLE_PROJECT_USERNAME}" == "navit-gps" && "${CIRCLE_BRANCH}" == "trun
 	export PATH=~/navit/cov-analysis-linux64-7.6.0/bin:$PATH
 	
 	mkdir bin && cd bin
-	cov-build --dir cov-int cmake ../ -Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=n
+	cov-build --dir cov-int cmake ../ -Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=y
 	cov-build --dir cov-int make || exit -1
 	tar czvf navit.tgz cov-int
 	
@@ -15,7 +15,7 @@ if [[ "${CIRCLE_PROJECT_USERNAME}" == "navit-gps" && "${CIRCLE_BRANCH}" == "trun
   https://scan.coverity.com/builds?project=$CIRCLE_PROJECT_USERNAME
 else
 	mkdir bin && cd bin
-	cmake ../ -Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=n|| exit -1
+	cmake ../ -Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=y|| exit -1
 	make  || exit -1
 fi
 cp -r navit/xpm $CIRCLE_ARTIFACTS

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -3334,84 +3334,84 @@ static struct gui_priv * gui_internal_new(struct navit *nav, struct gui_methods 
 	gui_internal_command_init(this, attrs);
 
 	if( (attr=attr_search(attrs,NULL,attr_font_size)))
-        {
-	  this->config.font_size=attr->u.num;
+	{
+		this->config.font_size=attr->u.num;
 	}
 	else
 	{
-	  this->config.font_size=-1;
+		this->config.font_size=-1;
 	}
 	if( (attr=attr_search(attrs,NULL,attr_icon_xs)))
 	{
-	  this->config.icon_xs=attr->u.num;
+		this->config.icon_xs=attr->u.num;
 	}
 	else
 	{
-	  this->config.icon_xs=-1;
+		this->config.icon_xs=-1;
 	}
 	if( (attr=attr_search(attrs,NULL,attr_icon_l)))
 	{
-	  this->config.icon_l=attr->u.num;
+		this->config.icon_l=attr->u.num;
 	}
 	else
-        {
-	  this->config.icon_l=-1;
+	{
+		this->config.icon_l=-1;
 	}
 	if( (attr=attr_search(attrs,NULL,attr_icon_s)))
 	{
-	  this->config.icon_s=attr->u.num;
+		this->config.icon_s=attr->u.num;
 	}
 	else
-        {
-	  this->config.icon_s=-1;
+	{
+		this->config.icon_s=-1;
 	}
 	if( (attr=attr_search(attrs,NULL,attr_spacing)))
 	{
-	  this->config.spacing=attr->u.num;
+		this->config.spacing=attr->u.num;
 	}
 	else
 	{
-	  this->config.spacing=-1;
+		this->config.spacing=-1;
 	}
 	if( (attr=attr_search(attrs,NULL,attr_gui_speech)))
 	{
-	  this->speech=attr->u.num;
+		this->speech=attr->u.num;
 	}
 	if( (attr=attr_search(attrs,NULL,attr_keyboard)))
-	  this->keyboard=attr->u.num;
-        else
-	  this->keyboard=1;
+		this->keyboard=attr->u.num;
+	else
+		this->keyboard=1;
 
-    if( (attr=attr_search(attrs,NULL,attr_fullscreen)))
-      this->fullscreen=attr->u.num;
+	if( (attr=attr_search(attrs,NULL,attr_fullscreen)))
+		this->fullscreen=attr->u.num;
 
 	if( (attr=attr_search(attrs,NULL,attr_flags)))
-	      this->flags=attr->u.num;
+		this->flags=attr->u.num;
 	if( (attr=attr_search(attrs,NULL,attr_background_color)))
-	      this->background_color=*attr->u.color;
+		this->background_color=*attr->u.color;
 	else
-	      this->background_color=color_black;
+		this->background_color=color_black;
 	if( (attr=attr_search(attrs,NULL,attr_background_color2)))
 		this->background2_color=*attr->u.color;
 	else
 		this->background2_color=back2_color;
 	if( (attr=attr_search(attrs,NULL,attr_text_color)))
-	      this->text_foreground_color=*attr->u.color;
+		this->text_foreground_color=*attr->u.color;
 	else
-	      this->text_foreground_color=color_white;
+		this->text_foreground_color=color_white;
 	if( (attr=attr_search(attrs,NULL,attr_text_background)))
-	      this->text_background_color=*attr->u.color;
+		this->text_background_color=*attr->u.color;
 	else
-	      this->text_background_color=color_black;
+		this->text_background_color=color_black;
 	if( (attr=attr_search(attrs,NULL,attr_columns)))
-	      this->cols=attr->u.num;
+		this->cols=attr->u.num;
 	if( (attr=attr_search(attrs,NULL,attr_osd_configuration)))
-	      this->osd_configuration=*attr;
+		this->osd_configuration=*attr;
 
 	if( (attr=attr_search(attrs,NULL,attr_pitch)))
-	      this->pitch=attr->u.num;
+		this->pitch=attr->u.num;
 	else
-		this->pitch=20;
+		this->pitch=10;
 	if( (attr=attr_search(attrs,NULL,attr_flags_town)))
 		this->flags_town=attr->u.num;
 	else

--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -35,7 +35,7 @@
 		Center coordinates format: "Long Lat" in decimal degrees (WGS 84).
 		For other formats see http://wiki.navit-project.org/index.php/Coordinate_format.
 		-->
-	<navit center="11.5666 48.1333" zoom="256" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0">
+	<navit center="11.5666 48.1333" zoom="256" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0" pitch="10">
 		<!-- Use one of gtk_drawing_area, qt_qpainter or sdl. 
 		     On windows systems, use win32 -->
 		<graphics type="gtk_drawing_area"/>

--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -35,7 +35,7 @@
 		Center coordinates format: "Long Lat" in decimal degrees (WGS 84).
 		For other formats see http://wiki.navit-project.org/index.php/Coordinate_format.
 		-->
-	<navit center="11.5666 48.1333" zoom="256" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0" pitch="10">
+	<navit center="11.5666 48.1333" zoom="32" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0" pitch="10">
 		<!-- Use one of gtk_drawing_area, qt_qpainter or sdl. 
 		     On windows systems, use win32 -->
 		<graphics type="gtk_drawing_area"/>

--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -35,7 +35,7 @@
 		Center coordinates format: "Long Lat" in decimal degrees (WGS 84).
 		For other formats see http://wiki.navit-project.org/index.php/Coordinate_format.
 		-->
-	<navit center="11.5666 48.1333" zoom="32" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0" pitch="10">
+	<navit center="11.5666 48.1333" zoom="32" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0" pitch="20">
 		<!-- Use one of gtk_drawing_area, qt_qpainter or sdl. 
 		     On windows systems, use win32 -->
 		<graphics type="gtk_drawing_area"/>

--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -35,7 +35,7 @@
 		Center coordinates format: "Long Lat" in decimal degrees (WGS 84).
 		For other formats see http://wiki.navit-project.org/index.php/Coordinate_format.
 		-->
-	<navit center="11.5666 48.1333" zoom="32" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0" pitch="20">
+	<navit center="11.5666 48.1333" zoom="32" tracking="1" orientation="-1" recent_dest="250" drag_bitmap="0">
 		<!-- Use one of gtk_drawing_area, qt_qpainter or sdl. 
 		     On windows systems, use win32 -->
 		<graphics type="gtk_drawing_area"/>


### PR DESCRIPTION
The default settings are not producing the most appealing map when starting Navit on Android, for example.

This is how the default map is currently rendered on the CI : ![default](https://circle-artifacts.com/gh/navit-gps/navit/856/artifacts/0/tmp/circle-artifacts.OXilABA/default.png)

The default zoom level renders an area that is too large, leading to the streets of lesser importance not being displayed. Most of the time when using Navit you mostly care about your next turn, not seeing the full city.

The default pitch value is too high, displaying a part of the "sky" which is currently not even blue, loosing in my opinion valuable space that could be used to display the map instead.

Default zoom with a suggested pitch of 10 : ![z=256,p=10](https://circle-artifacts.com/gh/navit-gps/navit/857/artifacts/0/tmp/circle-artifacts.RvpW53p/default.png)

Suggested zoom of 32 with the default pitch of 20 : ![z=32,p=20](https://circle-artifacts.com/gh/navit-gps/navit/860/artifacts/0/tmp/circle-artifacts.D7RjmYE/default.png)

Suggested zoom of 32 with a suggested pitch of 10 : ![z=32,p=10](https://circle-artifacts.com/gh/navit-gps/navit/858/artifacts/0/tmp/circle-artifacts.960RNxV/default.png)
