### PR TITLE
Sailfish icon size fix

### DIFF
--- a/contrib/sailfish/navit-sailfish.spec
+++ b/contrib/sailfish/navit-sailfish.spec
@@ -10,7 +10,7 @@ Name: harbour-navit
 Summary: Open Source car navigation system
 #Version: %{navit_version}_%{git_version}
 Version: 0.5.1
-Release: 3
+Release: 4
 License: GPL
 Group: Applications/Productivity
 URL: http://navit-projet.org/
@@ -123,6 +123,10 @@ cmake  -DCMAKE_INSTALL_PREFIX:PATH=/usr \
 
 
 %changelog
+*Tue Oct 17 2017 metalstrolch 0.5.1-4
+- Fix medium GUI icon size to cope with changed icon set on upstream
+- Update upstream
+
 *Wed Jun 05 2017 metalstrolch 0.5.1-3
 - Enable rotating.
 - Create default config from xlst

--- a/navit/xslt/sailfish_gui.xslt
+++ b/navit/xslt/sailfish_gui.xslt
@@ -25,7 +25,7 @@
          <xsl:apply-templates select="@*"/>
          <xsl:attribute name="font_size">350</xsl:attribute>
          <xsl:attribute name="icon_xs">32</xsl:attribute>
-         <xsl:attribute name="icon_s">96</xsl:attribute>
+         <xsl:attribute name="icon_s">64</xsl:attribute>
          <xsl:attribute name="icon_l">96</xsl:attribute>
          <xsl:attribute name="enabled">yes</xsl:attribute>
          <xsl:apply-templates select="node()"/>


### PR DESCRIPTION
 Navit medium GUI icon size fix

This changes the medium size icon for HMI to 64x64px. This is necessary
because of changed icon set and therefore different icon default sizes.
Otherwise the icons on POI screen were way too big.

