### PR TITLE
fix:XML: Adding missing sea/ocean display in T@H layout theme

### DIFF
--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -6802,6 +6802,9 @@ Waypoint</text></img>
 					<polyline color="#b5d6f1"/>
 					<text text_size="8"/>
 				</itemgra>
+				<itemgra item_types="poly_water_tiled">
+					<polygon color="#b5d6f1"/>
+				</itemgra>
 				<!-- leisure=park -->
 				<itemgra item_types="poly_park" order="0-">
 					<polygon color="#c7f1a3"/>


### PR DESCRIPTION
On the T@H layout theme, oceans and seas are not displayed:
![screenshot_2018-03-17-05-23-09](https://user-images.githubusercontent.com/383502/37555967-fde679b2-29ef-11e8-8c56-dd5371c0bb75.png)

This patch fixes this:
![screenshot_2018-03-17-05-32-52](https://user-images.githubusercontent.com/383502/37555968-07992e6e-29f0-11e8-93a8-8165c54469cf.png)
