### PR TITLE
[DNM] Add:xml:Set default pitch to 10 for Android build

### DIFF
--- a/navit/xslt/android.xslt
+++ b/navit/xslt/android.xslt
@@ -50,6 +50,7 @@
          <xsl:copy-of select="@*"/>
          <xsl:attribute name="zoom">32</xsl:attribute>
          <xsl:attribute name="autozoom_active">1</xsl:attribute>
+         <xsl:attribute name="pitch">10</xsl:attribute>
          <xsl:attribute name="timeout">86400</xsl:attribute>
          <xsl:attribute name="drag_bitmap">1</xsl:attribute>
          <xsl:apply-templates/>


### PR DESCRIPTION
The default pitch of 20 is too high for Android devices which usually have 16:9 or 16:10 screens. This results in some distortion and unused screen space. 10 seems to be a better default value.