### PR TITLE
fix:fix download center for wince

### DIFF
--- a/ci/update_download_center.sh
+++ b/ci/update_download_center.sh
@@ -59,7 +59,7 @@ echo "Init Git Repo"
 export GIT_TERMINAL_PROMPT=0 
 cd $TMP_DIR
 mkdir -p ~/.ssh/
-ssh-keyscan github.com >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 git clone $NAVIT_DOWNLOAD_CENTER_REPO $UUID
 if [ ! -d $UUID/_data/$JOB_NAME ]; then
     mkdir -p $UUID/_data/$JOB_NAME


### PR DESCRIPTION
Repo download on the wince docker image was broken due to really old ssh lib and git client