### PR TITLE
Solve problems when building on Ubuntu 17.04 system

### DIFF
--- a/navit/maptool/maptool.c
+++ b/navit/maptool/maptool.c
@@ -552,7 +552,7 @@ start_phase(struct maptool_params *p, char *str)
 
 static void
 exit_with_error(char* error_message) {
-	fprintf(stderr, error_message);
+	fprintf(stderr, "%s", error_message);
 	exit(1);
 }
 

--- a/navit/speech/qt5_espeak/qt5_espeak.cpp
+++ b/navit/speech/qt5_espeak/qt5_espeak.cpp
@@ -32,6 +32,10 @@ extern "C" {
 #include "plugin.h"
 #include "speech.h"
 #include "util.h"
+
+//Undefine the min and max macros (they conflict with functions of the same name in <alorithm>)
+#undef min
+#undef max
 }
 #include <espeak/speak_lib.h>
 


### PR DESCRIPTION
The first commit fixes a problem when building with -Werror=format-security (which is for example commonly used while building debian / ubuntu packages): using fprintf with a string variable instead of a string literal causes an error when building with this option. It is also a bad idea in general, since someone might accidentally call exit_with_error with a string containing a printf format specifier, like exit_with_error("Some error with a %s").

The second commit solves a name conflict between the min/max macros defined in util.h, and the min/max functions defined in c++'s <algorithm> header. This problem appeared while building on an Ubuntu 17.04 system. Of course, there might be more transparent solutions for this than just undefing the macros in util.h (like putting these in another header, or giving these macros another name).