### PR TITLE
Qt5 Graphics: Add QML support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,15 +320,21 @@ if (QT_FOUND)
    endif()
 endif(QT_FOUND)
 if (Qt5Widgets_FOUND OR Qt5Quick_FOUND)
+   set(Qt5_ADDITIONAL_LIBRARIES "")
    if(Qt5Widgets_FOUND)
 	   set_with_reason(USE_QWIDGET "Qt5Widgets found" TRUE)
+	   if(USE_QWIDGET)
+	   	set(Qt5_ADDITIONAL_LIBRARIES ${Qt5_ADDITIONAL_LIBRARIES} ${Qt5Widgets_LIBRARIES})
+           endif()
    endif()
    if(Qt5Quick_FOUND)
 	   set_with_reason(USE_QML "Qt5Quick found" TRUE)
+	   if(USE_QML)
+	   	set(Qt5_ADDITIONAL_LIBRARIES ${Qt5_ADDITIONAL_LIBRARIES} ${Qt5Quick_LIBRARIES})
+	   endif()
    endif()
    set_with_reason(graphics/qt5 "Qt5 found" TRUE
-		${Qt5Widgets_LIBRARIES}
-		${Qt5Quick_LIBRARIES}
+		${Qt5_ADDITIONAL_LIBRARIES}
 		${Qt5Svg_LIBRARIES}
 		${Qt5DBus_LIBRARIES})
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,18 +158,24 @@ libfind_pkg_check_modules(FONTCONFIG fontconfig)
 #Qt detection
 if (NOT DISABLE_QT)
   find_package(Qt5Widgets)
-  find_package(Qt5Svg)
-  find_package(Qt5DBus)
+  find_package(Qt5Quick)
   find_package(Qt5Positioning)
-  find_package(Qt5Sensors)
-  #find_package(Qt5Declarative)
-  if (Qt5Widgets_FOUND)
-  else (Qt5Widgets_FOUND)
+  if (Qt5Widgets_FOUND OR Qt5Quick_FOUND OR Qt5Sensors_FOUND)
+    add_feature (USE_QWIDGET "Qt5 Qt5Widget not found" FALSE)
+    add_feature (USE_QML "Qt5 Qt5Quick not found" FALSE)
+    if (Qt5Widgets_FOUND OR Qt5Quick_FOUND)
+      find_package(Qt5Svg REQUIRED)
+      find_package(Qt5DBus REQUIRED)
+    endif (Qt5Widgets_FOUND OR Qt5Quick_FOUND)
+    if (Qt5Positioning_FOUND)
+      find_package(Qt5Sensors REQUIRED)
+    endif (Qt5Positioning_FOUND)
+  else (Qt5Widgets_FOUND OR Qt5Quick_FOUND OR Qt5Sensors_FOUND)
     # Unfortunately, CMake seems to ignore the "OPTIONAL_COMPONENTS" flag,
     # and actually requires all components to be installed. Maybe this can
     # be fixed later...
     find_package(Qt4 4.7 COMPONENTS QtCore OPTIONAL_COMPONENTS QtGui QtXml QtDeclarative QtSvg)
-  endif (Qt5Widgets_FOUND)      
+  endif (Qt5Widgets_FOUND OR Qt5Quick_FOUND OR Qt5Sensors_FOUND)      
 endif (NOT DISABLE_QT)
 
 #pkg-config based detection
@@ -313,14 +319,21 @@ if (QT_FOUND)
       endif()
    endif()
 endif(QT_FOUND)
-if (Qt5Widgets_FOUND)
-	set_with_reason(graphics/qt5 "Qt5 found" TRUE ${Qt5Widgets_LIBRARIES}
-		${Qt5Declarative_LIBRARIES}
+if (Qt5Widgets_FOUND OR Qt5Quick_FOUND)
+   if(Qt5Widgets_FOUND)
+	   set_with_reason(USE_QWIDGET "Qt5Widgets found" TRUE)
+   endif()
+   if(Qt5Quick_FOUND)
+	   set_with_reason(USE_QML "Qt5Quick found" TRUE)
+   endif()
+   set_with_reason(graphics/qt5 "Qt5 found" TRUE
+		${Qt5Widgets_LIBRARIES}
+		${Qt5Quick_LIBRARIES}
 		${Qt5Svg_LIBRARIES}
 		${Qt5DBus_LIBRARIES})
 endif ()
 if (Qt5Positioning_FOUND)
-	set_with_reason(vehicle/qt5 "Qt5 Positioning found" TRUE
+   set_with_reason(vehicle/qt5 "Qt5 Positioning found" TRUE
 		${Qt5Positioning_LIBRARIES}
 		${Qt5Sensors_LIBRARIES}) 
 endif ()

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -1,4 +1,4 @@
-sudo apt-get install cmake libpng12-dev librsvg2-bin libfreetype6-dev libdbus-glib-1-dev g++ libgtk2.0-dev libqt5svg5-dev
+sudo apt-get install cmake libpng12-dev librsvg2-bin libfreetype6-dev libdbus-glib-1-dev g++ libgtk2.0-dev libqt5svg5-dev qml-module-qtquick-window2 qml-module-qtquick-controls
 
 cmake_opts="-Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=n -Dgraphics/gtk_drawing_area:BOOL=TRUE"
 

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -1,4 +1,4 @@
-sudo apt-get install cmake libpng12-dev librsvg2-bin libfreetype6-dev libdbus-glib-1-dev g++ libgtk2.0-dev libqt5svg5-dev qml-module-qtquick-window2 qml-module-qtquick-controls
+sudo apt-get install cmake libpng12-dev librsvg2-bin libfreetype6-dev libdbus-glib-1-dev g++ libgtk2.0-dev libqt5svg5-dev qtdeclarative5-qtquick2-plugin qtdeclarative5-window-plugin
 
 cmake_opts="-Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=n -Dgraphics/gtk_drawing_area:BOOL=TRUE"
 

--- a/ci/build_tomtom_minimal.sh
+++ b/ci/build_tomtom_minimal.sh
@@ -40,9 +40,9 @@ if ! [ -e "~/tomtom_assets/toolchain_redhat_gcc-3.3.4_glibc-2.3.2-20060131a.tar.
   wget -nv -c https://github.com/navit-gps/dependencies/raw/master/tomtom/toolchain_redhat_gcc-3.3.4_glibc-2.3.2-20060131a.tar.gz -P ~/tomtom_assets
 fi
 
-if ! test -f "~/tomtom_assets/libpng-1.6.28.tar.gz"
+if ! test -f "~/tomtom_assets/libpng-1.6.29.tar.gz"
 then 
-  wget -nv -c ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.28.tar.gz -P ~/tomtom_assets
+  wget -nv -c ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.29.tar.gz -P ~/tomtom_assets
 fi
 
 # toolchain
@@ -71,8 +71,8 @@ make install
 
 # libpng
 cd /tmp/
-tar xzf ~/tomtom_assets/libpng-1.6.28.tar.gz
-cd libpng-1.6.28/ 
+tar xzf ~/tomtom_assets/libpng-1.6.29.tar.gz
+cd libpng-1.6.29/ 
 ./configure --prefix=$PREFIX --host=$ARCH
 make -j$JOBS
 make install

--- a/ci/build_tomtom_plugin.sh
+++ b/ci/build_tomtom_plugin.sh
@@ -39,9 +39,9 @@ if ! [ -e "~/tomtom_assets/toolchain_redhat_gcc-3.3.4_glibc-2.3.2-20060131a.tar.
   wget -nv -c https://github.com/navit-gps/dependencies/raw/master/tomtom/toolchain_redhat_gcc-3.3.4_glibc-2.3.2-20060131a.tar.gz -P ~/tomtom_assets
 fi
 
-if ! test -f "~/tomtom_assets/libpng-1.6.28.tar.gz"
+if ! test -f "~/tomtom_assets/libpng-1.6.29.tar.gz"
 then 
-  wget -nv -c ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.28.tar.gz -P ~/tomtom_assets
+  wget -nv -c ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.29.tar.gz -P ~/tomtom_assets
 fi
 
 # toolchain
@@ -195,8 +195,8 @@ make install
 
 # libpng
 cd /tmp/
-tar xzf ~/tomtom_assets/libpng-1.6.28.tar.gz
-cd libpng-1.6.28/ 
+tar xzf ~/tomtom_assets/libpng-1.6.29.tar.gz
+cd libpng-1.6.29/ 
 ./configure --prefix=$PREFIX --host=$ARCH
 make -j$JOBS
 make install

--- a/ci/run_linux_tests.sh
+++ b/ci/run_linux_tests.sh
@@ -12,10 +12,10 @@ linux_test () {
 	sleep 5
 
 	# screen shot root window
-	import -window root $CIRCLE_ARTIFACTS/default.png
+	import -window root $CIRCLE_ARTIFACTS/logs_${1}/default.png
 
 	# run tests on X11
-	bash ~/navit/ci/xdotools.sh
+	bash ~/navit/ci/xdotools.sh ${1}
 
 	# python ~/navit/ci/dbus_tests.py $CIRCLE_TEST_REPORTS/
 	# dbus-send  --print-reply --session --dest=org.navit_project.navit /org/navit_project/navit/default_navit org.navit_project.navit.navit.quit
@@ -47,7 +47,7 @@ linux_test gtk_drawing_area
 # restore config
 cp navit.xml.bak navit.xml
 # run qt5 qwidget test
-sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" v="792" h="547" qt5_widget="qwidget"@' navit.xml
+sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" w="792" h="547" qt5_widget="qwidget"@' navit.xml
 sed -i -e 's@name="Local GPS" profilename="car" enabled="yes" active="1"@name="Local GPS" profilename="car" enabled="no" active="0"@' navit.xml
 sed -i -e 's@name="Demo" profilename="car" enabled="no" @name="Demo" profilename="car" enabled="yes" follow="1" refresh="1"@' navit.xml
 sed -i -e 's@type="internal" enabled@type="internal" fullscreen="1" font_size="350" enabled@' navit.xml
@@ -57,7 +57,7 @@ linux_test qt5_widget
 # restore config
 cp navit.xml.bak navit.xml
 # run qt5 qml test
-sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" v="792" h="547" qt5_widget="qml"@' navit.xml
+sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" w="792" h="547" qt5_widget="qml"@' navit.xml
 sed -i -e 's@name="Local GPS" profilename="car" enabled="yes" active="1"@name="Local GPS" profilename="car" enabled="no" active="0"@' navit.xml
 sed -i -e 's@name="Demo" profilename="car" enabled="no" @name="Demo" profilename="car" enabled="yes" follow="1" refresh="1"@' navit.xml
 sed -i -e 's@type="internal" enabled@type="internal" fullscreen="1" font_size="350" enabled@' navit.xml

--- a/ci/run_linux_tests.sh
+++ b/ci/run_linux_tests.sh
@@ -46,8 +46,18 @@ linux_test gtk_drawing_area
 
 # restore config
 cp navit.xml.bak navit.xml
-# run qt5 test
-sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" v="792" h="547"@' navit.xml
+# run qt5 qwidget test
+sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" v="792" h="547" qt5_widget="qwidget"@' navit.xml
+sed -i -e 's@name="Local GPS" profilename="car" enabled="yes" active="1"@name="Local GPS" profilename="car" enabled="no" active="0"@' navit.xml
+sed -i -e 's@name="Demo" profilename="car" enabled="no" @name="Demo" profilename="car" enabled="yes" follow="1" refresh="1"@' navit.xml
+sed -i -e 's@type="internal" enabled@type="internal" fullscreen="1" font_size="350" enabled@' navit.xml
+sed -i -e 's@libbinding_dbus.so" active="no"@libbinding_dbus.so" active="yes"@' navit.xml
+linux_test qt5
+
+# restore config
+cp navit.xml.bak navit.xml
+# run qt5 qml test
+sed -i -e 's@graphics type="gtk_drawing_area"@graphics type="qt5" v="792" h="547" qt5_widget="qml"@' navit.xml
 sed -i -e 's@name="Local GPS" profilename="car" enabled="yes" active="1"@name="Local GPS" profilename="car" enabled="no" active="0"@' navit.xml
 sed -i -e 's@name="Demo" profilename="car" enabled="no" @name="Demo" profilename="car" enabled="yes" follow="1" refresh="1"@' navit.xml
 sed -i -e 's@type="internal" enabled@type="internal" fullscreen="1" font_size="350" enabled@' navit.xml

--- a/ci/run_linux_tests.sh
+++ b/ci/run_linux_tests.sh
@@ -52,7 +52,7 @@ sed -i -e 's@name="Local GPS" profilename="car" enabled="yes" active="1"@name="L
 sed -i -e 's@name="Demo" profilename="car" enabled="no" @name="Demo" profilename="car" enabled="yes" follow="1" refresh="1"@' navit.xml
 sed -i -e 's@type="internal" enabled@type="internal" fullscreen="1" font_size="350" enabled@' navit.xml
 sed -i -e 's@libbinding_dbus.so" active="no"@libbinding_dbus.so" active="yes"@' navit.xml
-linux_test qt5
+linux_test qt5_widget
 
 # restore config
 cp navit.xml.bak navit.xml
@@ -62,5 +62,5 @@ sed -i -e 's@name="Local GPS" profilename="car" enabled="yes" active="1"@name="L
 sed -i -e 's@name="Demo" profilename="car" enabled="no" @name="Demo" profilename="car" enabled="yes" follow="1" refresh="1"@' navit.xml
 sed -i -e 's@type="internal" enabled@type="internal" fullscreen="1" font_size="350" enabled@' navit.xml
 sed -i -e 's@libbinding_dbus.so" active="no"@libbinding_dbus.so" active="yes"@' navit.xml
-linux_test qt5
+linux_test qt5_qml
 

--- a/ci/setup_tomtom_requirements.sh
+++ b/ci/setup_tomtom_requirements.sh
@@ -40,9 +40,9 @@ if ! [ -e "~/assets/tomtom/toolchain_redhat_gcc-3.3.4_glibc-2.3.2-20060131a.tar.
   wget -nv -c http://www.tomtom.com/gpl/toolchain_redhat_gcc-3.3.4_glibc-2.3.2-20060131a.tar.gz -P ~/assets/tomtom
 fi
 
-if ! test -f "~/assets/tomtom/libpng-1.6.27.tar.gz"
+if ! test -f "~/assets/tomtom/libpng-1.6.29.tar.gz"
 then 
-  wget -nv -c ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.27.tar.gz -P ~/assets/tomtom
+  wget -nv -c ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.29.tar.gz -P ~/assets/tomtom
 fi
 
 # toolchain
@@ -70,8 +70,8 @@ make install
 
 # libpng
 cd /tmp/
-tar xzf ~/assets/tomtom/libpng-1.6.27.tar.gz
-cd libpng-1.6.27/ 
+tar xzf ~/assets/tomtom/libpng-1.6.29.tar.gz
+cd libpng-1.6.29/ 
 ./configure --prefix=$PREFIX --host=$ARCH
 make -j$JOBS
 make install

--- a/ci/xdotools.sh
+++ b/ci/xdotools.sh
@@ -1,18 +1,21 @@
 sudo apt-get install xdotool
 # Use xinput test 4 when running x11vnc on the circleci server to find mouse coordinates
 
-[ -d $CIRCLE_ARTIFACTS/logs_${1}/frames/ ] || mkdir $CIRCLE_ARTIFACTS/logs_${1}/frames/
+FRAME_DIR=$CIRCLE_ARTIFACTS/logs_${1}/frames
+LOGS_DIR=$CIRCLE_ARTIFACTS/logs_${1}
+
+[ -d $FRAME_DIR/ ] || mkdir $FRAME_DIR/
 
 event=0
 
 send_event (){
     file=`printf "%05d\n" $event`
 
-    import -window root $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png
-    if [[ "$2" == "mousemove" ]]; then
-        composite -gravity NorthWest -geometry +$3+$4 ~/navit/ci/pointer-64.png $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
+    import -window root $FRAME_DIR/tmp.png
+    if [[ "$1" == "mousemove" ]]; then
+        composite -gravity NorthWest -geometry +$2+$3 ~/navit/ci/pointer-64.png $FRAME_DIR/tmp.png $FRAME_DIR/${file}.png
     else
-        mv $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
+        mv $FRAME_DIR/tmp.png $FRAME_DIR/${file}.png
     fi
     event=$((event+1))
     xdotool $@
@@ -21,64 +24,64 @@ send_event (){
 
 
 # Center the view
-send_event ${1} key KP_Enter # Open main menu
-send_event ${1} key Down     # Select 'Actions'
-send_event ${1} key KP_Enter # Validate
-send_event ${1} key Down     # Scroll to 'Bookmarks'
-send_event ${1} key Right    # Scroll to 'Former destinations'
-send_event ${1} key Right    # Select 'Town'
-send_event ${1} key KP_Enter # Validate
+send_event key KP_Enter # Open main menu
+send_event key Down     # Select 'Actions'
+send_event key KP_Enter # Validate
+send_event key Down     # Scroll to 'Bookmarks'
+send_event key Right    # Scroll to 'Former destinations'
+send_event key Right    # Select 'Town'
+send_event key KP_Enter # Validate
 # Send 'Berk'
-send_event ${1} key b
-send_event ${1} key e
-send_event ${1} key r
-send_event ${1} key k
-send_event ${1} key Down     # Highlight search area
-send_event ${1} key Down     # Highlight first result
-send_event ${1} key KP_Enter # Validate
+send_event key b
+send_event key e
+send_event key r
+send_event key k
+send_event key Down     # Highlight search area
+send_event key Down     # Highlight first result
+send_event key KP_Enter # Validate
 
 # Set the position
-send_event ${1} mousemove 482 318 click 1 # Open main menu, clicking on a somewhat random position on the map
-send_event ${1} key Down     # Select 'Actions'
-send_event ${1} key KP_Enter # Validate
-send_event ${1} key Down     # Scroll to 'Bookmarks'
-send_event ${1} key Right    # Scroll to 'Former destinations'
-send_event ${1} key Right    # Select current coordinates
-send_event ${1} key KP_Enter # Validate
+send_event mousemove 482 318 click 1 # Open main menu, clicking on a somewhat random position on the map
+send_event key Down     # Select 'Actions'
+send_event key KP_Enter # Validate
+send_event key Down     # Scroll to 'Bookmarks'
+send_event key Right    # Scroll to 'Former destinations'
+send_event key Right    # Select current coordinates
+send_event key KP_Enter # Validate
 
 # Set a destination
-send_event ${1} key KP_Enter # Open main menu
-send_event ${1} key Down     # Select 'Actions'
-send_event ${1} key KP_Enter # Validate
-send_event ${1} key Down     # Scroll to 'Bookmarks'
-send_event ${1} key Right    # Scroll to 'Former destinations'
-send_event ${1} key Right    # Select 'Town'
-send_event ${1} key KP_Enter # Validate
+send_event key KP_Enter # Open main menu
+send_event key Down     # Select 'Actions'
+send_event key KP_Enter # Validate
+send_event key Down     # Scroll to 'Bookmarks'
+send_event key Right    # Scroll to 'Former destinations'
+send_event key Right    # Select 'Town'
+send_event key KP_Enter # Validate
 # Send 'oakl'
-send_event ${1} key o
-send_event ${1} key a
-send_event ${1} key k
-send_event ${1} key l
-send_event ${1} key Down     # Highlight search area
-send_event ${1} key Down     # Highlight first result
-send_event ${1} key KP_Enter # Validate
+send_event key o
+send_event key a
+send_event key k
+send_event key l
+send_event key Down     # Highlight search area
+send_event key Down     # Highlight first result
+send_event key KP_Enter # Validate
 
 # Switch to 3d view
-send_event ${1} key KP_Enter # Open main menu
-send_event ${1} key Down     # Select 'Actions'
-send_event ${1} key Right    # Select 'Settings'
-send_event ${1} key KP_Enter # Validate
-send_event ${1} key Down     # Select 'Display'
-send_event ${1} key KP_Enter # Validate
-send_event ${1} key Down     # Scroll to 'Layout'
-send_event ${1} key Right    # Scroll to 'Fullscreen'
-send_event ${1} key Right    # Select '3d'
-send_event ${1} key KP_Enter # Validate
+send_event key KP_Enter # Open main menu
+send_event key Down     # Select 'Actions'
+send_event key Right    # Select 'Settings'
+send_event key KP_Enter # Validate
+send_event key Down     # Select 'Display'
+send_event key KP_Enter # Validate
+send_event key Down     # Scroll to 'Layout'
+send_event key Right    # Scroll to 'Fullscreen'
+send_event key Right    # Select '3d'
+send_event key KP_Enter # Validate
 # Send 'Berk'
 
 # capture 5 seconds of usage
 for i in `seq 99994 99999`; do
-	import -window root $CIRCLE_ARTIFACTS/logs_${1}/frames/${i}.png
+	import -window root $FRAME_DIR/${i}.png
 	sleep 1
 done
 
@@ -89,6 +92,6 @@ send_event key Down     # Select 'Route'
 send_event key Right    # Select 'About'
 send_event key Right    # Select 'Quit'
 send_event key KP_Enter # Validate
-
+01
 # Assemble the gif
-convert   -delay 100 -loop 0 $CIRCLE_ARTIFACTS/logs_${1}/frames/*.png $CIRCLE_ARTIFACTS/logs_${1}/town_search.gif
+convert   -delay 100 -loop 0 $FRAME_DIR/*.png $LOGS_DIR/town_search.gif

--- a/ci/xdotools.sh
+++ b/ci/xdotools.sh
@@ -1,18 +1,18 @@
 sudo apt-get install xdotool
 # Use xinput test 4 when running x11vnc on the circleci server to find mouse coordinates
 
-[ -d $CIRCLE_ARTIFACTS/frames/ ] || mkdir $CIRCLE_ARTIFACTS/frames/
+[ -d $CIRCLE_ARTIFACTS/logs_${1}/frames/ ] || mkdir $CIRCLE_ARTIFACTS/logs_${1}/frames/
 
 event=0
 
 send_event (){
     file=`printf "%05d\n" $event`
 
-    import -window root $CIRCLE_ARTIFACTS/frames/tmp.png
+    import -window root $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png
     if [[ "$1" == "mousemove" ]]; then
-        composite -gravity NorthWest -geometry +$2+$3 ~/navit/ci/pointer-64.png $CIRCLE_ARTIFACTS/frames/tmp.png $CIRCLE_ARTIFACTS/frames/${file}.png
+        composite -gravity NorthWest -geometry +$2+$3 ~/navit/ci/pointer-64.png $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
     else
-        mv $CIRCLE_ARTIFACTS/frames/tmp.png $CIRCLE_ARTIFACTS/frames/${file}.png
+        mv $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
     fi
     event=$((event+1))
     xdotool $@
@@ -78,7 +78,7 @@ send_event key KP_Enter # Validate
 
 # capture 5 seconds of usage
 for i in `seq 99994 99999`; do
-	import -window root $CIRCLE_ARTIFACTS/frames/${i}.png
+	import -window root $CIRCLE_ARTIFACTS/logs_${1}/frames/${i}.png
 	sleep 1
 done
 
@@ -91,4 +91,4 @@ send_event key Right    # Select 'Quit'
 send_event key KP_Enter # Validate
 
 # Assemble the gif
-convert   -delay 100 -loop 0 $CIRCLE_ARTIFACTS/frames/*.png $CIRCLE_ARTIFACTS/town_search.gif
+convert   -delay 100 -loop 0 $CIRCLE_ARTIFACTS/logs_${1}/frames/*.png $CIRCLE_ARTIFACTS/logs_${1}/town_search.gif

--- a/ci/xdotools.sh
+++ b/ci/xdotools.sh
@@ -92,6 +92,6 @@ send_event key Down     # Select 'Route'
 send_event key Right    # Select 'About'
 send_event key Right    # Select 'Quit'
 send_event key KP_Enter # Validate
-01
+
 # Assemble the gif
 convert   -delay 100 -loop 0 $FRAME_DIR/*.png $LOGS_DIR/town_search.gif

--- a/ci/xdotools.sh
+++ b/ci/xdotools.sh
@@ -9,8 +9,8 @@ send_event (){
     file=`printf "%05d\n" $event`
 
     import -window root $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png
-    if [[ "$1" == "mousemove" ]]; then
-        composite -gravity NorthWest -geometry +$2+$3 ~/navit/ci/pointer-64.png $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
+    if [[ "$2" == "mousemove" ]]; then
+        composite -gravity NorthWest -geometry +$3+$4 ~/navit/ci/pointer-64.png $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
     else
         mv $CIRCLE_ARTIFACTS/logs_${1}/frames/tmp.png $CIRCLE_ARTIFACTS/logs_${1}/frames/${file}.png
     fi
@@ -21,59 +21,59 @@ send_event (){
 
 
 # Center the view
-send_event key KP_Enter # Open main menu
-send_event key Down     # Select 'Actions'
-send_event key KP_Enter # Validate
-send_event key Down     # Scroll to 'Bookmarks'
-send_event key Right    # Scroll to 'Former destinations'
-send_event key Right    # Select 'Town'
-send_event key KP_Enter # Validate
+send_event ${1} key KP_Enter # Open main menu
+send_event ${1} key Down     # Select 'Actions'
+send_event ${1} key KP_Enter # Validate
+send_event ${1} key Down     # Scroll to 'Bookmarks'
+send_event ${1} key Right    # Scroll to 'Former destinations'
+send_event ${1} key Right    # Select 'Town'
+send_event ${1} key KP_Enter # Validate
 # Send 'Berk'
-send_event key b
-send_event key e
-send_event key r
-send_event key k
-send_event key Down     # Highlight search area
-send_event key Down     # Highlight first result
-send_event key KP_Enter # Validate
+send_event ${1} key b
+send_event ${1} key e
+send_event ${1} key r
+send_event ${1} key k
+send_event ${1} key Down     # Highlight search area
+send_event ${1} key Down     # Highlight first result
+send_event ${1} key KP_Enter # Validate
 
 # Set the position
-send_event mousemove 482 318 click 1 # Open main menu, clicking on a somewhat random position on the map
-send_event key Down     # Select 'Actions'
-send_event key KP_Enter # Validate
-send_event key Down     # Scroll to 'Bookmarks'
-send_event key Right    # Scroll to 'Former destinations'
-send_event key Right    # Select current coordinates
-send_event key KP_Enter # Validate
+send_event ${1} mousemove 482 318 click 1 # Open main menu, clicking on a somewhat random position on the map
+send_event ${1} key Down     # Select 'Actions'
+send_event ${1} key KP_Enter # Validate
+send_event ${1} key Down     # Scroll to 'Bookmarks'
+send_event ${1} key Right    # Scroll to 'Former destinations'
+send_event ${1} key Right    # Select current coordinates
+send_event ${1} key KP_Enter # Validate
 
 # Set a destination
-send_event key KP_Enter # Open main menu
-send_event key Down     # Select 'Actions'
-send_event key KP_Enter # Validate
-send_event key Down     # Scroll to 'Bookmarks'
-send_event key Right    # Scroll to 'Former destinations'
-send_event key Right    # Select 'Town'
-send_event key KP_Enter # Validate
+send_event ${1} key KP_Enter # Open main menu
+send_event ${1} key Down     # Select 'Actions'
+send_event ${1} key KP_Enter # Validate
+send_event ${1} key Down     # Scroll to 'Bookmarks'
+send_event ${1} key Right    # Scroll to 'Former destinations'
+send_event ${1} key Right    # Select 'Town'
+send_event ${1} key KP_Enter # Validate
 # Send 'oakl'
-send_event key o
-send_event key a
-send_event key k
-send_event key l
-send_event key Down     # Highlight search area
-send_event key Down     # Highlight first result
-send_event key KP_Enter # Validate
+send_event ${1} key o
+send_event ${1} key a
+send_event ${1} key k
+send_event ${1} key l
+send_event ${1} key Down     # Highlight search area
+send_event ${1} key Down     # Highlight first result
+send_event ${1} key KP_Enter # Validate
 
 # Switch to 3d view
-send_event key KP_Enter # Open main menu
-send_event key Down     # Select 'Actions'
-send_event key Right    # Select 'Settings'
-send_event key KP_Enter # Validate
-send_event key Down     # Select 'Display'
-send_event key KP_Enter # Validate
-send_event key Down     # Scroll to 'Layout'
-send_event key Right    # Scroll to 'Fullscreen'
-send_event key Right    # Select '3d'
-send_event key KP_Enter # Validate
+send_event ${1} key KP_Enter # Open main menu
+send_event ${1} key Down     # Select 'Actions'
+send_event ${1} key Right    # Select 'Settings'
+send_event ${1} key KP_Enter # Validate
+send_event ${1} key Down     # Select 'Display'
+send_event ${1} key KP_Enter # Validate
+send_event ${1} key Down     # Scroll to 'Layout'
+send_event ${1} key Right    # Scroll to 'Fullscreen'
+send_event ${1} key Right    # Select '3d'
+send_event ${1} key KP_Enter # Validate
 # Send 'Berk'
 
 # capture 5 seconds of usage

--- a/navit/attr_def.h
+++ b/navit/attr_def.h
@@ -282,7 +282,7 @@ ATTR_UNUSED
 ATTR_UNUSED
 ATTR(window_title)
 ATTR(qt5_platform)
-ATTR_UNUSED
+ATTR(qt5_widget)
 /* poi */
 ATTR_UNUSED
 ATTR(info_html)

--- a/navit/graphics/qt5/CMakeLists.txt
+++ b/navit/graphics/qt5/CMakeLists.txt
@@ -3,7 +3,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-# Find the QtWidgets library
-find_package(Qt5Widgets)
-
 module_add_library(graphics_qt5 graphics_qt5.cpp event_qt5.cpp QNavitWidget.cpp)
+set(QML 0)
+set(QWIDGET 0)
+if(USE_QML)
+	set(QML 1)
+endif ()
+if(USE_QWIDGET)
+	set(QWIDGET 1)
+endif ()
+
+target_compile_definitions(graphics_qt5 PRIVATE USE_QML=${QML} USE_QWIDGET=${QWIDGET})

--- a/navit/graphics/qt5/CMakeLists.txt
+++ b/navit/graphics/qt5/CMakeLists.txt
@@ -3,14 +3,32 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-module_add_library(graphics_qt5 graphics_qt5.cpp event_qt5.cpp QNavitWidget.cpp)
+# collect additional source files in this variable
+set (GRAPHICS_QT5_ADDITIONAL "")
+
+# initialize QML and QWIDGET usage to not use
 set(QML 0)
 set(QWIDGET 0)
+
+# check if we have QML
 if(USE_QML)
-	set(QML 1)
-endif ()
-if(USE_QWIDGET)
-	set(QWIDGET 1)
+        set(QML 1)
 endif ()
 
+#check if we have QWIDGET
+if(USE_QWIDGET)
+        set(QWIDGET 1)
+        set(GRAPHICS_QT5_ADDITIONAL "QNavitWidget.cpp")
+endif ()
+
+module_add_library(graphics_qt5 graphics_qt5.cpp event_qt5.cpp ${GRAPHICS_QT5_ADDITIONAL})
+# pass QML and QWIDGET preference to source
 target_compile_definitions(graphics_qt5 PRIVATE USE_QML=${QML} USE_QWIDGET=${QWIDGET})
+
+# install qml files if QML is used
+if(USE_QML)
+        install(FILES graphics_qt5.qml DESTINATION ${LIB_DIR}/navit/${graphics_qt5_TYPE}
+                                        PERMISSIONS OWNER_READ OWNER_WRITE
+                                        OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
+                                        WORLD_READ WORLD_EXECUTE)
+endif ()

--- a/navit/graphics/qt5/CMakeLists.txt
+++ b/navit/graphics/qt5/CMakeLists.txt
@@ -2,6 +2,8 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
+# Instruct CMake to build QRC if needed
+set(CMAKE_AUTORCC ON)
 
 # collect additional source files in this variable
 set (GRAPHICS_QT5_ADDITIONAL "")
@@ -13,22 +15,16 @@ set(QWIDGET 0)
 # check if we have QML
 if(USE_QML)
         set(QML 1)
+        set(GRAPHICS_QT5_ADDITIONAL ${GRAPHICS_QT5_ADDITIONAL} "QNavitQuick.cpp" "graphics_qt5.qrc")
 endif ()
 
 #check if we have QWIDGET
 if(USE_QWIDGET)
         set(QWIDGET 1)
-        set(GRAPHICS_QT5_ADDITIONAL "QNavitWidget.cpp")
+        set(GRAPHICS_QT5_ADDITIONAL ${GRAPHICS_QT5_ADDITIONAL} "QNavitWidget.cpp")
 endif ()
 
 module_add_library(graphics_qt5 graphics_qt5.cpp event_qt5.cpp ${GRAPHICS_QT5_ADDITIONAL})
 # pass QML and QWIDGET preference to source
 target_compile_definitions(graphics_qt5 PRIVATE USE_QML=${QML} USE_QWIDGET=${QWIDGET})
 
-# install qml files if QML is used
-if(USE_QML)
-        install(FILES graphics_qt5.qml DESTINATION ${LIB_DIR}/navit/${graphics_qt5_TYPE}
-                                        PERMISSIONS OWNER_READ OWNER_WRITE
-                                        OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
-                                        WORLD_READ WORLD_EXECUTE)
-endif ()

--- a/navit/graphics/qt5/CMakeLists.txt
+++ b/navit/graphics/qt5/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 # Instruct CMake to build QRC if needed
-set(CMAKE_AUTORCC ON)
+#set(CMAKE_AUTORCC ON) -> unfortunate cmake used in CI doesnt have this
 
 # collect additional source files in this variable
 set (GRAPHICS_QT5_ADDITIONAL "")
@@ -15,7 +15,8 @@ set(QWIDGET 0)
 # check if we have QML
 if(USE_QML)
         set(QML 1)
-        set(GRAPHICS_QT5_ADDITIONAL ${GRAPHICS_QT5_ADDITIONAL} "QNavitQuick.cpp" "graphics_qt5.qrc")
+        qt5_add_resources(QT5_QRC "graphics_qt5.qrc")
+        set(GRAPHICS_QT5_ADDITIONAL ${GRAPHICS_QT5_ADDITIONAL} "QNavitQuick.cpp" ${QT5_QRC})
 endif ()
 
 #check if we have QWIDGET

--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -1,5 +1,21 @@
-#include "QNavitQuick.h"
-#include <QPainter>
+/**
+ * Navit, a modular navigation system.
+ * Copyright (C) 2005-2008 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
 
 #include <glib.h>
 #include "config.h"
@@ -18,6 +34,8 @@
 #if defined(WINDOWS) || defined(WIN32) || defined (HAVE_API_WIN32_CE)
 #include <windows.h>
 #endif
+#include <QPainter>
+#include "QNavitQuick.h"
 #include "graphics_qt5.h"
 
 QNavitQuick::QNavitQuick(QQuickItem *parent)

--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -24,6 +24,7 @@ QNavitQuick::QNavitQuick(QQuickItem *parent)
     : QQuickPaintedItem(parent)
 {
     setAcceptedMouseButtons(Qt::AllButtons);
+    graphics_priv = NULL;
 }
 
 void QNavitQuick::setGraphicContext(GraphicsPriv *gp)
@@ -89,6 +90,11 @@ void QNavitQuick::geometryChanged(const QRectF &newGeometry, const QRectF &oldGe
     dbg(lvl_debug,"enter\n");
     QQuickPaintedItem::geometryChanged(newGeometry,oldGeometry);
     QPainter * painter = NULL;
+    if(graphics_priv == NULL)
+    {
+        dbg(lvl_debug,"Context not set, aborting\n");
+	return;
+    }
     if(graphics_priv->pixmap != NULL)
     {
             delete graphics_priv->pixmap;

--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -1,0 +1,35 @@
+#include "QNavitQuick.h"
+#include <QPainter>
+
+QNavitQuick::QNavitQuick(QQuickItem *parent)
+    : QQuickPaintedItem(parent)
+{
+}
+
+QString QNavitQuick::name() const
+{
+    return m_name;
+}
+
+void QNavitQuick::setName(const QString &name)
+{
+    m_name = name;
+}
+
+QColor QNavitQuick::color() const
+{
+    return m_color;
+}
+
+void QNavitQuick::setColor(const QColor &color)
+{
+    m_color = color;
+}
+
+void QNavitQuick::paint(QPainter *painter)
+{
+    QPen pen(m_color, 2);
+    painter->setPen(pen);
+    painter->setRenderHints(QPainter::Antialiasing, true);
+    painter->drawPie(boundingRect().adjusted(1, 1, -1, -1), 90 * 16, 290 * 16);
+}

--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -1,35 +1,177 @@
 #include "QNavitQuick.h"
 #include <QPainter>
 
+#include <glib.h>
+#include "config.h"
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include "item.h"
+#include "point.h"
+#include "graphics.h"
+#include "color.h"
+#include "plugin.h"
+#include "event.h"
+#include "debug.h"
+#include "window.h"
+#include "callback.h"
+#if defined(WINDOWS) || defined(WIN32) || defined (HAVE_API_WIN32_CE)
+#include <windows.h>
+#endif
+#include "graphics_qt5.h"
+
 QNavitQuick::QNavitQuick(QQuickItem *parent)
     : QQuickPaintedItem(parent)
 {
+    setAcceptedMouseButtons(Qt::AllButtons);
 }
 
-QString QNavitQuick::name() const
+void QNavitQuick::setGraphicContext(GraphicsPriv *gp)
 {
-    return m_name;
+    dbg(lvl_debug,"enter\n");
+    graphics_priv = gp->gp;
+    QObject::connect(gp, SIGNAL(update()), this, SLOT(update()));
 }
 
-void QNavitQuick::setName(const QString &name)
+static void paintOverlays(QPainter * painter, struct graphics_priv * gp, QPaintEvent * event)
 {
-    m_name = name;
-}
-
-QColor QNavitQuick::color() const
-{
-    return m_color;
-}
-
-void QNavitQuick::setColor(const QColor &color)
-{
-    m_color = color;
+        GHashTableIter iter;
+        struct graphics_priv * key, * value;
+        g_hash_table_iter_init (&iter, gp->overlays);
+        while (g_hash_table_iter_next (&iter, (void **)&key, (void **)&value))
+        {
+                if(! value->disable)
+                {
+                         QRect rr(value->x, value->y, value->pixmap->width(), value->pixmap->height());
+                         if(event->rect().intersects(rr))
+                         {
+                                 dbg(lvl_debug,"draw overlay (%d, %d, %d, %d)\n",value->x, value->y, value->pixmap->width(), value->pixmap->height());
+                                 painter->drawPixmap(value->x, value->y, *value->pixmap);
+                                 /* draw overlays of overlay if any by recursive calling */
+                                 paintOverlays(painter, value, event);
+                         }
+                }
+        } 
 }
 
 void QNavitQuick::paint(QPainter *painter)
 {
-    QPen pen(m_color, 2);
-    painter->setPen(pen);
-    painter->setRenderHints(QPainter::Antialiasing, true);
-    painter->drawPie(boundingRect().adjusted(1, 1, -1, -1), 90 * 16, 290 * 16);
+    QPaintEvent event = QPaintEvent(QRect(boundingRect().x(), boundingRect().y(), boundingRect().width(), boundingRect().height()));
+
+    dbg(lvl_debug,"enter (%f, %f, %f, %f)\n",boundingRect().x(), boundingRect().y(), boundingRect().width(), boundingRect().height());
+
+    /* color background if any */
+    if (graphics_priv->background_graphics_gc_priv != NULL)
+    {
+            painter->setPen(*graphics_priv->background_graphics_gc_priv->pen);
+            painter->fillRect(boundingRect(),*graphics_priv->background_graphics_gc_priv->brush);
+    }
+    /* draw base */
+    painter->drawPixmap(0,0,*graphics_priv->pixmap,
+                       boundingRect().x(), boundingRect().y(),
+                       boundingRect().width(), boundingRect().height());
+    paintOverlays(painter, graphics_priv, &event);
 }
+
+
+void QNavitQuick::keyPressEvent(QKeyEvent *event)
+{
+    dbg(lvl_debug,"enter\n");
+}
+
+void QNavitQuick::keyReleaseEvent(QKeyEvent *event)
+{
+    dbg(lvl_debug,"enter\n");
+}
+
+void QNavitQuick::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
+{
+    dbg(lvl_debug,"enter\n");
+    QQuickPaintedItem::geometryChanged(newGeometry,oldGeometry);
+    QPainter * painter = NULL;
+    if(graphics_priv->pixmap != NULL)
+    {
+            delete graphics_priv->pixmap;
+            graphics_priv->pixmap = NULL;
+    }
+    
+    graphics_priv->pixmap=new QPixmap(width(), height());
+    painter = new QPainter(graphics_priv->pixmap);
+    if(painter != NULL)
+    {
+        QBrush brush;
+        painter->fillRect(0, 0, width(), height(), brush);
+        delete painter;
+    }
+    dbg(lvl_debug,"size %fx%f\n", width(), height());
+    dbg(lvl_debug,"pixmap %p %dx%d\n", graphics_priv->pixmap, graphics_priv->pixmap->width(), graphics_priv->pixmap->height());
+    /* if the root window got resized, tell navit about it */
+    if(graphics_priv->root)
+        resize_callback(graphics_priv,width(),height());
+}
+
+void QNavitQuick::mouseEvent(int pressed, QMouseEvent *event)
+{
+    struct point p;
+    dbg(lvl_debug,"enter\n");
+    p.x=event->x();
+    p.y=event->y();
+    switch (event->button()) {
+    case Qt::LeftButton:
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1), GINT_TO_POINTER(&p));
+        break;
+    case Qt::MidButton:
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2), GINT_TO_POINTER(&p));
+        break;
+    case Qt::RightButton:
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3), GINT_TO_POINTER(&p));
+        break;
+    default:
+        break;
+    }
+}
+
+void QNavitQuick::mousePressEvent(QMouseEvent *event)
+{
+    dbg(lvl_debug,"enter\n");
+    mouseEvent(1, event);
+}
+
+void QNavitQuick::mouseReleaseEvent(QMouseEvent *event)
+{
+    dbg(lvl_debug,"enter\n");
+    mouseEvent(0, event);
+}
+
+void QNavitQuick::mouseMoveEvent(QMouseEvent *event)
+{
+    dbg(lvl_debug,"enter\n");
+    struct point p;
+    p.x=event->x();
+    p.y=event->y();
+    callback_list_call_attr_1(graphics_priv->callbacks, attr_motion, (void *)&p);
+}
+
+void QNavitQuick::wheelEvent(QWheelEvent *event)
+{
+   struct point p;
+	int button;
+	dbg(lvl_debug,"enter\n");
+	p.x=event->x();	// xy-coordinates of the mouse pointer
+	p.y=event->y();
+	
+	if (event->delta() > 0)	// wheel movement away from the person
+		button=4;
+	else if (event->delta() < 0) // wheel movement towards the person
+		button=5;
+	else
+		button=-1;
+	
+	if (button != -1) {
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button), GINT_TO_POINTER(&p));
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button), GINT_TO_POINTER(&p));
+	}
+	
+	event->accept();
+}
+

--- a/navit/graphics/qt5/QNavitQuick.h
+++ b/navit/graphics/qt5/QNavitQuick.h
@@ -1,6 +1,6 @@
 #ifndef QNAVITQUICK_H
 #define QNAVITQUICK_H
-
+class QNavitQuick;
 #include <QtQuick/QQuickPaintedItem>
 #include <QColor>
 

--- a/navit/graphics/qt5/QNavitQuick.h
+++ b/navit/graphics/qt5/QNavitQuick.h
@@ -1,0 +1,29 @@
+#ifndef QNAVITQUICK_H
+#define QNAVITQUICK_H
+
+#include <QtQuick/QQuickPaintedItem>
+#include <QColor>
+
+class QNavitQuick : public QQuickPaintedItem
+{
+    Q_OBJECT
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QColor color READ color WRITE setColor)
+
+public:
+    QNavitQuick(QQuickItem *parent = 0);
+
+    QString name() const;
+    void setName(const QString &name);
+
+    QColor color() const;
+    void setColor(const QColor &color);
+
+    void paint(QPainter *painter);
+
+private:
+    QString m_name;
+    QColor m_color;
+};
+
+#endif

--- a/navit/graphics/qt5/QNavitQuick.h
+++ b/navit/graphics/qt5/QNavitQuick.h
@@ -4,26 +4,31 @@
 #include <QtQuick/QQuickPaintedItem>
 #include <QColor>
 
+#include "graphics_qt5.h"
+
 class QNavitQuick : public QQuickPaintedItem
 {
     Q_OBJECT
-    Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(QColor color READ color WRITE setColor)
-
 public:
     QNavitQuick(QQuickItem *parent = 0);
 
-    QString name() const;
-    void setName(const QString &name);
-
-    QColor color() const;
-    void setColor(const QColor &color);
-
     void paint(QPainter *painter);
 
+    Q_INVOKABLE void setGraphicContext(GraphicsPriv *gp);
+
+protected:
+    virtual void keyPressEvent(QKeyEvent *event);
+    virtual void keyReleaseEvent(QKeyEvent *event);
+    virtual void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);
+    virtual void mouseEvent(int pressed, QMouseEvent *event);
+    virtual void mousePressEvent(QMouseEvent *event);
+    virtual void mouseReleaseEvent(QMouseEvent *event);
+    virtual void mouseMoveEvent(QMouseEvent *event);
+    virtual void wheelEvent(QWheelEvent *event);
+
+
 private:
-    QString m_name;
-    QColor m_color;
+    struct graphics_priv* graphics_priv;
 };
 
 #endif

--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -89,7 +89,7 @@ void QNavitWidget::resizeEvent(QResizeEvent * event)
         dbg(lvl_debug,"pixmap %p %dx%d\n", graphics_priv->pixmap, graphics_priv->pixmap->width(), graphics_priv->pixmap->height());
         /* if the root window got resized, tell navit about it */
         if(graphics_priv->root)
-                resize_callback(width(),height());
+                resize_callback(graphics_priv,width(),height());
 }
 
 void QNavitWidget::mouseEvent(int pressed, QMouseEvent *event)
@@ -100,13 +100,13 @@ void QNavitWidget::mouseEvent(int pressed, QMouseEvent *event)
 	p.y=event->y();
 	switch (event->button()) {
 	case Qt::LeftButton:
-		callback_list_call_attr_3(callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1), GINT_TO_POINTER(&p));
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1), GINT_TO_POINTER(&p));
 		break;
 	case Qt::MidButton:
-		callback_list_call_attr_3(callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2), GINT_TO_POINTER(&p));
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2), GINT_TO_POINTER(&p));
 		break;
 	case Qt::RightButton:
-		callback_list_call_attr_3(callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3), GINT_TO_POINTER(&p));
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3), GINT_TO_POINTER(&p));
 		break;
 	default:
 		break;
@@ -131,7 +131,7 @@ void QNavitWidget::mouseMoveEvent(QMouseEvent *event)
 //        dbg(lvl_debug,"enter\n");
 	p.x=event->x();
 	p.y=event->y();
-	callback_list_call_attr_1(callbacks, attr_motion, (void *)&p);
+	callback_list_call_attr_1(graphics_priv->callbacks, attr_motion, (void *)&p);
 }
 
 void QNavitWidget::wheelEvent(QWheelEvent *event)
@@ -150,8 +150,8 @@ void QNavitWidget::wheelEvent(QWheelEvent *event)
 		button=-1;
 	
 	if (button != -1) {
-		callback_list_call_attr_3(callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button), GINT_TO_POINTER(&p));
-		callback_list_call_attr_3(callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button), GINT_TO_POINTER(&p));
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button), GINT_TO_POINTER(&p));
+		callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button), GINT_TO_POINTER(&p));
 	}
 	
 	event->accept();

--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -53,20 +53,42 @@ bool QNavitWidget::event(QEvent *event)
     return QWidget::event(event);
 }
 
+static void paintOverlays(QPainter * painter, struct graphics_priv * gp, QPaintEvent * event)
+{
+        GHashTableIter iter;
+        struct graphics_priv * key, * value;
+        g_hash_table_iter_init (&iter, gp->overlays);
+        while (g_hash_table_iter_next (&iter, (void **)&key, (void **)&value))
+        {
+                if(! value->disable)
+                {
+                         QRect rr(value->x, value->y, value->pixmap->width(), value->pixmap->height());
+                         if(event->rect().intersects(rr))
+                         {
+                                 dbg(lvl_debug,"draw overlay (%d, %d, %d, %d)\n",value->x, value->y, value->pixmap->width(), value->pixmap->height());
+                                 painter->drawPixmap(value->x, value->y, *value->pixmap);
+                                 /* draw overlays of overlay if any by recursive calling */
+                                 paintOverlays(painter, value, event);
+                         }
+                }
+        }
+        
+}
+
 void QNavitWidget :: paintEvent(QPaintEvent * event)
 {
-//        dbg(lvl_debug,"enter\n");
+        dbg(lvl_debug,"enter (%d, %d, %d, %d)\n",event->rect().x(), event->rect().y(), event->rect().width(), event->rect().height());
         QPainter painter(this);
         /* color background if any */
-    	if (graphics_priv->background_graphics_gc_priv != NULL)
+        if (graphics_priv->background_graphics_gc_priv != NULL)
         {
                 painter.setPen(*graphics_priv->background_graphics_gc_priv->pen);
-                painter.fillRect(0, 0, graphics_priv->pixmap->width(),
-                                       graphics_priv->pixmap->height(),
-                                       *graphics_priv->background_graphics_gc_priv->brush);
+                painter.fillRect(event->rect(),*graphics_priv->background_graphics_gc_priv->brush);
         }
-        painter.drawPixmap(0,0,*graphics_priv->pixmap);
-        
+        painter.drawPixmap(0,0,*graphics_priv->pixmap,
+                           event->rect().x(), event->rect().y(),
+                           event->rect().width(), event->rect().height());
+        paintOverlays(&painter, graphics_priv, event);
 }
 
 void QNavitWidget::resizeEvent(QResizeEvent * event)
@@ -79,12 +101,13 @@ void QNavitWidget::resizeEvent(QResizeEvent * event)
         }
     
         graphics_priv->pixmap=new QPixmap(size());
-        graphics_priv->pixmap->fill();
         painter = new QPainter(graphics_priv->pixmap);
-        QBrush brush;
-        painter->fillRect(0, 0, width(), height(), brush);
         if(painter != NULL)
-           delete painter;
+        {
+                QBrush brush;
+                painter->fillRect(0, 0, width(), height(), brush);
+                delete painter;
+        }
         dbg(lvl_debug,"size %dx%d\n", width(), height());
         dbg(lvl_debug,"pixmap %p %dx%d\n", graphics_priv->pixmap, graphics_priv->pixmap->width(), graphics_priv->pixmap->height());
         /* if the root window got resized, tell navit about it */
@@ -138,7 +161,7 @@ void QNavitWidget::wheelEvent(QWheelEvent *event)
 {
 	struct point p;
 	int button;
-	dbg(lvl_debug,"enter");
+	dbg(lvl_debug,"enter\n");
 	p.x=event->x();	// xy-coordinates of the mouse pointer
 	p.y=event->y();
 	

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -427,7 +427,7 @@ draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point 
 static void
 draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy)
 {
-//        dbg(lvl_debug,"enter gc=%p, fg=%p, bg=%p pos(%d,%d) %s\n", gr, fg, bg, p->x, p->y, text);
+        dbg(lvl_debug,"enter gc=%p, fg=%p, bg=%p pos(%d,%d) %s\n", gr, fg, bg, p->x, p->y, text);
 	QPainter *painter=gr->painter;
         if(painter == NULL)
                 return;

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -837,14 +837,14 @@ graphics_qt5_new(struct navit *nav, struct graphics_methods *meth, struct attr *
         graphics_priv->disable = 0;
 #if USE_QML
 	graphics_priv->window = NULL;
-   qmlRegisterType<QNavitQuick>("com.navit.graphics_qml", 1, 0, "QNavitQuick");
-   gchar* url = g_strjoin(NULL,getenv("NAVIT_LIBDIR"),"/graphics/graphics_qt5.qml",NULL);
-//	QQmlApplicationEngine * engine = new QQmlApplicationEngine(url);
+	/* register our QtQuick widget to allow it's usage within QML */
+	qmlRegisterType<QNavitQuick>("com.navit.graphics_qt5", 1, 0, "QNavitQuick");
+	/* get our qml application from embedded resources. May be replaced by the
+	 * QtQuick gui component if enabled */
 	QQmlApplicationEngine * engine = new QQmlApplicationEngine(QUrl("qrc:///graphics_qt5.qml"));
-   g_free (url);
 	if(engine != NULL)
 	{
-	        //engine->load(QUrl::fromLocalFile("graphics_qt5.qml"));
+		/* Get the engine's root window (for resizing) */
 	        QObject *toplevel = engine->rootObjects().value(0);
 	        graphics_priv->window = qobject_cast<QQuickWindow *> (toplevel);
 	}

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -44,6 +44,7 @@
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include <QFile>
+#include <QScreen>
 #if USE_QML
 #include <QQuickWindow>
 #include <QQmlApplicationEngine>
@@ -940,6 +941,12 @@ graphics_qt5_new(struct navit *nav, struct graphics_methods *meth, struct attr *
                 QRect geomet;
 		geomet.setHeight(100);
 		geomet.setWidth(100);
+		/* get desktop size */
+		QScreen *primary = navit_app->primaryScreen();
+		if(primary != NULL)
+		{
+                        geomet = primary->availableGeometry();
+                }
                 /* check for height */
                 if ((h = attr_search(attrs, NULL, attr_h)) && (h->u.num > 100))
                                 geomet.setHeight(h->u.num);

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -36,7 +36,7 @@
 #endif
 #include "graphics_qt5.h"
 #include "event_qt5.h"
-#include <QApplication>
+#include <QGuiApplication>
 #include <QPixmap>
 #include <QPainter>
 #include <QFont>
@@ -50,11 +50,12 @@
 #include "QNavitQuick.h"
 #endif
 #if USE_QWIDGET
+#include <QApplication>
 #include <QDesktopWidget>
 #include "QNavitWidget.h"
 #endif
 
-QApplication * navit_app = NULL;
+QGuiApplication * navit_app = NULL;
 
 struct graphics_font_priv {
 	QFont * font;
@@ -818,7 +819,12 @@ graphics_qt5_new(struct navit *nav, struct graphics_methods *meth, struct attr *
                 graphics_priv->argc ++;
         }
         /* create surrounding application */
-        navit_app = new QApplication(graphics_priv->argc, graphics_priv->argv);
+#if USE_QWIDGET
+	QApplication * internal_app = new QApplication(graphics_priv->argc, graphics_priv->argv);
+	navit_app = internal_app;
+#else
+        navit_app = new QGuiApplication(graphics_priv->argc, graphics_priv->argv);
+#endif
 
 #ifdef QT_QPAINTER_USE_FREETYPE
         graphics_priv->font_freetype_new=font_freetype_new;
@@ -871,7 +877,7 @@ graphics_qt5_new(struct navit *nav, struct graphics_methods *meth, struct attr *
                 /* default to desktop size if nothing else is given */
                 QRect geomet;
 #if USE_QWIDGET
-                geomet = navit_app->desktop()->screenGeometry(graphics_priv->widget);
+                geomet = internal_app->desktop()->screenGeometry(graphics_priv->widget);
 #endif
                 /* check for height */
                 if ((h = attr_search(attrs, NULL, attr_h)) && (h->u.num > 100))

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -47,6 +47,7 @@
 #if USE_QML
 #include <QQuickWindow>
 #include <QQmlApplicationEngine>
+#include "QNavitQuick.h"
 #endif
 #if USE_QWIDGET
 #include <QDesktopWidget>
@@ -836,8 +837,10 @@ graphics_qt5_new(struct navit *nav, struct graphics_methods *meth, struct attr *
         graphics_priv->disable = 0;
 #if USE_QML
 	graphics_priv->window = NULL;
+   qmlRegisterType<QNavitQuick>("com.navit.graphics_qml", 1, 0, "QNavitQuick");
    gchar* url = g_strjoin(NULL,getenv("NAVIT_LIBDIR"),"/graphics/graphics_qt5.qml",NULL);
-	QQmlApplicationEngine * engine = new QQmlApplicationEngine(url);
+//	QQmlApplicationEngine * engine = new QQmlApplicationEngine(url);
+	QQmlApplicationEngine * engine = new QQmlApplicationEngine(QUrl("qrc:///graphics_qt5.qml"));
    g_free (url);
 	if(engine != NULL)
 	{

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -836,7 +836,9 @@ graphics_qt5_new(struct navit *nav, struct graphics_methods *meth, struct attr *
         graphics_priv->disable = 0;
 #if USE_QML
 	graphics_priv->window = NULL;
-	QQmlApplicationEngine * engine = new QQmlApplicationEngine("graphics_qt5.qml");
+   gchar* url = g_strjoin(NULL,getenv("NAVIT_LIBDIR"),"/graphics/graphics_qt5.qml",NULL);
+	QQmlApplicationEngine * engine = new QQmlApplicationEngine(url);
+   g_free (url);
 	if(engine != NULL)
 	{
 	        //engine->load(QUrl::fromLocalFile("graphics_qt5.qml"));

--- a/navit/graphics/qt5/graphics_qt5.h
+++ b/navit/graphics/qt5/graphics_qt5.h
@@ -1,12 +1,26 @@
 #ifndef __graphics_qt_h
 #define __graphics_qt_h
+
+#ifndef USE_QWIDGET
+#define USE_QWIDGET 1
+#endif
+
+#ifndef USE_QML
+#define USE_QML 0
+#endif
+
 #include <glib.h>
 #include <QApplication>
 #include <QPixmap>
 #include <QPainter>
 #include <QPen>
 #include <QBrush>
+#if USE_QML
+#include <QQuickWindow>
+#endif
+#if USE_QWIDGET
 #include "QNavitWidget.h"
+#endif
 
 #ifndef QT_QPAINTER_USE_FREETYPE
 #define QT_QPAINTER_USE_FREETYPE 1
@@ -25,7 +39,12 @@ struct graphics_gc_priv;
 struct graphics_priv;
 
 struct graphics_priv {
+#if USE_QML
+	QQuickWindow * window;
+#endif
+#if USE_QWIDGET
         QNavitWidget * widget;
+#endif
         QPixmap * pixmap;
         QPainter * painter;
         int use_count;

--- a/navit/graphics/qt5/graphics_qt5.h
+++ b/navit/graphics/qt5/graphics_qt5.h
@@ -17,6 +17,7 @@
 #include <QBrush>
 #if USE_QML
 #include <QQuickWindow>
+#include <QObject>
 #endif
 #if USE_QWIDGET
 #include "QNavitWidget.h"
@@ -38,8 +39,25 @@
 struct graphics_gc_priv;
 struct graphics_priv;
 
+#if USE_QML
+class GraphicsPriv : public QObject
+{
+   Q_OBJECT
+public:
+   GraphicsPriv(struct graphics_priv * gp);
+   ~GraphicsPriv();
+   void emit_update();
+
+   struct graphics_priv * gp;
+
+signals:
+   void update();
+};
+#endif
+
 struct graphics_priv {
 #if USE_QML
+   GraphicsPriv * GPriv;
 	QQuickWindow * window;
 #endif
 #if USE_QWIDGET
@@ -67,6 +85,7 @@ struct graphics_priv {
         int argc;
         char * argv[4];
 };
+
 
 struct graphics_gc_priv {
         struct graphics_priv * graphics_priv;

--- a/navit/graphics/qt5/graphics_qt5.h
+++ b/navit/graphics/qt5/graphics_qt5.h
@@ -29,6 +29,9 @@ struct graphics_priv {
         QPixmap * pixmap;
         QPainter * painter;
         int use_count;
+        int disable;
+        int x;
+        int y;
         struct graphics_gc_priv * background_graphics_gc_priv;
 #ifdef QT_QPAINTER_USE_FREETYPE
 	struct font_priv * (*font_freetype_new)(void *meth);

--- a/navit/graphics/qt5/graphics_qt5.h
+++ b/navit/graphics/qt5/graphics_qt5.h
@@ -38,6 +38,7 @@ struct graphics_priv {
         struct callback *display_on_cb;
         struct event_timeout *display_on_ev;
 #endif
+        struct callback_list* callbacks;
         GHashTable *overlays;
         struct graphics_priv * parent;
         bool root;
@@ -53,11 +54,7 @@ struct graphics_gc_priv {
 /* central exported application info */
 extern QApplication * navit_app;
 
-/* navit callback list */
-extern struct callback_list* callbacks;
-
-void
-resize_callback(int w, int h);
+void resize_callback(struct graphics_priv * gr, int w, int h);
 
 #endif
 

--- a/navit/graphics/qt5/graphics_qt5.h
+++ b/navit/graphics/qt5/graphics_qt5.h
@@ -10,7 +10,7 @@
 #endif
 
 #include <glib.h>
-#include <QApplication>
+#include <QGuiApplication>
 #include <QPixmap>
 #include <QPainter>
 #include <QPen>
@@ -74,7 +74,7 @@ struct graphics_gc_priv {
         QBrush * brush;
 };
 /* central exported application info */
-extern QApplication * navit_app;
+extern QGuiApplication * navit_app;
 
 void resize_callback(struct graphics_priv * gr, int w, int h);
 

--- a/navit/graphics/qt5/graphics_qt5.qml
+++ b/navit/graphics/qt5/graphics_qt5.qml
@@ -1,6 +1,6 @@
 import com.navit.graphics_qt5 1.0
-import QtQuick 2.3
-import QtQuick.Window 2.2
+import QtQuick 2.2
+import QtQuick.Window 2.0
 
 Window {
    width: 200; height: 200

--- a/navit/graphics/qt5/graphics_qt5.qml
+++ b/navit/graphics/qt5/graphics_qt5.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.3
+import QtQuick.Window 2.2
+
+Window {
+   Rectangle {
+      width: 200
+      height: 100
+      color: "red"
+
+      Text {
+         anchors.centerIn: parent
+         text: "Hello, World!"
+      }
+   }
+}

--- a/navit/graphics/qt5/graphics_qt5.qml
+++ b/navit/graphics/qt5/graphics_qt5.qml
@@ -1,15 +1,13 @@
+import com.navit.graphics_qml 1.0
 import QtQuick 2.3
 import QtQuick.Window 2.2
 
 Window {
-   Rectangle {
-      width: 200
-      height: 100
-      color: "red"
-
-      Text {
-         anchors.centerIn: parent
-         text: "Hello, World!"
-      }
+   QNavitQuick {
+       id: aPieChart
+       anchors.centerIn: parent
+       width: 100; height: 100
+       name: "A simple pie chart"
+       color: "red"
    }
 }

--- a/navit/graphics/qt5/graphics_qt5.qml
+++ b/navit/graphics/qt5/graphics_qt5.qml
@@ -1,4 +1,4 @@
-import com.navit.graphics_qml 1.0
+import com.navit.graphics_qt5 1.0
 import QtQuick 2.3
 import QtQuick.Window 2.2
 

--- a/navit/graphics/qt5/graphics_qt5.qml
+++ b/navit/graphics/qt5/graphics_qt5.qml
@@ -3,11 +3,12 @@ import QtQuick 2.3
 import QtQuick.Window 2.2
 
 Window {
+   width: 200; height: 200
    QNavitQuick {
-       id: aPieChart
-       anchors.centerIn: parent
-       width: 100; height: 100
-       name: "A simple pie chart"
-       color: "red"
+       id: navit1
+       anchors.fill: parent
+       Component.onCompleted: {
+          navit1.setGraphicContext(graphics_qt5_context)
+       }
    }
 }

--- a/navit/graphics/qt5/graphics_qt5.qrc
+++ b/navit/graphics/qt5/graphics_qt5.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>graphics_qt5.qml</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
This pull request is about adding QML (QtQuick) Support to graphics_qt5 plug in.
A QML based graphics back plug in allows:
 a) to easily add a QML based GUI
 b) to integrate navit to Jolla Sailfish OS once, since QWidgets library is banned in Sailfish's Harbour shop.
This adds two build flags:
USE_QWIDGET:BOOL --> Enable QWidgets support (autodetected)
USE_QML:BOOL --> Enable QML support (autodetected)
Both can be set at the same time.

This adds one attr to graphics section in navit.xml:
qt5_widget -> set to "qml" for QML display, set to "qwidget" for qwidget display. Must only be set if both methods are present at the same time.