### PR TITLE
fix:build Get Git in cmake to read git version

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
-FIND_PROGRAM(GIT_EXECUTABLE NAMES git git.exe DOC "git command line client")
+find_program(GIT_EXECUTABLE NAMES git git.exe DOC "git command line client")
 
 get_filename_component(SOURCE_DIR ${SRC} PATH)
 


### PR DESCRIPTION
On my box, GIT_EXECUTABLE is never set during cmake build regardless if git is present or not.
In order to get GIT_EXECUTABLE set if the package is built, I propose including cmake Git module in version.cmake.
