### PR TITLE
Auto pitch and orientation + Apply pitch correction in reverse when reading attribute

### DIFF
--- a/navit/navit.c
+++ b/navit/navit.c
@@ -2596,7 +2596,7 @@ navit_set_attr_do(struct navit *this_, struct attr *attr, int init)
 	case attr_pitch:
 		attr_updated=(this_->pitch != attr->u.num);
 		this_->pitch=attr->u.num;
-		transform_set_pitch(this_->trans, ceil(this_->pitch*sqrt(240*320)/sqrt(this_->w*this_->h))); // Pitch corrected for window resolution
+		transform_set_pitch(this_->trans, round(this_->pitch*sqrt(240*320)/sqrt(this_->w*this_->h))); // Pitch corrected for window resolution
 		if (!init && attr_updated && this_->ready == 3)
 			navit_draw(this_);
 		break;
@@ -2836,7 +2836,7 @@ navit_get_attr(struct navit *this_, enum attr_type type, struct attr *attr, stru
 		attr->u.num=this_->osd_configuration;
 		break;
 	case attr_pitch:
-		attr->u.num=transform_get_pitch(this_->trans);
+		attr->u.num=round(transform_get_pitch(this_->trans)*sqrt(this_->w*this_->h)/sqrt(240*320)); // Pitch corrected for window resolution
 		break;
 	case attr_projection:
 		if(this_->trans) {

--- a/navit/xslt/osd_minimum.xslt
+++ b/navit/xslt/osd_minimum.xslt
@@ -23,7 +23,7 @@
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(2*(number($ICON_BIG)+8*number($OSD_SIZE)))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0||follow>1" />
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="cmd_interface" update_period="1" command="pitch=autozoom_active==0?(pitch==0?0:20):(follow>1?0:20);orientation=autozoom_active==0?orientation:(follow>1?0:-1)" x="-1" y="-1" w="1" h="1" />
+      <osd type="cmd_interface" update_period="1" command="pitch=autozoom_active==0?pitch:(follow>1?0:20);orientation=autozoom_active==0?orientation:(follow>1?0:-1)" x="-1" y="-1" w="1" h="1" />
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="button" src="cursor_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="follow=0;set_center_cursor()" x="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" y="0" enable_expression="follow>1" use_overlay="{$OSD_USE_OVERLAY}"/>
       <xsl:text>&#x0A;        </xsl:text>

--- a/navit/xslt/osd_minimum.xslt
+++ b/navit/xslt/osd_minimum.xslt
@@ -15,9 +15,15 @@
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="text" label="${{navigation.item[1].length[named]}}" x="0" y="{-$NEXT_TURN_TEXT_HIGHT}" w="{$NEXT_TURN_SIZE+$NEXT_TURN_TEXT_HIGHT}" h="{$NEXT_TURN_TEXT_HIGHT}" font_size="{round(200*number($OSD_SIZE))}" enable_expression="navigation.nav_status>=3"/>
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_in_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_in()" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}"/>
+      <osd type="button" src="gui_zoom_manual_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=0" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active!=0" />
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}"/>
+      <osd type="button" src="gui_zoom_auto_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=1" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0" />
+      <xsl:text>&#x0A;        </xsl:text>
+      <osd type="button" src="gui_zoom_in_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_in()" x="0" y="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0||follow>1" />
+      <xsl:text>&#x0A;        </xsl:text>
+      <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(2*(number($ICON_BIG)+8*number($OSD_SIZE)))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0||follow>1" />
+      <xsl:text>&#x0A;        </xsl:text>
+      <osd type="cmd_interface" update_period="1" command="pitch=autozoom_active==0?(pitch==0?0:20):(follow>1?0:20);orientation=autozoom_active==0?orientation:(follow>1?0:-1)" x="-1" y="-1" w="1" h="1" />
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="button" src="cursor_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="follow=0;set_center_cursor()" x="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" y="0" enable_expression="follow>1" use_overlay="{$OSD_USE_OVERLAY}"/>
       <xsl:text>&#x0A;        </xsl:text>

--- a/navit/xslt/osd_minimum.xslt
+++ b/navit/xslt/osd_minimum.xslt
@@ -19,9 +19,9 @@
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="button" src="gui_zoom_auto_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=1" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0" />
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_in_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_in()" x="0" y="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0||follow>1" />
+      <osd type="button" src="gui_zoom_in_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_in()" x="0" y="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" />
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(2*(number($ICON_BIG)+8*number($OSD_SIZE)))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0||follow>1" />
+      <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(2*(number($ICON_BIG)+8*number($OSD_SIZE)))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" />
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="cmd_interface" update_period="1" command="pitch=autozoom_active==0?pitch:(follow>1?0:20);orientation=autozoom_active==0?orientation:(follow>1?0:-1)" x="-1" y="-1" w="1" h="1" />
       <xsl:text>&#x0A;        </xsl:text>

--- a/navit/xslt/osd_minimum.xslt
+++ b/navit/xslt/osd_minimum.xslt
@@ -15,15 +15,15 @@
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="text" label="${{navigation.item[1].length[named]}}" x="0" y="{-$NEXT_TURN_TEXT_HIGHT}" w="{$NEXT_TURN_SIZE+$NEXT_TURN_TEXT_HIGHT}" h="{$NEXT_TURN_TEXT_HIGHT}" font_size="{round(200*number($OSD_SIZE))}" enable_expression="navigation.nav_status>=3"/>
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_manual_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=0" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active!=0" />
+      <osd type="button" src="gui_zoom_manual_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=0" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active!=0"/>
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_auto_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=1" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0" />
+      <osd type="button" src="gui_zoom_auto_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="autozoom_active=1" x="0" y="0" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" enable_expression="autozoom_active==0"/>
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_in_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_in()" x="0" y="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" />
+      <osd type="button" src="gui_zoom_in_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_in()" x="0" y="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}"/>
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(2*(number($ICON_BIG)+8*number($OSD_SIZE)))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}" />
+      <osd type="button" src="gui_zoom_out_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="zoom_out()" x="0" y="{round(2*(number($ICON_BIG)+8*number($OSD_SIZE)))}" osd_configuration="1" use_overlay="{$OSD_USE_OVERLAY}"/>
       <xsl:text>&#x0A;        </xsl:text>
-      <osd type="cmd_interface" update_period="1" command="pitch=autozoom_active==0?pitch:(follow>1?0:20);orientation=autozoom_active==0?orientation:(follow>1?0:-1)" x="-1" y="-1" w="1" h="1" />
+      <osd type="cmd_interface" update_period="1" command="pitch=autozoom_active==0?pitch:(follow>1?0:20);orientation=autozoom_active==0?orientation:(follow>1?0:-1)" x="-1" y="-1" w="1" h="1"/>
       <xsl:text>&#x0A;        </xsl:text>
       <osd type="button" src="cursor_{number($ICON_BIG)}_{number($ICON_BIG)}.png" command="follow=0;set_center_cursor()" x="{round(number($ICON_BIG)+8*number($OSD_SIZE))}" y="0" enable_expression="follow>1" use_overlay="{$OSD_USE_OVERLAY}"/>
       <xsl:text>&#x0A;        </xsl:text>


### PR DESCRIPTION
Suggestion for improving the out-of-box experience for builds using ```osd_minimum.xslt``` (Android and iPhone).

Depending on the ```autozoom_active``` setting (which is enabled by default on Android; https://github.com/navit-gps/navit/blob/trunk/navit/xslt/android.xslt#L52) the following paramers are set automatically:

- ```pitch``` (```pitch=autozoom_active==0?pitch:(follow>1?0:20)```)
- ```orientation``` (```orientation=autozoom_active==0?orientation:(follow>1?0:-1)```)

And a new OSD element is added:

- _Zoom auto_ or _Zoom manual_ (depending on active setting/```autozoom_active```)

Initial startup: **auto mode; driving/navigating**:
![screenshot_20170731-200546](https://user-images.githubusercontent.com/23396293/28791444-c7fd5144-762c-11e7-8c11-41d4f7242272.png)
Because autozoom is active by default, this sets the ```pitch``` to a value of 20 for a 3D look. ```orientation``` is set to -1 so the map rotates in the direction of travel.
**Edit:** Zoom in and out buttons are now also shown in this mode since https://github.com/navit-gps/navit/pull/306/commits/ba2b45475842d43cf6ac60039a727b4c1c456fa4.

Dragging the map: **auto mode; browsing**:
![screenshot_20170731-200601](https://user-images.githubusercontent.com/23396293/28791452-d2baeb8c-762c-11e7-80c4-7e9ea7a57891.png)
By moving the map, ```orientation``` is automatically set to 0 to force a North-up view. ```pitch``` is set to 0 so the map is shown top-down. OSD Zoom buttons are shown, as the user might want to manually zoom in and out from this view.

Select manual zoom (M icon):
![screenshot_20170731-200619](https://user-images.githubusercontent.com/23396293/28791467-e16bebe0-762c-11e7-9fd9-f915425d1e3d.png)
Enabling manual zoom mode always shows the OSD zoom buttons and allows ```pitch``` to be toggled using the standard (2D/3D) buttons in the menu. ```orientation``` is unchanged.

Select automatic zoom (A icon) and follow cursor:
![screenshot_20170731-200631](https://user-images.githubusercontent.com/23396293/28791492-f2838820-762c-11e7-9794-a18a0519d54b.png)
Enabling automatic zoom and centering on the cursor again, ```pitch``` is set to 20 and ```orientation``` is set to -1.
**Edit:** Zoom in and out buttons are now also shown in this mode since https://github.com/navit-gps/navit/pull/306/commits/ba2b45475842d43cf6ac60039a727b4c1c456fa4.

Zoom-to-route:
![screenshot_20170731-202828](https://user-images.githubusercontent.com/23396293/28792235-39e90d96-762f-11e7-8421-2adb1c27b7f1.png)
North-oriented and top view.
