### PR TITLE
Add self checking workaround for android platform tools

### DIFF
--- a/ci/setup_android.sh
+++ b/ci/setup_android.sh
@@ -13,6 +13,14 @@ cd /opt && rm -f android-sdk.tgz
 export PATH=${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools:/opt/tools
 
 echo y | android update sdk --no-ui --all --filter platform-tools | grep 'package installed'
+
+# This is only an workaround to make sure the platform tools are installed
+if [ ! -d ${ANDROID_SDK_HOME}/platform-tools ] && [ -f ${ANDROID_SDK_HOME}/temp/platform-tools_r26.0.2-linux.zip ]; then
+	if [ "$(md5sum ${ANDROID_SDK_HOME}/temp/platform-tools_r26.0.2-linux.zip | cut -d" " -f1)" == "ef952bb31497f7535e061ad0e712bed8" ]; then
+		cd ${ANDROID_SDK_HOME} && unzip ${ANDROID_SDK_HOME}/temp/platform-tools_r26.0.2-linux.zip
+	fi
+fi
+
 #RUN echo y | android update sdk --no-ui --all --filter extra-android-support | grep 'package installed'
 
 echo y | android update sdk --no-ui --all --filter android-25 | grep 'package installed'


### PR DESCRIPTION
This pull request adds a workaround to the CI because current platform tools from google are broken.
This fixes Ticket #1354

(This is the replacement for PR #356 because I had a problem with my repo)