### PR TITLE
change:android:always build apk release

### DIFF
--- a/ci/build_android.sh
+++ b/ci/build_android.sh
@@ -30,12 +30,5 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../Toolchain/arm-eabi.cmake -DCACHE_SIZE='(20*1024*
 
 make -j $(nproc --all)
 
-if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-  make -j $(nproc --all) apkg-release && mv navit/android/bin/Navit-release-unsigned.apk navit/android/bin/navit-$CIRCLE_SHA1-${ARCH}-release-unsigned.apk || exit 1
-else
-  make -j $(nproc --all) apkg && mv navit/android/bin/Navit-debug.apk navit/android/bin/navit-$CIRCLE_SHA1-${ARCH}-debug.apk || exit 1
-fi
-
-echo
-echo "Build leftovers :"
-find .
+make -j $(nproc --all) apkg-release && mv navit/android/bin/Navit-release-unsigned.apk navit/android/bin/navit-$CIRCLE_SHA1-${ARCH}-release-unsigned.apk || exit 1
+make -j $(nproc --all) apkg && mv navit/android/bin/Navit-debug.apk navit/android/bin/navit-$CIRCLE_SHA1-${ARCH}-debug.apk || exit 1


### PR DESCRIPTION
With CI v1 we were building release apk in `master` and debug apk everywhere else (including `trunk`).
With CI v2 we currently don't push from trunk to master automatically, thus our play store releases are lagging behind. 