### PR TITLE
:qnavigation_analyze_roundabout : central_angle may lead to division by 0

### DIFF
--- a/navit/navigation.c
+++ b/navit/navigation.c
@@ -2486,7 +2486,12 @@ void navigation_analyze_roundabout(struct navigation *this_, struct navigation_c
 			 * The central angle is approximated using the unweighted average of delta1 and delta2,
 			 * which is somewhat crude but sufficient for our purposes. */
 			central_angle = abs((delta1 + delta2) / 2 + ((cmd->delta < dtsir) ? 180 : -180));
-			roundabout_length = len * 360 / central_angle;
+			if (central_angle)
+				roundabout_length = len * 360 / central_angle;
+			else {
+				dbg(lvl_error,"central_angle in roundabout_length computation lead to divide by zero (delta1 = %d, delta2 = %d, cmd->delta  = %d, dtsir = %d, len = %d)",delta1,delta2,cmd->delta,dtsir,len);
+				roundabout_length = len;
+			}
 			dbg(lvl_debug,"roundabout_length = %dm (for central_angle = %d degrees)\n", roundabout_length, central_angle);
 
 			/* in the case of separate carriageways, approach roads become hard to identify, thus we keep a cap on distance.


### PR DESCRIPTION
On the path from orange (france) to valence (france) by highway,
the third roundabout after highway exit lead to central_angle=0, leading
to divide by 0 (near line 2488).

from osm_id : 160627295 to osm_id : 4277896

(delta1 + delta2) seams to be 360, so I just set roundabout_length to len in that
case.