### PR TITLE
fix:gtk:fixed missing imperial units in the GTK ui.

### DIFF
--- a/navit/gui/gtk/gui_gtk_statusbar.c
+++ b/navit/gui/gtk/gui_gtk_statusbar.c
@@ -22,7 +22,6 @@
 #include <time.h>
 #include <math.h>
 #include <gtk/gtk.h>
-/* #include <gps.h>                /\* Not the same as gpsd.h. Get converion constants. *\/ */
 #include "item.h"
 #include "coord.h"
 #include "debug.h"

--- a/navit/gui/gtk/gui_gtk_statusbar.c
+++ b/navit/gui/gtk/gui_gtk_statusbar.c
@@ -22,7 +22,7 @@
 #include <time.h>
 #include <math.h>
 #include <gtk/gtk.h>
-#include <gps.h>                /* Not the same as gpsd.h. Get converion constants. */
+/* #include <gps.h>                /\* Not the same as gpsd.h. Get converion constants. *\/ */
 #include "item.h"
 #include "coord.h"
 #include "debug.h"
@@ -124,7 +124,7 @@ statusbar_route_update(struct statusbar_priv *this, struct navit *navit, struct 
 		map_rect_destroy(mr);
 
         sprintf(buffer,_("Route %4.1f%s    %02d:%02d ETA" ),
-                imperial == TRUE ? route_len*METERS_TO_MILES : route_len/1000,
+                imperial == TRUE ? route_len / METERS_PER_MILE : route_len/1000,
                 imperial == TRUE ? "mi" : "km",
                 eta_tm ? eta_tm->tm_hour : 0 ,
                 eta_tm ? eta_tm->tm_min : 0);
@@ -161,10 +161,10 @@ statusbar_route_update(struct statusbar_priv *this, struct navit *navit, struct 
         sprintf(this->gps_text,"GPS:%s %02d/%02d HD:%02.2f %s %4.0f%s %3.0f°%-2s %3.1f%s", 
                 status_fix2str(status),
                 sats, qual, hdop, buffer,
-                imperial ? height * METERS_TO_FEET : height,
+                imperial ? height * FEET_PER_METER : height,
                 imperial == TRUE ? "\'" : "m",
                 direction, dir,
-                imperial == TRUE ? speed * (METERS_TO_MILES * 1000) : speed, /* hard-coded. Ugly */
+                imperial == TRUE ? speed / (METERS_PER_MILE / 1000) : speed, /* hard-coded. Ugly */
                 imperial == TRUE ? " mph" : "km/h"
             );
 


### PR DESCRIPTION
	modified:   navit/gui/gtk/gui_gtk_statusbar.c

The status bar under GTK was only showing metric units. So I coded up a fix.

I tested as follows:

* Initialized the local variable imperial to true. Had imperial set to one in my navit.xml. Got imperial measures, as expected.

* Changed the local variable initialization to false. Recompiled and ran. Got imperial, as expected. This indicates that the function collected it as expected.

* Changed the attribute in navit.xml to 0. Ran again. Got metric units as expected.
