### PR TITLE
fix: android cursor size

### DIFF
--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -3762,7 +3762,7 @@ Waypoint</text></img>
 		</layout>
 
     <layout name="Car-Android" color="#fef9ee" font="Liberation Sans">
-      <cursor w="49" h="49">
+      <cursor w="57" h="57">
         <itemgra speed_range="-2">
           <polyline color="#00BC00" radius="0" width="4">
             <coord x="0" y="0" />


### PR DESCRIPTION
Fix the base size of the android curser so the cursor drawing does not
draw out of the given space. Some graphics backends (like qt5) that have
real overlays don't like drawing out of the given overlay area.