### PR TITLE
sunrise near poles simplification

### DIFF
--- a/navit/navit.c
+++ b/navit/navit.c
@@ -3408,13 +3408,19 @@ navit_layout_switch(struct navit *n)
 		currTs=iso8601_to_secs(iso8601_attr.u.str);
 		dbg(lvl_debug,"currTs: %u:%u\n",currTs%86400/3600,((currTs%86400)%3600)/60);
 	}
+
+
 	dbg(lvl_debug,"prevTs: %u:%u\n",n->prevTs%86400/3600,((n->prevTs%86400)%3600)/60);
-	if (currTs-(n->prevTs)<60) {
-		//We've have to wait a little
-		return;
-	}
+
 	if (n->auto_switch == FALSE)
 		return;
+
+	if (currTs-(n->prevTs)<60) {
+			//We've have to wait a little
+			return;
+		}
+
+
 	if (sscanf(iso8601_attr.u.str,"%d-%02d-%02dT",&year,&month,&day) != 3)
 		return;
 	if (vehicle_get_attr(n->vehicle->vehicle, attr_position_valid, &valid_attr,NULL) && valid_attr.u.num==attr_position_valid_invalid) {
@@ -3426,29 +3432,25 @@ navit_layout_switch(struct navit *n)
 	}
 	//We calculate sunrise anyway, cause it is needed both for day and for night
 	if (__sunriset__(year,month,day,geo_attr.u.coord_geo->lng,geo_attr.u.coord_geo->lat,-5,1,&trise,&tset)!=0) {
-		//near the pole sun never rises/sets, so we should never switch profiles
-		dbg(lvl_debug,"trise: %u:%u, sun never visible, never switch profile\n",HOURS(trise),MINUTES(trise));
+		dbg(lvl_debug,"near the pole sun never rises/sets, so we should never switch profiles\n");
+		dbg(lvl_debug,"trise: %u:%u\n",HOURS(trise),MINUTES(trise));
+		dbg(lvl_debug,"tset: %u:%u\n",HOURS(tset),MINUTES(tset));
 		n->prevTs=currTs;
 		return;
 		}
 	trise_actual=trise;
 	dbg(lvl_debug,"trise: %u:%u\n",HOURS(trise),MINUTES(trise));
+	dbg(lvl_debug,"tset: %u:%u\n",HOURS(tset),MINUTES(tset));
 	dbg(lvl_debug,"dayname = %s, name =%s \n",l->dayname, l->name);
+	dbg(lvl_debug,"nightname = %s, name = %s \n",l->nightname, l->name);
 	if (HOURS(trise)*60+MINUTES(trise)<(currTs%86400)/60) {
 		after_sunrise = TRUE;
 	}
-	dbg(lvl_debug,"nightname = %s, name = %s \n",l->nightname, l->name);
-	if (__sunriset__(year,month,day,geo_attr.u.coord_geo->lng,geo_attr.u.coord_geo->lat,-5,1,&trise,&tset)!=0) {
-		//near the pole sun never rises/sets, so we should never switch profiles
-		dbg(lvl_debug,"tset: %u:%u, sun always visible, never switch profile\n",HOURS(tset),MINUTES(tset));
-		n->prevTs=currTs;
-		return;
-	}
-	dbg(lvl_debug,"tset: %u:%u\n",HOURS(tset),MINUTES(tset));
+	
 	if (((HOURS(tset)*60+MINUTES(tset)<(currTs%86400)/60)) ||
 			((HOURS(trise_actual)*60+MINUTES(trise_actual)>(currTs%86400)/60))) {
 		after_sunset = TRUE;
-	}	
+	}
 	if (after_sunrise && !after_sunset && l->dayname) {
 		navit_set_layout_by_name(n,l->dayname);
 			dbg(lvl_debug,"layout set to day\n");


### PR DESCRIPTION
Remove redundant sunrise/set test.
If the first test shows we are near a pole, it will never get to the second test.
If we are not near a pole, a second test will result in the same.