### PR TITLE
fix:gtk:Initialize Follow menu entry correctly.

### DIFF
--- a/navit/gui/gtk/gui_gtk_action.c
+++ b/navit/gui/gtk/gui_gtk_action.c
@@ -605,6 +605,10 @@ gui_gtk_ui_init(struct gui_priv *this)
 		toggle_action = GTK_TOGGLE_ACTION(gtk_action_group_get_action(this->base_group, "CursorAction"));
 		gtk_toggle_action_set_active(toggle_action, attr.u.num);
 	}
+	if (navit_get_attr(this->nav, attr_follow_cursor, &attr, NULL)) {
+		toggle_action = GTK_TOGGLE_ACTION(gtk_action_group_get_action(this->base_group, "FollowVehicleAction"));
+		gtk_toggle_action_set_active(toggle_action, attr.u.num);
+	}
 	if (navit_get_attr(this->nav, attr_orientation, &attr, NULL)) {
 		toggle_action = GTK_TOGGLE_ACTION(gtk_action_group_get_action(this->base_group, "OrientationAction"));
 		gtk_toggle_action_set_active(toggle_action, attr.u.num != -1);


### PR DESCRIPTION
This should fix http://trac.navit-project.org/ticket/1357 I tested for
follow_vehicle set to zero and one, and absent.

	modified:   navit/gui/gtk/gui_gtk_action.c