### PR TITLE
fix old iOS jailbreak build

### DIFF
--- a/navit/xslt/iphone.xslt
+++ b/navit/xslt/iphone.xslt
@@ -4,6 +4,7 @@
    <xsl:param name="ICON_SMALL" select="32"/>
    <xsl:param name="ICON_MEDIUM" select="32"/>
    <xsl:param name="ICON_BIG" select="64"/>
+   <xsl:param name="OSD_USE_OVERLAY">yes</xsl:param>
    
    <xsl:output method="xml" doctype-system="navit.dtd" cdata-section-elements="gui"/>
    <xsl:include href="osd_minimum.xslt"/>


### PR DESCRIPTION
I suppose https://github.com/navit-gps/navit/commit/f18e9dfb5110db7943d719ffe90171ac888326aa broke the build on the Navit server of the old iOS jailbreak packages.
Attempt to fix it.