### PR TITLE
maptool: migrate malloc/free/realloc to g_malloc/g_free/g_realloc

### DIFF
--- a/navit/maptool/buffer.c
+++ b/navit/maptool/buffer.c
@@ -60,8 +60,7 @@ load_buffer(char *filename, struct buffer *b, long long offset, long long size)
 	long long len;
 	dbg_assert(size>=0);
 	dbg_assert(offset>=0);
-	if (b->base)
-		free(b->base);
+	g_free(b->base);
 	b->malloced=0;
 	f=fopen(filename,"rb");
 	fseeko(f, 0, SEEK_END);

--- a/navit/maptool/buffer.c
+++ b/navit/maptool/buffer.c
@@ -74,8 +74,7 @@ load_buffer(char *filename, struct buffer *b, long long offset, long long size)
 	dbg_assert(b->size>0);
 	
 	fseeko(f, offset, SEEK_SET);
-	b->base=malloc(b->size);
-	dbg_assert(b->base != NULL);
+	b->base=g_malloc(b->size);
 	if (fread(b->base, b->size, 1, f) == 0){
 		dbg(lvl_warning, "fread failed");
 		return 0;

--- a/navit/maptool/ch.c
+++ b/navit/maptool/ch.c
@@ -529,7 +529,7 @@ ch_assemble_map(char *map_suffix, char *suffix, struct zip_info *zip_info)
 	}
 	th=tile_head_root;
         while (th) {
-		th->zip_data=malloc(th->total_size);
+		th->zip_data=g_malloc(th->total_size);
 		th->total_size_used=0;
                 th=th->next;
         }

--- a/navit/maptool/google/protobuf-c/protobuf-c.c
+++ b/navit/maptool/google/protobuf-c/protobuf-c.c
@@ -106,7 +106,7 @@ static void *system_alloc(void *allocator_data, size_t size)
   (void) allocator_data;
   if (size == 0)
     return NULL;
-  rv = malloc (size);
+  rv = g_malloc (size);
   if (rv == NULL)
     protobuf_c_out_of_memory ();
   return rv;
@@ -114,9 +114,8 @@ static void *system_alloc(void *allocator_data, size_t size)
 
 static void system_free (void *allocator_data, void *data)
 {
-  (void) allocator_data;
-  if (data)
-    free (data);
+	(void) allocator_data;
+	g_free (data);
 }
 
 /* Some users may configure the default allocator;

--- a/navit/maptool/maptool.c
+++ b/navit/maptool/maptool.c
@@ -1014,7 +1014,7 @@ int main(int argc, char **argv)
 				osm_resolve_coords_and_split_at_intersections(&p, suffix);
 			}
 		}
-		free(node_buffer.base);
+		g_free(node_buffer.base);
 		node_buffer.base=NULL;
 		node_buffer.malloced=0;
 		node_buffer.size=0;

--- a/navit/maptool/misc.c
+++ b/navit/maptool/misc.c
@@ -364,7 +364,7 @@ process_slice(FILE **in, FILE **reference, int in_count, int with_range, long lo
 			dbg_assert(fwrite(th->zip_data, th->total_size, 1, zip_get_index(zip_info))==1);
 		}
 	}
-	free(slice_data);
+	g_free(slice_data);
 
 	return zipfiles;
 }

--- a/navit/maptool/misc.c
+++ b/navit/maptool/misc.c
@@ -326,8 +326,7 @@ process_slice(FILE **in, FILE **reference, int in_count, int with_range, long lo
 	struct tile_info info;
 	int i;
 
-	slice_data=malloc(size);
-	assert(slice_data != NULL);
+	slice_data=g_malloc(size);
 	zip_data=slice_data;
 	th=tile_head_root;
 	while (th) {

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1359,12 +1359,7 @@ static void
 extend_buffer(struct buffer *b)
 {
 	b->malloced+=b->malloced_step;
-	b->base=realloc(b->base, b->malloced);
-	if (b->base == NULL) {
-		fprintf(stderr,"realloc of %d bytes failed\n",(int)b->malloced);
-		exit(1);
-	}
-
+	b->base=g_realloc(b->base, b->malloced);
 }
 
 /** The node currently being processed. */

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -2240,7 +2240,7 @@ osm_process_towns(FILE *in, FILE *boundaries, FILE *ways, char *suffix)
 		if (!item_is_district(*ib))
 		{
 			char *townname=item_bin_get_attr(ib, attr_town_name, NULL);
-			char *dup=strdup(townname);
+			char *dup=g_strdup(townname);
 			g_hash_table_replace(town_hash, dup, dup);
 		}
 	}

--- a/navit/maptool/osm_protobuf.c
+++ b/navit/maptool/osm_protobuf.c
@@ -91,12 +91,12 @@ uncompress_blob(OSMPBF__Blob *blob)
 	strm.next_out=ret;
 	zerr = inflateInit(&strm);
 	if (zerr != Z_OK) {
-		free(ret);
+		g_free(ret);
 		return NULL;
 	}
 	zerr = inflate(&strm, Z_NO_FLUSH);
 	if (zerr != Z_STREAM_END) {
-		free(ret);
+		g_free(ret);
 		return NULL;
 	}
 	inflateEnd(&strm);
@@ -370,14 +370,14 @@ map_collect_data_osm_protobuf(FILE *in, struct maptool_osm *osm)
 			process_osmdata(blob, data, osm);
 		} else {
 			printf("skipping fileblock of unknown type '%s'\n", header->type);
-			free(buffer);
+			g_free(buffer);
 			return 0;
 		}
-		free(data);
+		g_free(data);
 		osmpbf__blob__free_unpacked(blob, &protobuf_c_system_allocator);
 		osmpbf__blob_header__free_unpacked(header, &protobuf_c_system_allocator);
 	}
-	free(buffer);
+	g_free(buffer);
 #if 0
 	printf("</osm>\n");
 #endif

--- a/navit/maptool/osm_protobuf.c
+++ b/navit/maptool/osm_protobuf.c
@@ -76,7 +76,7 @@ read_blob(OSMPBF__BlobHeader *header, FILE *f, unsigned char *buffer)
 static unsigned char *
 uncompress_blob(OSMPBF__Blob *blob)
 {
-	unsigned char *ret=malloc(blob->raw_size);
+	unsigned char *ret=g_malloc(blob->raw_size);
 	int zerr;
 	z_stream strm;
 
@@ -355,7 +355,7 @@ map_collect_data_osm_protobuf(FILE *in, struct maptool_osm *osm)
 	OSMPBF__BlobHeader *header;
 	OSMPBF__Blob *blob;
 	unsigned char *data;
-	unsigned char *buffer=malloc(MAX_BLOB_LENGTH);
+	unsigned char *buffer=g_malloc(MAX_BLOB_LENGTH);
 
 #if 0
 	printf("<?xml version='1.0' encoding='UTF-8'?>\n");

--- a/navit/maptool/osm_protobufdb.c
+++ b/navit/maptool/osm_protobufdb.c
@@ -420,7 +420,7 @@ osm_protobufdb_string(struct osm_protobufdb_context *ctx, char *str)
 	if (!st->n_s) {
 		st->n_s++;
 	}
-	strd=strdup(str);
+	strd=g_strdup(str);
 	st->s=g_realloc(st->s, sizeof(st->s[0])*(st->n_s+1));
 	if (st->n_s == 1) {
 		st->s[0].data=NULL;

--- a/navit/maptool/osm_protobufdb.c
+++ b/navit/maptool/osm_protobufdb.c
@@ -122,11 +122,11 @@ osm_protobufdb_finish_block(struct osm_protobufdb_context *ctx)
 		osm_protobufdb_write_blob(&empty_blob, ctx->f);	
 		ctx->current_block++;
 	}
-	blob=malloc(sizeof(*blob));
+	blob=g_malloc(sizeof(*blob));
 	*blob=empty_blob;
 	blob->has_raw=1;
 	blob->has_raw_size=1;
-	blob->raw.data=malloc(len);
+	blob->raw.data=g_malloc(len);
 	osmpbf__primitive_block__pack(ctx->pb, blob->raw.data);
 	blob->raw.len=len;
 	blob->raw_size=len;
@@ -147,9 +147,9 @@ osm_protobufdb_start_block(struct osm_protobufdb_context *ctx, int blocknum)
 		return 0;
 	osm_protobufdb_finish_block(ctx);
 	ctx->active_block=blocknum;
-	ctx->pb=malloc(sizeof(*ctx->pb));
+	ctx->pb=g_malloc(sizeof(*ctx->pb));
 	*ctx->pb=pb;
-	ctx->pb->stringtable=malloc(sizeof(*ctx->pb->stringtable));
+	ctx->pb->stringtable=g_malloc(sizeof(*ctx->pb->stringtable));
 	*ctx->pb->stringtable=st;
 	ctx->st=ctx->pb->stringtable;
 	return 1;
@@ -162,7 +162,7 @@ osm_protobufdb_start_group(struct osm_protobufdb_context *ctx, int groupnum)
 	if (ctx->pb->n_primitivegroup <= groupnum) {
 		ctx->pb->primitivegroup=realloc(ctx->pb->primitivegroup, (groupnum+1)*sizeof(ctx->pb->primitivegroup[0]));
 		while (ctx->pb->n_primitivegroup <= groupnum) {
-			ctx->pb->primitivegroup[ctx->pb->n_primitivegroup]=malloc(sizeof(*context.pg));
+			ctx->pb->primitivegroup[ctx->pb->n_primitivegroup]=g_malloc(sizeof(*context.pg));
 			*ctx->pb->primitivegroup[ctx->pb->n_primitivegroup++]=pg;
 		}
 		g_hash_table_destroy(ctx->string_hash);
@@ -170,7 +170,7 @@ osm_protobufdb_start_group(struct osm_protobufdb_context *ctx, int groupnum)
 	}
 	ctx->pg=ctx->pb->primitivegroup[groupnum];
 	if (!ctx->pg) {
-		ctx->pg=malloc(sizeof(*context.pg));
+		ctx->pg=g_malloc(sizeof(*context.pg));
 		*ctx->pg=pg;
 		ctx->pb->primitivegroup[groupnum]=ctx->pg;
 	}
@@ -185,13 +185,13 @@ osm_protobufdb_start_densenode(struct osm_protobufdb_context *ctx)
 	OSMPBF__DenseNodes dn=OSMPBF__DENSE_NODES__INIT;
 
 	if (!ctx->pg->dense) {
-		ctx->dn=malloc(sizeof(*context.dn));
+		ctx->dn=g_malloc(sizeof(*context.dn));
 		*ctx->dn=dn;
 		ctx->pg->dense=ctx->dn;
 	} else
 		ctx->dn=ctx->pg->dense;
 	if (!ctx->dn->denseinfo) {
-		ctx->di=malloc(sizeof(*context.di));
+		ctx->di=g_malloc(sizeof(*context.di));
 		*ctx->di=di;
 		ctx->dn->denseinfo=ctx->di;
 	} else
@@ -287,7 +287,7 @@ osm_protobufdb_insert_node(long long id, OSMPBF__PrimitiveGroup *pg)
 	l=pg->n_nodes;
 	p=l;
 	insert(pg, nodes, p);
-	pg->nodes[p]=malloc(sizeof(*pg->nodes[0]));
+	pg->nodes[p]=g_malloc(sizeof(*pg->nodes[0]));
 	*pg->nodes[p]=node;
 	return p;
 }
@@ -312,7 +312,7 @@ osm_protobufdb_modify_node(OSMPBF__Node *node, OSMPBF__Info *info, int pos, OSMP
 		if (old_info)
 			n->info=old_info;
 		else
-			n->info=malloc(sizeof(*info));
+			n->info=g_malloc(sizeof(*info));
 		*n->info=*info;
 	}
 	
@@ -326,7 +326,7 @@ osm_protobufdb_insert_way(long long id, OSMPBF__PrimitiveGroup *pg)
 	l=pg->n_ways;
 	p=l;
 	insert(pg, ways, p);
-	pg->ways[p]=malloc(sizeof(*pg->ways[0]));
+	pg->ways[p]=g_malloc(sizeof(*pg->ways[0]));
 	*pg->ways[p]=way;
 	return p;
 }
@@ -359,7 +359,7 @@ osm_protobufdb_modify_way(OSMPBF__Way *way, OSMPBF__Info *info, int pos, OSMPBF_
 		if (old_info)
 			w->info=old_info;
 		else
-			w->info=malloc(sizeof(*info));
+			w->info=g_malloc(sizeof(*info));
 		*w->info=*info;
 	}
 	
@@ -373,7 +373,7 @@ osm_protobufdb_insert_relation(long long id, OSMPBF__PrimitiveGroup *pg)
 	l=pg->n_relations;
 	p=l;
 	insert(pg, relations, p);
-	pg->relations[p]=malloc(sizeof(*pg->relations[0]));
+	pg->relations[p]=g_malloc(sizeof(*pg->relations[0]));
 	*pg->relations[p]=relation;
 	return p;
 }
@@ -410,7 +410,7 @@ osm_protobufdb_modify_relation(OSMPBF__Relation *relation, OSMPBF__Info *info, i
 		if (old_info)
 			r->info=old_info;
 		else
-			r->info=malloc(sizeof(*info));
+			r->info=g_malloc(sizeof(*info));
 		*r->info=*info;
 	}
 	
@@ -495,9 +495,9 @@ test(void)
 	context.current_file=-1;
 
 #if 0
-	context.di=malloc(sizeof(*context.di));
+	context.di=g_malloc(sizeof(*context.di));
 	*context.di=di;
-	context.dn=malloc(sizeof(*context.dn));
+	context.dn=g_malloc(sizeof(*context.dn));
 	*context.dn=dn;
 #endif
 

--- a/navit/maptool/osm_protobufdb.c
+++ b/navit/maptool/osm_protobufdb.c
@@ -160,7 +160,7 @@ osm_protobufdb_start_group(struct osm_protobufdb_context *ctx, int groupnum)
 {
 	OSMPBF__PrimitiveGroup pg=OSMPBF__PRIMITIVE_GROUP__INIT;
 	if (ctx->pb->n_primitivegroup <= groupnum) {
-		ctx->pb->primitivegroup=realloc(ctx->pb->primitivegroup, (groupnum+1)*sizeof(ctx->pb->primitivegroup[0]));
+		ctx->pb->primitivegroup=g_realloc(ctx->pb->primitivegroup, (groupnum+1)*sizeof(ctx->pb->primitivegroup[0]));
 		while (ctx->pb->n_primitivegroup <= groupnum) {
 			ctx->pb->primitivegroup[ctx->pb->n_primitivegroup]=g_malloc(sizeof(*context.pg));
 			*ctx->pb->primitivegroup[ctx->pb->n_primitivegroup++]=pg;
@@ -202,7 +202,7 @@ osm_protobufdb_start_densenode(struct osm_protobufdb_context *ctx)
 static void
 osm_protobufdb_write_primitive_group(OSMPBF__PrimitiveGroup *pg, OSMPBF__PrimitiveBlock *pb)
 {
-	pb->primitivegroup=realloc(pb->primitivegroup,(pb->n_primitivegroup+1)*sizeof(OSMPBF__PrimitiveGroup *));
+	pb->primitivegroup=g_realloc(pb->primitivegroup,(pb->n_primitivegroup+1)*sizeof(OSMPBF__PrimitiveGroup *));
 	pb->primitivegroup[pb->n_primitivegroup++]=pg;
 }
 #endif
@@ -211,7 +211,7 @@ osm_protobufdb_write_primitive_group(OSMPBF__PrimitiveGroup *pg, OSMPBF__Primiti
 #define insert(struct, member, pos) {\
 	int n=struct->n_##member; \
 	int s=sizeof(struct->member[0]); \
-	struct->member=realloc(struct->member, (n+1)*s); \
+	struct->member=g_realloc(struct->member, (n+1)*s); \
 	memmove(&struct->member[n+1], &struct->member[n], (pos-n)*s); \
 	memset(&struct->member[n], 0, s); \
 	struct->n_##member++;\
@@ -265,7 +265,7 @@ osm_protobufdb_modify_densenode(OSMPBF__Node *node, OSMPBF__Info *info, OSMPBF__
 	dn->id[pos]=node->id-offset->id;
 	dn->lat[pos]=node->lat-offset->lat;
 	dn->lon[pos]=node->lon-offset->lon;
-	dn->keys_vals=realloc(dn->keys_vals, (dn->n_keys_vals+node->n_keys+node->n_vals+1)*sizeof(dn->keys_vals[0]));
+	dn->keys_vals=g_realloc(dn->keys_vals, (dn->n_keys_vals+node->n_keys+node->n_vals+1)*sizeof(dn->keys_vals[0]));
 	for (i = 0 ; i < node->n_keys ; i++) {
 		dn->keys_vals[dn->n_keys_vals++]=node->keys[i];
 		dn->keys_vals[dn->n_keys_vals++]=node->vals[i];
@@ -421,7 +421,7 @@ osm_protobufdb_string(struct osm_protobufdb_context *ctx, char *str)
 		st->n_s++;
 	}
 	strd=strdup(str);
-	st->s=realloc(st->s, sizeof(st->s[0])*(st->n_s+1));
+	st->s=g_realloc(st->s, sizeof(st->s[0])*(st->n_s+1));
 	if (st->n_s == 1) {
 		st->s[0].data=NULL;
 		st->s[0].len=0;
@@ -729,20 +729,20 @@ osm_protobufdb_parse_tag(struct osm_protobufdb_context *ctx, char *str)
 		return 0;
 	osm_xml_decode_entities(v_buffer);
 	if (ctx->in_node) {
-		n->keys=realloc(n->keys, (n->n_keys+1)*sizeof(n->keys[0]));
-		n->vals=realloc(n->vals, (n->n_vals+1)*sizeof(n->vals[0]));
+		n->keys=g_realloc(n->keys, (n->n_keys+1)*sizeof(n->keys[0]));
+		n->vals=g_realloc(n->vals, (n->n_vals+1)*sizeof(n->vals[0]));
 		n->keys[n->n_keys++]=osm_protobufdb_string(ctx, k_buffer);
 		n->vals[n->n_vals++]=osm_protobufdb_string(ctx, v_buffer);
 	}
 	if (ctx->in_way) {
-		w->keys=realloc(w->keys, (w->n_keys+1)*sizeof(w->keys[0]));
-		w->vals=realloc(w->vals, (w->n_vals+1)*sizeof(w->vals[0]));
+		w->keys=g_realloc(w->keys, (w->n_keys+1)*sizeof(w->keys[0]));
+		w->vals=g_realloc(w->vals, (w->n_vals+1)*sizeof(w->vals[0]));
 		w->keys[w->n_keys++]=osm_protobufdb_string(ctx, k_buffer);
 		w->vals[w->n_vals++]=osm_protobufdb_string(ctx, v_buffer);
 	}
 	if (ctx->in_relation) {
-		r->keys=realloc(r->keys, (r->n_keys+1)*sizeof(r->keys[0]));
-		r->vals=realloc(r->vals, (r->n_vals+1)*sizeof(r->vals[0]));
+		r->keys=g_realloc(r->keys, (r->n_keys+1)*sizeof(r->keys[0]));
+		r->vals=g_realloc(r->vals, (r->n_vals+1)*sizeof(r->vals[0]));
 		r->keys[r->n_keys++]=osm_protobufdb_string(ctx, k_buffer);
 		r->vals[r->n_vals++]=osm_protobufdb_string(ctx, v_buffer);
 	}
@@ -757,7 +757,7 @@ osm_protobufdb_parse_nd(struct osm_protobufdb_context *ctx, char *str)
 	if (!osm_xml_get_attribute(str, "ref", ref_buffer, BUFFER_SIZE))
 		return 0;
 	if (ctx->in_way) {
-		w->refs=realloc(w->refs, (w->n_refs+1)*sizeof(w->refs[0]));
+		w->refs=g_realloc(w->refs, (w->n_refs+1)*sizeof(w->refs[0]));
 		w->refs[w->n_refs++]=atoll(ref_buffer);
 	}
 	return 1;
@@ -784,11 +784,11 @@ osm_protobufdb_parse_member(struct osm_protobufdb_context *ctx, char *str)
 	else if (!strcmp(type_buffer,"relation"))
 		type=2;
 	if (ctx->in_relation) {
-		r->roles_sid=realloc(r->roles_sid, (r->n_roles_sid+1)*sizeof(r->roles_sid[0]));
+		r->roles_sid=g_realloc(r->roles_sid, (r->n_roles_sid+1)*sizeof(r->roles_sid[0]));
 		r->roles_sid[r->n_roles_sid++]=osm_protobufdb_string(ctx, role_buffer);
-		r->memids=realloc(r->memids, (r->n_memids+1)*sizeof(r->memids[0]));
+		r->memids=g_realloc(r->memids, (r->n_memids+1)*sizeof(r->memids[0]));
 		r->memids[r->n_memids++]=atoll(ref_buffer);
-		r->types=realloc(r->types, (r->n_types+1)*sizeof(r->types[0]));
+		r->types=g_realloc(r->types, (r->n_types+1)*sizeof(r->types[0]));
 		r->types[r->n_types++]=type;
 	}
 	return 1;

--- a/navit/maptool/osm_protobufdb.c
+++ b/navit/maptool/osm_protobufdb.c
@@ -298,10 +298,8 @@ osm_protobufdb_modify_node(OSMPBF__Node *node, OSMPBF__Info *info, int pos, OSMP
 	OSMPBF__Node *n=pg->nodes[pos];
 	OSMPBF__Info *old_info;
 
-	if (n->keys)
-		free(n->keys);
-	if (n->vals)
-		free(n->vals);
+	g_free(n->keys);
+	g_free(n->vals);
 	old_info=n->info;
 	*n=*node;
 	if (!info) {
@@ -339,12 +337,9 @@ osm_protobufdb_modify_way(OSMPBF__Way *way, OSMPBF__Info *info, int pos, OSMPBF_
 	int i;
 	long long ref=0;
 
-	if (w->keys)
-		free(w->keys);
-	if (w->vals)
-		free(w->vals);
-	if (w->refs)
-		free(w->refs);
+	g_free(w->keys);
+	g_free(w->vals);
+	g_free(w->refs);
 	old_info=w->info;
 	*w=*way;
 	for (i = 0 ; i < w->n_refs ; i++) {
@@ -386,16 +381,11 @@ osm_protobufdb_modify_relation(OSMPBF__Relation *relation, OSMPBF__Info *info, i
 	int i;
 	long long ref=0;
 
-	if (r->keys)
-		free(r->keys);
-	if (r->vals)
-		free(r->vals);
-	if (r->roles_sid)
-		free(r->roles_sid);
-	if (r->memids)
-		free(r->memids);
-	if (r->types)
-		free(r->types);
+	g_free(r->keys);
+	g_free(r->vals);
+	g_free(r->roles_sid);
+	g_free(r->memids);
+	g_free(r->types);
 	old_info=r->info;
 	*r=*relation;
 	for (i = 0 ; i < r->n_memids ; i++) {

--- a/navit/maptool/tile.c
+++ b/navit/maptool/tile.c
@@ -414,7 +414,7 @@ write_aux_tiles(struct zip_info *zip_info)
 			l=g_list_next(l);
 			zip_add_member(zip_info);
 		}
-		free(buffer);
+		g_free(buffer);
 	}
 	return count;
 }

--- a/navit/maptool/tile.c
+++ b/navit/maptool/tile.c
@@ -194,8 +194,7 @@ tile_extend(char *tile, struct item_bin *ib, GList **tiles_list)
 	if (!th)
 		th=g_hash_table_lookup(tile_hash, tile);
 	if (! th) {
-		th=malloc(sizeof(struct tile_head)+ sizeof( char* ) );
-		assert(th != NULL);
+		th=g_malloc(sizeof(struct tile_head)+ sizeof( char* ) );
 		// strcpy(th->subtiles, tile);
 		th->num_subtiles=1;
 		th->total_size=0;
@@ -401,8 +400,7 @@ write_aux_tiles(struct zip_info *zip_info)
 	
 	while (l) {
 		at=l->data;
-		buffer=malloc(at->size);
-		assert(buffer != NULL);
+		buffer=g_malloc(at->size);
 		f=fopen(at->filename,"rb");
 		assert(f != NULL);
 
@@ -496,7 +494,7 @@ load_tilesdir(FILE *in)
 	tile_hash=g_hash_table_new(g_str_hash, g_str_equal);
 	last=&tile_head_root;
 	while (fscanf(in,"%[^:]:%d",tile,&size) == 2) {
-		struct tile_head *th=malloc(sizeof(struct tile_head));
+		struct tile_head *th=g_malloc(sizeof(struct tile_head));
 		if (!strcmp(tile,"index"))
 			tile[0]='\0';
 		th->num_subtiles=0;

--- a/navit/maptool/tile.c
+++ b/navit/maptool/tile.c
@@ -245,8 +245,7 @@ merge_tile(char *base, char *sub)
 		g_hash_table_insert(tile_hash, string_hash_lookup( thb->name ), thb);
 
 	} else {
-		thb=realloc(thb, sizeof(struct tile_head)+( ths->num_subtiles+thb->num_subtiles ) * sizeof( char*) );
-		assert(thb != NULL);
+		thb=g_realloc(thb, sizeof(struct tile_head)+( ths->num_subtiles+thb->num_subtiles ) * sizeof( char*) );
 		memcpy( th_get_subtile( thb, thb->num_subtiles ), th_get_subtile( ths, 0 ), ths->num_subtiles * sizeof( char*) );
 		thb->num_subtiles+=ths->num_subtiles;
 		thb->total_size+=ths->total_size;
@@ -510,14 +509,9 @@ load_tilesdir(FILE *in)
 #if 0
 			printf("subtile '%s'\n",subtile);
 #endif
-			struct tile_head *th_tmp=realloc(th, sizeof(struct tile_head)+(th->num_subtiles+1)*sizeof(char*));
-			if (th_tmp == NULL) {
-				printf("Memory allocation failure, unable to load subtiles\n");
-			} else {
-				th = th_tmp;
-				*th_get_subtile( th, th->num_subtiles ) = string_hash_lookup(subtile);
-				th->num_subtiles++;
-			}
+			th=g_realloc(th, sizeof(struct tile_head)+(th->num_subtiles+1)*sizeof(char*));
+			*th_get_subtile( th, th->num_subtiles ) = string_hash_lookup(subtile);
+			th->num_subtiles++;
 		}
 		*last=th;
 		last=&th->next;

--- a/navit/maptool/zip.c
+++ b/navit/maptool/zip.c
@@ -126,11 +126,7 @@ write_zipmember(struct zip_info *zip_info, char *name, int filelen, char *data, 
 	uLongf destlen=data_size+data_size/500+12;
 	char *compbuffer;
 
-	compbuffer = malloc(destlen);
-	if (!compbuffer) {
-	  fprintf(stderr, "No more memory.\n");
-	  exit (1);
-	}
+	compbuffer = g_malloc(destlen);
 	crc=crc32(0, NULL, 0);
 	crc=crc32(crc, (unsigned char *)data, data_size);
 	lfh.zipmthd=zip_info->compression_level ? 8:0;

--- a/navit/maptool/zip.c
+++ b/navit/maptool/zip.c
@@ -175,7 +175,7 @@ write_zipmember(struct zip_info *zip_info, char *name, int filelen, char *data, 
 		zip_info->dir_size+=sizeof(cd_ext);
 	}
 	
-	free(compbuffer);
+	g_free(compbuffer);
 }
 
 int


### PR DESCRIPTION
Closes: #427.
Migrating the `malloc` to `g_malloc` and removing some asserts already done by `g_malloc`.

The other operations will come later in another PR.