### PR TITLE
Sailfish build on newer SDKs

### DIFF
--- a/contrib/sailfish/build_on_sailfish_sdk.sh
+++ b/contrib/sailfish/build_on_sailfish_sdk.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-#run on the Sailfish OS sdk virtual machine. Check that rpmbuild directory exists.
+#run on the Sailfish OS sdk virtual machine. Check that rpmbuild directory exists. Remember to export VERSION_ID
 #arm devices
 sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 #intel devices

--- a/contrib/sailfish/build_on_sailfish_sdk.sh
+++ b/contrib/sailfish/build_on_sailfish_sdk.sh
@@ -1,5 +1,8 @@
 #! /bin/sh
 #run on the Sailfish OS sdk virtual machine. Check that rpmbuild directory exists. Remember to export VERSION_ID
+
+if [ -z ${VERSION_ID+x} ]; then echo "VERSION_ID not set. Forgot to export VERSION_ID?"; exit 1; fi
+
 #arm devices
 sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 #intel devices

--- a/contrib/sailfish/build_on_sailfish_sdk.sh
+++ b/contrib/sailfish/build_on_sailfish_sdk.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 #run on the Sailfish OS sdk virtual machine. Check that rpmbuild directory exists.
 #arm devices
-sb2 -t SailfishOS-armv7hl -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
+sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 #intel devices
-sb2 -t SailfishOS-i486 -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
+sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 

--- a/contrib/sailfish/navit-sailfish.spec
+++ b/contrib/sailfish/navit-sailfish.spec
@@ -15,6 +15,8 @@ License: GPL
 Group: Applications/Productivity
 URL: http://navit-projet.org/
 
+#git is vor version info while building
+BuildRequires: git
 BuildRequires: gcc
 BuildRequires: cmake
 BuildRequires: glib2-devel


### PR DESCRIPTION
This pull request enables Navit to be built on newer Sailfish SDKs which uses different tool paths than before. Beside that is adds now mandatory build requirement "git".