### PR TITLE
keep vehicle profile when deactivating vehicle

### DIFF
--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -2042,6 +2042,7 @@ gui_internal_cmd_set_active_profile(struct gui_priv *this, struct
 	struct attr vehicle_name_attr;
 	char *vehicle_name = NULL;
 	struct attr profilename_attr;
+	struct attr vehicle;
 
 	// Get the vehicle name
 	vehicle_get_attr(v, attr_name, &vehicle_name_attr, NULL);
@@ -2057,15 +2058,23 @@ gui_internal_cmd_set_active_profile(struct gui_priv *this, struct
 		dbg(lvl_error, "Unable to set the vehicle's profile name\n");
 	}
 
+	navit_set_vehicleprofile_name(this->nav,profilename);
+	
+	save_vehicle_xml(v);
+
     // Notify Navit that the routing should be re-done if this is the
     // active vehicle.
 	if (gui_internal_is_active_vehicle(this, v)) {
-		struct attr vehicle;
-		vehicle.type=attr_vehicle;
 		vehicle.u.vehicle=v;
-		navit_set_attr(this->nav, &vehicle);
 	}
-	save_vehicle_xml(v);
+	else {
+
+		vehicle.u.vehicle=NULL;
+	}
+	
+	vehicle.type=attr_vehicle;
+	navit_set_attr(this->nav, &vehicle);
+
 	
 	gui_internal_prune_menu_count(this, 1, 0);
 	gui_internal_menu_vehicle_settings(this, v, vehicle_name);

--- a/navit/navit.c
+++ b/navit/navit.c
@@ -3269,7 +3269,7 @@ navit_set_vehicleprofile(struct navit *this_, struct vehicleprofile *vp)
 	return 1;
 }
 
-static int
+int
 navit_set_vehicleprofile_name(struct navit *this_, char *name)
 {
 	struct attr attr;
@@ -3296,16 +3296,22 @@ navit_set_vehicle(struct navit *this_, struct navit_vehicle *nv)
 		if (navit_set_vehicleprofile_name(this_, attr.u.str))
 			return;
 	}
-	if (!navit_set_vehicleprofile_name(this_,"car")) {
-		/* We do not have a fallback "car" profile
-		* so lets set any profile */
-		GList *l;
-		l=this_->vehicleprofiles;
-		if (l) {
-		    this_->vehicleprofile=l->data;
-		    if (this_->route)
-			route_set_profile(this_->route, this_->vehicleprofile);
+	if (!this_->vehicleprofile) { // When deactivating vehicle, keep the last profile if any
+		if (!navit_set_vehicleprofile_name(this_,"car")) {
+			/* We do not have a fallback "car" profile
+			* so lets set any profile */
+			GList *l;
+			l=this_->vehicleprofiles;
+			if (l) {
+		    		this_->vehicleprofile=l->data;
+		    		if (this_->route)
+				route_set_profile(this_->route, this_->vehicleprofile);
+			}
 		}
+	}
+	else {
+		if (this_->route)
+			route_set_profile(this_->route, this_->vehicleprofile);
 	}
 }
 

--- a/navit/navit.h
+++ b/navit/navit.h
@@ -117,6 +117,7 @@ struct navigation *navit_get_navigation(struct navit *this_);
 struct displaylist *navit_get_displaylist(struct navit *this_);
 void navit_layout_switch(struct navit *n);
 int navit_set_vehicle_by_name(struct navit *n, const char *name);
+int navit_set_vehicleprofile_name(struct navit *this_, char *name);
 int navit_set_layout_by_name(struct navit *n, const char *name);
 void navit_disable_suspend(void);
 int navit_block(struct navit *this_, int block);


### PR DESCRIPTION
When deactivating vehicle, profile is choosen from "car" vehicle_profile or by
default the first vehicle_profile in list. So, by example,
car_avoid_tolls never work when manually selecting current position (and
deactivate vehicle).

Now, if there is a selected vehicle profile, we keep it as
vehicle_profile (not changing it).

Aditionnaly, in internal gui, selecting a vehicle profile when wehicle
is deactivated, in gui_internal_cmd_set_active_profile(), call navit_set_vehicleprofile_name() with new
vehicle_profile (by name) before setting vehicle_attr to NULL (like in
gui_internal_cmd_set_position()).

Now, we can switch profile when vehicle is deactivatied and route is
update correctly.

TO DO : Same in other gui
TO TEST : with more than one vehicle enable