### PR TITLE
Fix: Don't crash if LANG environment not set

### DIFF
--- a/navit/gui/internal/gui_internal_keyboard.c
+++ b/navit/gui/internal/gui_internal_keyboard.c
@@ -429,6 +429,10 @@ int
 gui_internal_keyboard_init_mode(char *lang)
 {
 	int ret=0;
+	/* do not crash if lang is NULL, which may be returned by getenv*/
+	if(lang == NULL)
+	    return VKBD_LATIN_UPPER;
+
 	/* Converting to upper case here is required for Android */
 	lang=g_ascii_strup(lang,-1);
 	/*


### PR DESCRIPTION
Since getenv may return NULL if a variable is not set, current keyboard
code crashes if LANG environment is not set.