### PR TITLE
Set default pitch to 5 for Android build

### DIFF
--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -3427,7 +3427,11 @@ static struct gui_priv * gui_internal_new(struct navit *nav, struct gui_methods 
 	if( (attr=attr_search(attrs,NULL,attr_pitch)))
 	      this->pitch=attr->u.num;
 	else
+#ifdef HAVE_API_ANDROID
+		this->pitch=10;
+#else
 		this->pitch=20;
+#endif
 	if( (attr=attr_search(attrs,NULL,attr_flags_town)))
 		this->flags_town=attr->u.num;
 	else

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -3428,7 +3428,7 @@ static struct gui_priv * gui_internal_new(struct navit *nav, struct gui_methods 
 	      this->pitch=attr->u.num;
 	else
 #ifdef HAVE_API_ANDROID
-		this->pitch=10;
+		this->pitch=5;
 #else
 		this->pitch=20;
 #endif

--- a/navit/gui/qml/gui_qml.cpp
+++ b/navit/gui/qml/gui_qml.cpp
@@ -435,7 +435,7 @@ static struct gui_priv * gui_qml_new(struct navit *nav, struct gui_methods *meth
 	if( (attr=attr_search(attrs,NULL,attr_radius)))
 			  this_->radius=attr->u.num;
 #ifdef HAVE_API_ANDROID
-	this_->pitch = 10; //Default value
+	this_->pitch = 5; //Default value
 #else
 	this_->pitch = 20; //Default value
 #endif

--- a/navit/gui/qml/gui_qml.cpp
+++ b/navit/gui/qml/gui_qml.cpp
@@ -434,7 +434,11 @@ static struct gui_priv * gui_qml_new(struct navit *nav, struct gui_methods *meth
 	this_->radius = 10; //Default value
 	if( (attr=attr_search(attrs,NULL,attr_radius)))
 			  this_->radius=attr->u.num;
+#ifdef HAVE_API_ANDROID
+	this_->pitch = 10; //Default value
+#else
 	this_->pitch = 20; //Default value
+#endif
 	if( (attr=attr_search(attrs,NULL,attr_pitch)))
 			  this_->pitch=attr->u.num;
 	this_->lazy = 1; //YES by default


### PR DESCRIPTION
The default pitch of 20 is too high for Android devices which usually have 16:9 or 16:10 screens. This results in some distortion and unused screen space. 5 seems to be a better default value with less unused screen space and a nice 3D look (and it is still a 'nice' number). I've tested this on 7 devices.

Example:

Pitch 20:
![pitch20](https://user-images.githubusercontent.com/23396293/28256973-782eaa70-6ac7-11e7-9883-e3eeecafe8af.png)

Pitch 5:
![pitch5](https://user-images.githubusercontent.com/23396293/28256976-7b04e598-6ac7-11e7-8581-f5b0c4ad7e41.png)
