### PR TITLE
fix:cmake:Rework of xslt convert process

### DIFF
--- a/navit/CMakeLists.txt
+++ b/navit/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories( "${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories( "${CMAKE_CURRENT_BINARY_DIR}")
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/support")
 
-# navit cre
+# navit core
 set(NAVIT_SRC announcement.c atom.c attr.c cache.c callback.c command.c config_.c coord.c country.c data_window.c debug.c
    event.c file.c geom.c graphics.c gui.c item.c layout.c log.c main.c map.c maps.c
    linguistics.c mapset.c maptype.c menu.c messages.c bookmarks.c navit.c navit_nls.c navigation.c osd.c param.c phrase.c plugin.c popup.c
@@ -12,7 +12,7 @@ set(NAVIT_SRC announcement.c atom.c attr.c cache.c callback.c command.c config_.
    search_houseno_interpol.c util.c vehicle.c vehicleprofile.c xmlconfig.c )
 
 if(NOT USE_PLUGINS)
-  list(APPEND NAVIT_SRC  ${CMAKE_CURRENT_BINARY_DIR}/builtin.c)
+   list(APPEND NAVIT_SRC  ${CMAKE_CURRENT_BINARY_DIR}/builtin.c)
 endif(NOT USE_PLUGINS)
 
 if (${HAVE_GLIB})
@@ -82,7 +82,7 @@ if(NOT ANDROID)
    add_executable(navit ${NAVIT_START_SRC})
    target_link_libraries (navit ${NAVIT_LIBNAME})
    if(DEFINED NAVIT_BINARY)
-	   set_target_properties(navit PROPERTIES OUTPUT_NAME ${NAVIT_BINARY})
+      set_target_properties(navit PROPERTIES OUTPUT_NAME ${NAVIT_BINARY})
    endif(DEFINED NAVIT_BINARY)
    if (BUILD_BUNDLE)
       add_custom_command(OUTPUT resources/share COMMAND mkdir -p resources/share)
@@ -96,12 +96,12 @@ if(NOT ANDROID)
 endif()
 
 if (SHARED_LIBNAVIT)
-  add_library (${NAVIT_LIBNAME} SHARED ${NAVIT_SRC} )
+   add_library (${NAVIT_LIBNAME} SHARED ${NAVIT_SRC} )
 else(SHARED_LIBNAVIT)
-  add_library (${NAVIT_LIBNAME} STATIC ${NAVIT_SRC} )
+   add_library (${NAVIT_LIBNAME} STATIC ${NAVIT_SRC} )
 endif(SHARED_LIBNAVIT)
 if(NOT MSVC)
-    SET(NAVIT_LIBS ${NAVIT_LIBS} m)
+   SET(NAVIT_LIBS ${NAVIT_LIBS} m)
 endif(NOT MSVC)
 target_link_libraries(${NAVIT_LIBNAME}  ${MODULES_NAME} ${NAVIT_SUPPORT_LIBS} fib ${NAVIT_LIBS} ) 
 set_target_properties(${NAVIT_LIBNAME} PROPERTIES COMPILE_DEFINITIONS "MODULE=navit;LIBDIR=\"${CMAKE_INSTALL_PREFIX}/${LIB_DIR}\";PREFIX=\"${CMAKE_INSTALL_PREFIX}\"")
@@ -113,50 +113,59 @@ ADD_CUSTOM_TARGET(
    git_version
    ${CMAKE_COMMAND} -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
                     -D DST=${CMAKE_CURRENT_BINARY_DIR}/version.h
-		    -D NAME="GIT_VERSION"
+                    -D NAME="GIT_VERSION"
                     -P ${PROJECT_SOURCE_DIR}/cmake/version.cmake
+)
+
+add_custom_command(
+   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/navit.dtd"
+   COMMENT "Copy navit.dtd to ${CMAKE_CURRENT_BINARY_DIR}/navit.dtd"
+   COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/navit/navit.dtd" "${CMAKE_CURRENT_BINARY_DIR}/navit.dtd"
 )
 
 # additional parameter are passed to the stylesheet processor as parameter
 macro(process_xslt SRC_XML DEST_XML)
-   set(XSLT_COMMANDS COMMAND ${CMAKE_COMMAND} -E copy ${SRC_XML} ${DEST_XML}
-                     COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/navit/navit.dtd ${CMAKE_CURRENT_BINARY_DIR}/navit.dtd)
-   if(XSL_PROCESSING AND XSLTS)
-       string(REPLACE "," ";" XSLTS "${XSLTS}")
-       foreach(tmp ${XSLTS})
-          set(XSLT_FILE "${PROJECT_SOURCE_DIR}/navit/xslt/${tmp}.xslt")
-          list(APPEND XSLT_FILES "${XSLT_FILE}")
-          list(APPEND XSLT_COMMANDS COMMAND ${CMAKE_COMMAND} -E echo  Applying ${tmp}.xslt)
-          compose_xslt_transform_command(CMD "${XSLT_FILE}" "${DEST_XML}" "${DEST_XML}.tmp" "${ARGN}")
-          list(APPEND XSLT_COMMANDS ${CMD})
-          list(APPEND XSLT_COMMANDS COMMAND ${CMAKE_COMMAND} -E rename ${DEST_XML}.tmp ${DEST_XML})
-       endforeach()
-   endif()
+   set(XSLT_COMMANDS COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/navit/navit_shipped.xml" "${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML}" )
+   if(XSL_PROCESSING)
+      if(NOT XSLTS STREQUAL "")
+         string(REPLACE "," ";" XSLTS "${XSLTS}")
+         foreach(tmp ${XSLTS})
+            set(XSLT_FILE "${PROJECT_SOURCE_DIR}/navit/xslt/${tmp}.xslt")
+            list(APPEND XSLT_FILES "${XSLT_FILE}")
+            list(APPEND XSLT_COMMANDS COMMAND ${CMAKE_COMMAND} -E echo  Applying ${tmp}.xslt)
+            compose_xslt_transform_command(CMD "${XSLT_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML}" "${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML}.tmp" "${ARGN}")
+            list(APPEND XSLT_COMMANDS ${CMD})
+            list(APPEND XSLT_COMMANDS COMMAND ${CMAKE_COMMAND} -E rename "${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML}.tmp" ${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML})
+         endforeach()
+      endif()
+   endif(XSL_PROCESSING)
    # Depend on all XSLT files, because the main XSLT file may pull in other files.
    # Ideally we'd parse the main XSLT file for includes, but that is tricky to do reliably.
    # Note that this list of files is only updated when (re)running CMake, so if files are
    # added/deleted, CMake must be re-run manually.
    file(GLOB ALL_XSLT_FILES "${PROJECT_SOURCE_DIR}/navit/xslt/*.xslt")
+   #message(FATAL_ERROR ${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML})
    ADD_CUSTOM_COMMAND(
-      OUTPUT ${DEST_XML}
-      DEPENDS ${SRC_XML} ${ALL_XSLT_FILES}
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${DEST_XML}
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/navit/xslt/
+      DEPENDS ${SRC_XML} "${CMAKE_CURRENT_BINARY_DIR}/navit.dtd" ${ALL_XSLT_FILES}
       ${XSLT_COMMANDS}
    )
 endmacro()
 
 if(ANDROID)
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navitxxxhdpi.xml OSD_SIZE=5.33 ICON_SMALL=128 ICON_MEDIUM=192 ICON_BIG=256)
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navitxxhdpi.xml OSD_SIZE=4 ICON_SMALL=96 ICON_MEDIUM=128 ICON_BIG=192)
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navitxhdpi.xml OSD_SIZE=2.67 ICON_SMALL=64 ICON_MEDIUM=96 ICON_BIG=128)
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navithdpi.xml OSD_SIZE=2 ICON_SMALL=48 ICON_MEDIUM=64 ICON_BIG=96)
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navitmdpi.xml OSD_SIZE=1.33 ICON_SMALL=32 ICON_MEDIUM=48 ICON_BIG=64)
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navitldpi.xml OSD_SIZE=1 ICON_SMALL=24 ICON_MEDIUM=32 ICON_BIG=48)
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navitxxxhdpi.xml OSD_SIZE=5.33 ICON_SMALL=128 ICON_MEDIUM=192 ICON_BIG=256)
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navitxxhdpi.xml OSD_SIZE=4 ICON_SMALL=96 ICON_MEDIUM=128 ICON_BIG=192)
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navitxhdpi.xml OSD_SIZE=2.67 ICON_SMALL=64 ICON_MEDIUM=96 ICON_BIG=128)
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navithdpi.xml OSD_SIZE=2 ICON_SMALL=48 ICON_MEDIUM=64 ICON_BIG=96)
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navitmdpi.xml OSD_SIZE=1.33 ICON_SMALL=32 ICON_MEDIUM=48 ICON_BIG=64)
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navitldpi.xml OSD_SIZE=1 ICON_SMALL=24 ICON_MEDIUM=32 ICON_BIG=48)
    add_custom_target( navit_config_xml ALL DEPENDS navitxxxhdpi.xml navitxxhdpi.xml navitxhdpi.xml navithdpi.xml navitmdpi.xml navitldpi.xml)
 else()
-   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml ${CMAKE_CURRENT_BINARY_DIR}/navit.xml "")
+   process_xslt(${CMAKE_CURRENT_SOURCE_DIR}/navit_shipped.xml navit.xml "")
    add_custom_target( navit_config_xml_resource DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/navit.xml COMMAND mkdir -p resources/share/navit COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/navit.xml resources/share/navit)
    add_custom_target( locale_resource DEPENDS locales COMMAND mkdir -p resources/share COMMAND cp -a ${CMAKE_CURRENT_BINARY_DIR}/../locale resources/share/locale)
-   add_custom_target( navit_config_xml ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/navit.xml)
+   add_custom_target( navit_config_xml ALL DEPENDS navit.xml)
 endif()
 
 ADD_DEPENDENCIES(${NAVIT_LIBNAME} git_version)
@@ -182,17 +191,17 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/navit.xml
 
 get_directory_property(INCLUDE_DIRECTORIES INCLUDE_DIRECTORIES)
 WRITE_FILE("cmake_plugin_settings.txt"
-	"set(APPLE ${APPLE} CACHE BOOL init)\n" 
-	"set(ANDROID ${ANDROID} CACHE BOOL init)\n"
-	"set(USE_PLUGINS ${USE_PLUGINS} CACHE BOOL init)\n"
-	"set(MODULE_BUILD_TYPE \"${MODULE_BUILD_TYPE}\" CACHE STRING init)\n"
-	"set(NAVIT_COMPILE_FLAGS \"${NAVIT_COMPILE_FLAGS}\" CACHE STRING init)\n"
-	"set(navit_SOURCE_DIR \"${navit_SOURCE_DIR}\" CACHE STRING init)\n"
-	"set(NAVIT_LIBNAME \"${NAVIT_LIBNAME}\" CACHE STRING init)\n"
-	"set(ANDROID_API_VERSION \"${ANDROID_API_VERSION}\" CACHE STRING init)\n"
-	"set(ANDROID_NDK_API_VERSION \"${ANDROID_NDK_API_VERSION}\" CACHE STRING init)\n"
-	"set(CMAKE_TOOLCHAIN_FILE \"${CMAKE_TOOLCHAIN_FILE}\" CACHE STRING init)\n"
-	"set(INCLUDE_DIRECTORIES \"${INCLUDE_DIRECTORIES}\" CACHE STRING init)\n"
-	"set(LIB_DIR \"${LIB_DIR}\" CACHE STRING init)\n"
-	"set(CMAKE_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\" CACHE STRING init)\n"
-	)
+   "set(APPLE ${APPLE} CACHE BOOL init)\n" 
+   "set(ANDROID ${ANDROID} CACHE BOOL init)\n"
+   "set(USE_PLUGINS ${USE_PLUGINS} CACHE BOOL init)\n"
+   "set(MODULE_BUILD_TYPE \"${MODULE_BUILD_TYPE}\" CACHE STRING init)\n"
+   "set(NAVIT_COMPILE_FLAGS \"${NAVIT_COMPILE_FLAGS}\" CACHE STRING init)\n"
+   "set(navit_SOURCE_DIR \"${navit_SOURCE_DIR}\" CACHE STRING init)\n"
+   "set(NAVIT_LIBNAME \"${NAVIT_LIBNAME}\" CACHE STRING init)\n"
+   "set(ANDROID_API_VERSION \"${ANDROID_API_VERSION}\" CACHE STRING init)\n"
+   "set(ANDROID_NDK_API_VERSION \"${ANDROID_NDK_API_VERSION}\" CACHE STRING init)\n"
+   "set(CMAKE_TOOLCHAIN_FILE \"${CMAKE_TOOLCHAIN_FILE}\" CACHE STRING init)\n"
+   "set(INCLUDE_DIRECTORIES \"${INCLUDE_DIRECTORIES}\" CACHE STRING init)\n"
+   "set(LIB_DIR \"${LIB_DIR}\" CACHE STRING init)\n"
+   "set(CMAKE_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\" CACHE STRING init)\n"
+)


### PR DESCRIPTION
This PR fixes the issue that navit.dtd could not been copyed on android build which caused the build to fail sometimes.
Also i reworked this file to use 3 spaces anywhere