### PR TITLE
fix:ci:Fix Wince download center upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Prepare the WinCE build environment
+          command: |
+            bash ci/setup_wince.sh
+      - run:
           name: Build for Windows CE
           command: bash ci/build_wince.sh
       - store_artifacts:

--- a/ci/setup_wince.sh
+++ b/ci/setup_wince.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+set -e
+
+mkdir -p /var/lib/apt/lists/partial
+apt-get update
+apt-get install -y git-core


### PR DESCRIPTION
Because the image is to old we need to install git-core after the code checkout.

With this the WinCE build is fixed **and** able to push to the download center