### PR TITLE
Patch:core:More Talker IDs other than GP accepted

### DIFF
--- a/navit/vehicle/file/vehicle_file.c
+++ b/navit/vehicle/file/vehicle_file.c
@@ -451,7 +451,7 @@ vehicle_file_parse(struct vehicle_priv *priv, char *buffer)
 		*p++ = '\0';
 	}
 
-	if (!strncmp(buffer, "$GPGGA", 6)) {
+	if (!strncmp(&buffer[3], "GGA", 3)) {
 		/*                                                           1 1111
 		   0      1          2         3 4          5 6 7  8   9     0 1234
 		   $GPGGA,184424.505,4924.2811,N,01107.8846,E,1,05,2.5,408.6,M,,,,0000*0C
@@ -475,14 +475,15 @@ vehicle_file_parse(struct vehicle_priv *priv, char *buffer)
 			if (!g_ascii_strcasecmp(item[5],"W"))
 				priv->geo.lng=-priv->geo.lng;
 			priv->valid=attr_position_valid_valid;
-            dbg(lvl_info, "latitude '%2.4f' longitude %2.4f\n", priv->geo.lat, priv->geo.lng);
+
+			dbg(lvl_info, "latitude '%2.4f' longitude %2.4f\n", priv->geo.lat, priv->geo.lng);
 
 		} else
 			priv->valid=attr_position_valid_invalid;
 		if (*item[6])
 			sscanf(item[6], "%d", &priv->status);
 		if (*item[7])
-		sscanf(item[7], "%d", &priv->sats_used);
+			sscanf(item[7], "%d", &priv->sats_used);
 		if (*item[8])
 			sscanf(item[8], "%lf", &priv->hdop);
 		if (*item[1]) 
@@ -500,7 +501,7 @@ vehicle_file_parse(struct vehicle_priv *priv, char *buffer)
 			}
 		}
 	}
-	if (!strncmp(buffer, "$GPVTG", 6)) {
+	if (!strncmp(&buffer[3], "VTG", 3)) {
 		/* 0      1      2 34 5    6 7   8
 		   $GPVTG,143.58,T,,M,0.26,N,0.5,K*6A
 		   Course Over Ground Degrees True[1],"T"[2],Course Over Ground Degrees Magnetic[3],"M"[4],
@@ -516,7 +517,7 @@ vehicle_file_parse(struct vehicle_priv *priv, char *buffer)
 			dbg(lvl_info,"direction %lf, speed %2.1lf\n", priv->direction, priv->speed);
 		}
 	}
-	if (!strncmp(buffer, "$GPRMC", 6)) {
+	if (!strncmp(&buffer[3], "RMC", 3)) {
 		/*                                                           1     1
 		   0      1      2 3        4 5         6 7     8     9      0     1
 		   $GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A
@@ -576,7 +577,7 @@ vehicle_file_parse(struct vehicle_priv *priv, char *buffer)
 			priv->next_count=0;
 		}
 	}
-	if (!strncmp(buffer, "$GPZDA", 6)) {
+	if (!strncmp(&buffer[3], "ZDA", 3)) {
 	/*
 		0        1        2  3  4    5  6
 		$GPZDA,hhmmss.ss,dd,mm,yyyy,xx,yy*CC

--- a/navit/vehicle/webos/bluetooth.c
+++ b/navit/vehicle/webos/bluetooth.c
@@ -206,7 +206,7 @@ vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer)
 //		dbg(lvl_info,"delta(%i)\n",priv->delta);
 //	}
 
-	if (!strncmp(buffer, "$GPGGA", 6)) {
+	if (!strncmp(&buffer[3], "GGA", 3)) {
 		/*                                                           1 1111
 		   0      1          2         3 4          5 6 7  8   9     0 1234
 		   $GPGGA,184424.505,4924.2811,N,01107.8846,E,1,05,2.5,408.6,M,,,,0000*0C
@@ -262,7 +262,7 @@ vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer)
 #endif
 		ret = 1;
 	}
-	if (!strncmp(buffer, "$GPVTG", 6)) {
+	if (!strncmp(&buffer[3], "VTG", 3)) {
 		/* 0      1      2 34 5    6 7   8
 		   $GPVTG,143.58,T,,M,0.26,N,0.5,K*6A
 		   Course Over Ground Degrees True[1],"T"[2],Course Over Ground Degrees Magnetic[3],"M"[4],
@@ -278,7 +278,7 @@ vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer)
 			dbg(lvl_info,"direction %lf, speed %2.1lf\n", priv->track, priv->speed);
 		}
 	}
-	if (!strncmp(buffer, "$GPRMC", 6)) {
+	if (!strncmp(&buffer[3], "RMC", 3)) {
 		/*                                                           1     1
 		   0      1      2 3        4 5         6 7     8     9      0     1
 		   $GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A
@@ -352,7 +352,7 @@ vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer)
 #endif
 	}
 #if 0
-	if (!strncmp(buffer, "$GPZDA", 6)) {
+	if (!strncmp(&buffer[3], "ZDA", 3)) {
 	/*
 		0        1        2  3  4    5  6
 		$GPZDA,hhmmss.ss,dd,mm,yyyy,xx,yy*CC

--- a/navit/vehicle/wince/vehicle_wince.c
+++ b/navit/vehicle/wince/vehicle_wince.c
@@ -467,7 +467,7 @@ vehicle_wince_parse(struct vehicle_priv *priv, char *buffer)
 		*p++ = '\0';
 	}
 
-	if (!strncmp(buffer, "$GPGGA", 6)) {
+	if (!strncmp(&buffer[3], "GGA", 3)) {
 		/*                                                           1 1111
 		   0      1          2         3 4          5 6 7  8   9     0 1234
 		   $GPGGA,184424.505,4924.2811,N,01107.8846,E,1,05,2.5,408.6,M,,,,0000*0C
@@ -491,7 +491,8 @@ vehicle_wince_parse(struct vehicle_priv *priv, char *buffer)
 			if (!g_strcasecmp(item[5],"W"))
 				priv->geo.lng=-priv->geo.lng;
 			priv->valid=attr_position_valid_valid;
-		dbg(lvl_info, "latitude '%2.4f' longitude %2.4f\n", priv->geo.lat, priv->geo.lng);
+
+			dbg(lvl_info, "latitude '%2.4f' longitude %2.4f\n", priv->geo.lat, priv->geo.lng);
 
 		} else
 			priv->valid=attr_position_valid_invalid;
@@ -510,7 +511,7 @@ vehicle_wince_parse(struct vehicle_priv *priv, char *buffer)
 		priv->nmea_data=priv->nmea_data_buf;
 		priv->nmea_data_buf=NULL;
 	}
-	if (!strncmp(buffer, "$GPVTG", 6)) {
+	if (!strncmp(&buffer[3], "VTG", 3)) {
 		/* 0      1      2 34 5    6 7   8
 		   $GPVTG,143.58,T,,M,0.26,N,0.5,K*6A
 		   Course Over Ground Degrees True[1],"T"[2],Course Over Ground Degrees Magnetic[3],"M"[4],
@@ -526,7 +527,7 @@ vehicle_wince_parse(struct vehicle_priv *priv, char *buffer)
 			dbg(lvl_info,"direction %lf, speed %2.1lf\n", priv->direction, priv->speed);
 		}
 	}
-	if (!strncmp(buffer, "$GPRMC", 6)) {
+	if (!strncmp(&buffer[3], "RMC", 3)) {
 		/*                                                           1     1
 		   0      1      2 3        4 5         6 7     8     9      0     1
 		   $GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A
@@ -586,7 +587,7 @@ vehicle_wince_parse(struct vehicle_priv *priv, char *buffer)
 			priv->next_count=0;
 		}
 	}
-	if (!strncmp(buffer, "$GPZDA", 6)) {
+	if (!strncmp(&buffer[3], "ZDA", 3)) {
 	/*
 		0        1        2  3  4    5  6
 		$GPZDA,hhmmss.ss,dd,mm,yyyy,xx,yy*CC


### PR DESCRIPTION
NMEA messages starts with '$' followed by 2 digits that indicates
the Talker ID. The most common was GP for GPS, but now many modules
can use other satellites systems or even 2 systems at the same time.

Other Talker IDs are:
- GL:russian GLONASS
- GA: european Galileo
- BD: chinesse BeiDu
- GN: Global Navigation: a combination of 2 or more systems.