### PR TITLE
doc: fix misspell

### DIFF
--- a/man/navit.1
+++ b/man/navit.1
@@ -23,7 +23,7 @@ destination, but also generates directions and even speaks to you.
 
 Navit is translated in more than 40 languages currently, please see https://translations.launchpad.net/navit/trunk
 
-For more informations, please refer to our wiki :
+For more information, please refer to our wiki :
  http://wiki.navit-project.org
 
 You can also try our mailing lists :


### PR DESCRIPTION
Fixing a minor typo in the man page for navit:
information is a non-count noun, so the convention is that information is both singular and plural