### PR TITLE
Fix trac1347.

### DIFF
--- a/navit/vehicle/demo/vehicle_demo.c
+++ b/navit/vehicle/demo/vehicle_demo.c
@@ -168,6 +168,8 @@ vehicle_demo_set_attr_do(struct vehicle_priv *priv, struct attr *attr)
 	case attr_profilename:
 	case attr_source:
 	case attr_name:
+	case attr_follow:
+	case attr_active:
 		// Ignore; used by Navit's infrastructure, but not relevant for this vehicle.
 		break;
 	default:


### PR DESCRIPTION
Add 'Follow' and 'Active' to vehicle_demo to remove the corresponding error messages (Unsupported Attribute)

[trac1347](http://trac.navit-project.org/ticket/1347#no1)

The Demo_Vehicle complains about its unsupported attributes follow and active. These Attributes arent really unsupported but processes inside navit.c for all vehicles. Since these Attributes are processes globally we might want to ignore them inside vehicle_demo.c.

So this will be acheived by this PR. 