### PR TITLE
Android: disable pedestrian default build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,7 +615,6 @@ if(ANDROID)
    set_with_reason(graphics/android "Android detected" TRUE)
    set_with_reason(speech/android "Android detected" TRUE)
    set_with_reason(vehicle/android "Android detected" TRUE)
-   set_with_reason(plugin/pedestrian "Android detected" TRUE)
    set(SHARED_LIBNAVIT TRUE)
 
    add_feature(XPM2PNG "Android detected" TRUE)


### PR DESCRIPTION
disable the building of the pedestrian plugin by default for the Android port