### PR TITLE
fix:doc:ensure that the custom domain is set for doxygen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             git config user.email "circleci@navit-project.org"
             rsync -vrtza --exclude '.git' --delete /root/project/doc/html/ /root/navit-doc/
             echo "" > .nojekyll
+            echo "doxygen.navit-project.org" > CNAME
             git add .
             git commit -am "update:doc:Doxygen update for commit ${CIRCLE_SHA1} [ci skip]" || true
             git push


### PR DESCRIPTION
Needed to get doxygen.navit-project.org to point to the Github-hosted content.