### PR TITLE
PR to fix Trac 1202 (Make Image and Scale osd types obey osd_configuration setting)

### DIFF
--- a/navit/osd.c
+++ b/navit/osd.c
@@ -292,7 +292,7 @@ osd_std_reconfigure(struct osd_item *item, struct command_saved *cs)
 	dbg(lvl_debug, "enter, item=%p, cs=%p\n", item, cs);
 	if (!command_saved_error(cs)) {
 		item->configured = !! command_saved_get_int(cs);
-		if (item->gr && !(item->flags & FLAG16)) 
+		if (item->gr && !(item->flags & DISABLE_OVERLAY)) 
 			graphics_overlay_disable(item->gr, !item->configured);
 	} else {
 		err = command_error_to_text(command_saved_error(cs));
@@ -305,7 +305,6 @@ void
 osd_set_std_attr(struct attr **attrs, struct osd_item *item, int flags)
 {
 	struct attr *attr;
-
 	item->flags=flags;
 	item->osd_configuration=-1;
 	item->color_fg.r = 0xffff;
@@ -316,8 +315,8 @@ osd_set_std_attr(struct attr **attrs, struct osd_item *item, int flags)
 	item->text_color.g = 0xffff;
 	item->text_color.b = 0xffff;
 	item->text_color.a = 0xffff;
-	// TODO: DEFINE & NAME FLAGS
-	if (flags & FLAG1) {
+
+	if (flags & TRANSPARENT_BG) {
 		item->color_bg.r = 0x0808;
 		item->color_bg.g = 0x0808;
 		item->color_bg.b = 0xf8f8;
@@ -405,8 +404,8 @@ osd_std_config(struct osd_item *item, struct navit *navit)
 			attr.u.num=-1;
 		item->configured = !!(attr.u.num & item->osd_configuration);
 	}
-	// TODO: DEFINE & NAME FLAGS
-	if (item->gr && !(item->flags & FLAG16)) 
+
+	if (item->gr && !(item->flags & DISABLE_OVERLAY)) 
 		graphics_overlay_disable(item->gr, !item->configured);
 }
 
@@ -477,8 +476,7 @@ osd_set_std_graphic(struct navit *nav, struct osd_item *item, struct osd_priv *p
 	item->graphic_fg = graphics_gc_new(item->gr);
 	graphics_gc_set_foreground(item->graphic_fg, &item->color_fg);
 
-	// TODO: DEFINE & NAME FLAGS
-	if (item->flags & FLAG2) {
+	if (item->flags & ITEM_HAS_TEXT) {
 		item->font = graphics_named_font_new(item->gr, item->font_name, item->font_size, 1);
 		item->graphic_fg_text = graphics_gc_new(item->gr);
 		graphics_gc_set_foreground(item->graphic_fg_text, &item->text_color);

--- a/navit/osd.c
+++ b/navit/osd.c
@@ -292,7 +292,7 @@ osd_std_reconfigure(struct osd_item *item, struct command_saved *cs)
 	dbg(lvl_debug, "enter, item=%p, cs=%p\n", item, cs);
 	if (!command_saved_error(cs)) {
 		item->configured = !! command_saved_get_int(cs);
-		if (item->gr && !(item->flags & 16)) 
+		if (item->gr && !(item->flags & FLAG16)) 
 			graphics_overlay_disable(item->gr, !item->configured);
 	} else {
 		err = command_error_to_text(command_saved_error(cs));
@@ -316,7 +316,8 @@ osd_set_std_attr(struct attr **attrs, struct osd_item *item, int flags)
 	item->text_color.g = 0xffff;
 	item->text_color.b = 0xffff;
 	item->text_color.a = 0xffff;
-	if (flags & 1) {
+	// TODO: DEFINE & NAME FLAGS
+	if (flags & FLAG1) {
 		item->color_bg.r = 0x0808;
 		item->color_bg.g = 0x0808;
 		item->color_bg.b = 0xf8f8;
@@ -404,7 +405,8 @@ osd_std_config(struct osd_item *item, struct navit *navit)
 			attr.u.num=-1;
 		item->configured = !!(attr.u.num & item->osd_configuration);
 	}
-	if (item->gr && !(item->flags & 16)) 
+	// TODO: DEFINE & NAME FLAGS
+	if (item->gr && !(item->flags & FLAG16)) 
 		graphics_overlay_disable(item->gr, !item->configured);
 }
 
@@ -475,7 +477,8 @@ osd_set_std_graphic(struct navit *nav, struct osd_item *item, struct osd_priv *p
 	item->graphic_fg = graphics_gc_new(item->gr);
 	graphics_gc_set_foreground(item->graphic_fg, &item->color_fg);
 
-	if (item->flags & 2) {
+	// TODO: DEFINE & NAME FLAGS
+	if (item->flags & FLAG2) {
 		item->font = graphics_named_font_new(item->gr, item->font_name, item->font_size, 1);
 		item->graphic_fg_text = graphics_gc_new(item->gr);
 		graphics_gc_set_foreground(item->graphic_fg_text, &item->text_color);

--- a/navit/osd.h
+++ b/navit/osd.h
@@ -23,6 +23,12 @@
 struct osd_priv;
 struct attr;
 
+#define FLAG1 1
+#define FLAG2 2
+#define FLAG4 4
+#define FLAG8 8
+#define FLAG16 16
+
 struct osd_methods {
 	void (*osd_destroy)(struct osd_priv *osd);
 	int (*set_attr)(struct osd_priv *osd, struct attr* attr);

--- a/navit/osd.h
+++ b/navit/osd.h
@@ -23,11 +23,9 @@
 struct osd_priv;
 struct attr;
 
-#define FLAG1 1
-#define FLAG2 2
-#define FLAG4 4
-#define FLAG8 8
-#define FLAG16 16
+#define TRANSPARENT_BG 1
+#define ITEM_HAS_TEXT 2
+#define DISABLE_OVERLAY 4
 
 struct osd_methods {
 	void (*osd_destroy)(struct osd_priv *osd);

--- a/navit/osd/core/osd_core.c
+++ b/navit/osd/core/osd_core.c
@@ -539,6 +539,7 @@ osd_route_guard_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_route_guard_draw);
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 
 	attr = attr_search(attrs, NULL, attr_min_dist);
@@ -968,8 +969,9 @@ osd_odometer_reset(struct osd_priv_common *opc, int flags)
 {
   struct odometer *this = (struct odometer *)opc->data;
 
-  if(!this->bDisableReset || (flags & 1)) {
-    if (!(flags & 2)) 
+	// TODO: DEFINE & NAME FLAGS
+  if(!this->bDisableReset || (flags & FLAG1)) {
+    if (!(flags & FLAG2)) 
       this->bActive         = 0;
     this->sum_dist        = 0;
     this->sum_time        = 0;
@@ -1153,6 +1155,7 @@ osd_odometer_new(struct navit *nav, struct osd_methods *meth,
 	if (attr)
 		this->align=attr->u.num;
 
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
@@ -1334,6 +1337,7 @@ osd_cmd_interface_new(struct navit *nav, struct osd_methods *meth,
 	opc->spec_set_attr_func = osd_cmd_interface_set_attr;
 	meth->set_attr = set_std_osd_attr;
 
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 
 	attr = attr_search(attrs, NULL, attr_width);
@@ -1498,6 +1502,7 @@ osd_stopwatch_new(struct navit *nav, struct osd_methods *meth,
 	this->sum_time = 0;
 	this->last_click_time = 0;
 
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
@@ -1615,6 +1620,7 @@ osd_compass_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_compass_draw);
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
@@ -1820,6 +1826,7 @@ osd_button_new(struct navit *nav, struct osd_methods *meth,
 	attr=attr_search(attrs, NULL, attr_use_overlay);
 	if (attr)
 		this->use_overlay=attr->u.num;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? 1:(1|16));
 
 	if (!opc->osd_item.command) {
@@ -1878,7 +1885,7 @@ osd_image_init(struct osd_priv_common *opc, struct navit *nav)
 		graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
 		graphics_image_free(opc->osd_item.gr, img);
 	} else {
-		opc->osd_item.configured=1;
+		osd_set_std_config(nav, &opc->osd_item);
 		opc->osd_item.gr=gra;
 		opc->osd_item.graphic_bg=graphics_gc_new(opc->osd_item.gr);
 		graphics_add_callback(gra, this->draw_cb=callback_new_attr_2(callback_cast(osd_button_draw), attr_postdraw, opc, nav));
@@ -1903,11 +1910,13 @@ osd_image_new(struct navit *nav, struct osd_methods *meth,
 	meth->set_attr = set_std_osd_attr;
 	opc->spec_set_attr_func = osd_button_set_attr;
 
-	osd_set_std_attr(attrs, &opc->osd_item, 1);
-
 	attr=attr_search(attrs, NULL, attr_use_overlay);
 	if (attr)
 		this->use_overlay=attr->u.num;
+		
+	// TODO: DEFINE & NAME FLAGS
+	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? 1:(1|16));
+
 	attr = attr_search(attrs, NULL, attr_src);
 	if (!attr) {
 		dbg(lvl_error, "no src\n");
@@ -2088,6 +2097,7 @@ static struct osd_priv *osd_navigation_status_new(struct navit *nav, struct osd_
 	opc->osd_item.font_size = 200;  // FIXME may not be needed
 	opc->osd_item.meth.draw = osd_draw_cast(osd_navigation_status_draw);
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -2238,6 +2248,7 @@ osd_nav_next_turn_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_nav_next_turn_draw);
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -2373,6 +2384,7 @@ osd_nav_toggle_announcer_new(struct navit *nav, struct osd_methods *meth, struct
 	opc->osd_item.meth.draw = osd_draw_cast(osd_nav_toggle_announcer_draw);
 	meth->set_attr = set_std_osd_attr;
 
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -2550,6 +2562,7 @@ osd_speed_cam_draw(struct osd_priv_common *opc, struct navit *navit, struct vehi
   }
   mapset_close(msh);
 
+	// TODO: DEFINE & NAME FLAGS
   if(bFound && (idx==-1 || this_->flags & (1<<(idx-1))) ) {
     dCurrDist = transform_distance(projection_mg, &curr_coord, &cam_coord);
     ret_attr = vehicle_get_attr(curr_vehicle,attr_position_speed,&speed_attr, NULL);
@@ -2666,6 +2679,7 @@ osd_speed_cam_new(struct navit *nav, struct osd_methods *meth, struct attr **att
   opc->osd_item.meth.draw = osd_draw_cast(osd_speed_cam_draw);
   meth->set_attr = set_std_osd_attr;
 
+	// TODO: DEFINE & NAME FLAGS
   osd_set_std_attr(attrs, &opc->osd_item, 2);
   attr = attr_search(attrs, NULL, attr_width);
   this->width=attr ? attr->u.num : 2;
@@ -2758,6 +2772,7 @@ osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct v
 			imperial=imperial_attr.u.num;
 	}
 
+	// TODO: DEFINE & NAME FLAGS
         flags=tracking_get_current_flags(tracking);
         if (flags && (*flags & AF_SPEED_LIMIT) && tracking_get_attr(tracking, attr_maxspeed, &maxspeed_attr, NULL)) {
             routespeed = maxspeed_attr.u.num;
@@ -2964,6 +2979,8 @@ osd_speed_warner_new(struct navit *nav, struct osd_methods *meth, struct attr **
 		this->announce_on = attr->u.num;
 	else
 		this->announce_on = 1;    //announce by default
+	
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 	navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_speed_warner_init), attr_graphics_ready, opc));
 	return (struct osd_priv *) opc;
@@ -3604,6 +3621,7 @@ osd_text_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.meth.draw = osd_draw_cast(osd_text_draw);
 	meth->set_attr = set_std_osd_attr;
 	opc->spec_set_attr_func = osd_text_set_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 2);
 
 	this->active = -1;
@@ -3717,6 +3735,7 @@ osd_gps_status_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_gps_status_draw);
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -3827,6 +3846,7 @@ osd_volume_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_volume_draw);
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -3967,7 +3987,7 @@ osd_scale_init(struct osd_priv_common *opc, struct navit *nav)
 	if (this->use_overlay) {
 		osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
 	} else {
-		opc->osd_item.configured=1;
+		osd_set_std_config(nav, &opc->osd_item);
 		opc->osd_item.gr=gra;
 		opc->osd_item.font = graphics_font_new(opc->osd_item.gr, opc->osd_item.font_size, 1);
 		opc->osd_item.graphic_fg=graphics_gc_new(opc->osd_item.gr);
@@ -3993,12 +4013,14 @@ osd_scale_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.meth.draw = osd_draw_cast(osd_scale_draw);
 	meth->set_attr = set_std_osd_attr;
 
-	osd_set_std_attr(attrs, &opc->osd_item, 3);
-
 	attr=attr_search(attrs, NULL, attr_use_overlay);
 	if (attr)
 		this->use_overlay=attr->u.num;
-
+// TODO: DEFINE & NAME FLAGS
+	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? 1:(1|16));
+	// TODO: DEFINE & NAME FLAGS
+	//osd_set_std_attr(attrs, &opc->osd_item, 3);
+	
 	navit_add_callback(nav, this->navit_init_cb = callback_new_attr_1(callback_cast (osd_scale_init), attr_graphics_ready, opc));
 
 	return (struct osd_priv *) opc;
@@ -4108,6 +4130,7 @@ osd_auxmap_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs)
 	opc->osd_item.rel_h = 40;
 	opc->osd_item.font_size = 200;
 	meth->set_attr = set_std_osd_attr;
+	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_auxmap_init), attr_navit, opc));

--- a/navit/osd/core/osd_core.c
+++ b/navit/osd/core/osd_core.c
@@ -539,8 +539,8 @@ osd_route_guard_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_route_guard_draw);
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 
 	attr = attr_search(attrs, NULL, attr_min_dist);
 	if (attr) {
@@ -969,9 +969,8 @@ osd_odometer_reset(struct osd_priv_common *opc, int flags)
 {
   struct odometer *this = (struct odometer *)opc->data;
 
-	// TODO: DEFINE & NAME FLAGS
-  if(!this->bDisableReset || (flags & FLAG1)) {
-    if (!(flags & FLAG2)) 
+  if(!this->bDisableReset || (flags & 1)) {
+    if (!(flags & 2)) 
       this->bActive         = 0;
     this->sum_dist        = 0;
     this->sum_time        = 0;
@@ -1155,8 +1154,7 @@ osd_odometer_new(struct navit *nav, struct osd_methods *meth,
 	if (attr)
 		this->align=attr->u.num;
 
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
 	attr = attr_search(attrs, NULL, attr_idle_color);
@@ -1337,8 +1335,7 @@ osd_cmd_interface_new(struct navit *nav, struct osd_methods *meth,
 	opc->spec_set_attr_func = osd_cmd_interface_set_attr;
 	meth->set_attr = set_std_osd_attr;
 
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
@@ -1502,8 +1499,7 @@ osd_stopwatch_new(struct navit *nav, struct osd_methods *meth,
 	this->sum_time = 0;
 	this->last_click_time = 0;
 
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
 	attr = attr_search(attrs, NULL, attr_idle_color);
@@ -1620,8 +1616,7 @@ osd_compass_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_compass_draw);
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 	attr = attr_search(attrs, NULL, attr_width);
 	this->width=attr ? attr->u.num : 2;
 	attr = attr_search(attrs, NULL, attr_destination_dir_color);
@@ -1826,8 +1821,8 @@ osd_button_new(struct navit *nav, struct osd_methods *meth,
 	attr=attr_search(attrs, NULL, attr_use_overlay);
 	if (attr)
 		this->use_overlay=attr->u.num;
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? 1:(1|16));
+
+	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? TRANSPARENT_BG:(TRANSPARENT_BG|DISABLE_OVERLAY));
 
 	if (!opc->osd_item.command) {
 		dbg(lvl_error, "no command\n");
@@ -1914,8 +1909,8 @@ osd_image_new(struct navit *nav, struct osd_methods *meth,
 	if (attr)
 		this->use_overlay=attr->u.num;
 		
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? 1:(1|16));
+
+	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? TRANSPARENT_BG:(TRANSPARENT_BG|DISABLE_OVERLAY));
 
 	attr = attr_search(attrs, NULL, attr_src);
 	if (!attr) {
@@ -2097,7 +2092,6 @@ static struct osd_priv *osd_navigation_status_new(struct navit *nav, struct osd_
 	opc->osd_item.font_size = 200;  // FIXME may not be needed
 	opc->osd_item.meth.draw = osd_draw_cast(osd_navigation_status_draw);
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -2248,7 +2242,7 @@ osd_nav_next_turn_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_nav_next_turn_draw);
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
+
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -2384,7 +2378,6 @@ osd_nav_toggle_announcer_new(struct navit *nav, struct osd_methods *meth, struct
 	opc->osd_item.meth.draw = osd_draw_cast(osd_nav_toggle_announcer_draw);
 	meth->set_attr = set_std_osd_attr;
 
-	// TODO: DEFINE & NAME FLAGS
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -2562,7 +2555,6 @@ osd_speed_cam_draw(struct osd_priv_common *opc, struct navit *navit, struct vehi
   }
   mapset_close(msh);
 
-	// TODO: DEFINE & NAME FLAGS
   if(bFound && (idx==-1 || this_->flags & (1<<(idx-1))) ) {
     dCurrDist = transform_distance(projection_mg, &curr_coord, &cam_coord);
     ret_attr = vehicle_get_attr(curr_vehicle,attr_position_speed,&speed_attr, NULL);
@@ -2679,8 +2671,7 @@ osd_speed_cam_new(struct navit *nav, struct osd_methods *meth, struct attr **att
   opc->osd_item.meth.draw = osd_draw_cast(osd_speed_cam_draw);
   meth->set_attr = set_std_osd_attr;
 
-	// TODO: DEFINE & NAME FLAGS
-  osd_set_std_attr(attrs, &opc->osd_item, 2);
+  osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
   attr = attr_search(attrs, NULL, attr_width);
   this->width=attr ? attr->u.num : 2;
   attr = attr_search(attrs, NULL, attr_idle_color);
@@ -2772,7 +2763,6 @@ osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct v
 			imperial=imperial_attr.u.num;
 	}
 
-	// TODO: DEFINE & NAME FLAGS
         flags=tracking_get_current_flags(tracking);
         if (flags && (*flags & AF_SPEED_LIMIT) && tracking_get_attr(tracking, attr_maxspeed, &maxspeed_attr, NULL)) {
             routespeed = maxspeed_attr.u.num;
@@ -2980,8 +2970,7 @@ osd_speed_warner_new(struct navit *nav, struct osd_methods *meth, struct attr **
 	else
 		this->announce_on = 1;    //announce by default
 	
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 	navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_speed_warner_init), attr_graphics_ready, opc));
 	return (struct osd_priv *) opc;
 }
@@ -3621,8 +3610,7 @@ osd_text_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.meth.draw = osd_draw_cast(osd_text_draw);
 	meth->set_attr = set_std_osd_attr;
 	opc->spec_set_attr_func = osd_text_set_attr;
-	// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, 2);
+	osd_set_std_attr(attrs, &opc->osd_item, ITEM_HAS_TEXT);
 
 	this->active = -1;
 	this->last = NULL;
@@ -3735,7 +3723,7 @@ osd_gps_status_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_gps_status_draw);
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
+
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -3846,7 +3834,7 @@ osd_volume_new(struct navit *nav, struct osd_methods *meth,
 	opc->osd_item.font_size = 200;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_volume_draw);
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
+
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	this->icon_w = -1;
@@ -3921,14 +3909,14 @@ osd_scale_draw(struct osd_priv_common *opc, struct navit *nav)
 
 	if (!navit_get_attr(nav, attr_transformation, &transformation, NULL))
 		return;
-	if (this->use_overlay) {
+	//if (this->use_overlay) {
 		graphics_draw_mode(opc->osd_item.gr, draw_mode_begin);
 		item_pos.x=0;
 		item_pos.y=0;
 		graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_bg, &item_pos, opc->osd_item.w, opc->osd_item.h);
-	} else {
+	/*} else {
 		item_pos=opc->osd_item.p;
-	}
+	}*/
 	scale_line_start=item_pos;
 	scale_line_start.y+=opc->osd_item.h/2;
 	scale_line_start.x+=(opc->osd_item.w-width_reduced)/2;
@@ -3963,14 +3951,14 @@ osd_scale_draw(struct osd_priv_common *opc, struct navit *nav)
 	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_fg, p+6, 4,opc->osd_item.h/5+4);
 	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_fg, p+7, p[1].x-p[0].x, 4);
 	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_fg, p+8, 4,opc->osd_item.h/5+4);
-	graphics_draw_lines(opc->osd_item.gr, this->black, p, 2);
-	graphics_draw_lines(opc->osd_item.gr, this->black, p+2, 2);
-	graphics_draw_lines(opc->osd_item.gr, this->black, p+4, 2);
+	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, p, 2);
+	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, p+2, 2);
+	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, p+4, 2);
 	text=format_distance(scale_length_on_map, "", imperial);
 	graphics_get_text_bbox(opc->osd_item.gr, opc->osd_item.font, text, 0x10000, 0, bbox, 0);
 	p[0].x=(opc->osd_item.w-bbox[2].x)/2+item_pos.x;
 	p[0].y=item_pos.y+opc->osd_item.h-opc->osd_item.h/10;
-	graphics_draw_text(opc->osd_item.gr, this->black, opc->osd_item.graphic_fg, opc->osd_item.font, text, &p[0], 0x10000, 0);
+	graphics_draw_text(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, opc->osd_item.graphic_fg, opc->osd_item.font, text, &p[0], 0x10000, 0);
 	g_free(text);
 	if (this->use_overlay)
 		graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
@@ -3981,19 +3969,34 @@ osd_scale_init(struct osd_priv_common *opc, struct navit *nav)
 {
 	struct osd_scale *this = (struct osd_scale *)opc->data;
 
-	struct color color_black={COLOR_BLACK_};
 	struct graphics *gra = navit_get_graphics(nav);
-	dbg(lvl_debug, "enter\n");
-	if (this->use_overlay) {
-		osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
-	} else {
+	
+	struct color transparent = {0,0,0,0};
+	
+	opc->osd_item.color_fg.r = 0xffff-opc->osd_item.text_color.r;
+	opc->osd_item.color_fg.g = 0xffff-opc->osd_item.text_color.g;
+	opc->osd_item.color_fg.b = 0xffff-opc->osd_item.text_color.b;
+	opc->osd_item.color_fg.a = 0xffff-opc->osd_item.text_color.a;
+	
+	
+	if(COLOR_IS_SAME(opc->osd_item.color_fg, transparent)){
+		opc->osd_item.color_fg.r = 0x1111;
+		opc->osd_item.color_fg.g = 0x1111;
+		opc->osd_item.color_fg.b = 0x1111;
+		opc->osd_item.color_fg.a = 0x1111;
+	}
+
+	osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
+	
+	/*} else {
 		osd_set_std_config(nav, &opc->osd_item);
+		osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
 		opc->osd_item.gr=gra;
 		opc->osd_item.font = graphics_font_new(opc->osd_item.gr, opc->osd_item.font_size, 1);
 		opc->osd_item.graphic_fg=graphics_gc_new(opc->osd_item.gr);
-	}
-	this->black=graphics_gc_new(opc->osd_item.gr);
-	graphics_gc_set_foreground(this->black, &color_black);
+	}//*/
+	//this->black=graphics_gc_new(opc->osd_item.gr);
+	//graphics_gc_set_foreground(this->black, &opc->osd_item.text_color);
 	graphics_add_callback(gra, this->draw_cb=callback_new_attr_2(callback_cast(osd_scale_draw), attr_postdraw, opc, nav));
 	if (navit_get_ready(nav) == 3)
 		osd_scale_draw(opc, nav);
@@ -4008,18 +4011,12 @@ osd_scale_new(struct navit *nav, struct osd_methods *meth,
 	struct attr *attr;
 
 	opc->data = (void*)this;
-
+	opc->osd_item.font_size = 200;
 	opc->osd_item.navit = nav;
 	opc->osd_item.meth.draw = osd_draw_cast(osd_scale_draw);
 	meth->set_attr = set_std_osd_attr;
 
-	attr=attr_search(attrs, NULL, attr_use_overlay);
-	if (attr)
-		this->use_overlay=attr->u.num;
-// TODO: DEFINE & NAME FLAGS
-	osd_set_std_attr(attrs, &opc->osd_item, this->use_overlay ? 1:(1|16));
-	// TODO: DEFINE & NAME FLAGS
-	//osd_set_std_attr(attrs, &opc->osd_item, 3);
+	osd_set_std_attr(attrs, &opc->osd_item, TRANSPARENT_BG | ITEM_HAS_TEXT);
 	
 	navit_add_callback(nav, this->navit_init_cb = callback_new_attr_1(callback_cast (osd_scale_init), attr_graphics_ready, opc));
 
@@ -4130,7 +4127,7 @@ osd_auxmap_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs)
 	opc->osd_item.rel_h = 40;
 	opc->osd_item.font_size = 200;
 	meth->set_attr = set_std_osd_attr;
-	// TODO: DEFINE & NAME FLAGS
+
 	osd_set_std_attr(attrs, &opc->osd_item, 0);
 
 	navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_auxmap_init), attr_navit, opc));

--- a/navit/osd/core/osd_core.c
+++ b/navit/osd/core/osd_core.c
@@ -3909,14 +3909,12 @@ osd_scale_draw(struct osd_priv_common *opc, struct navit *nav)
 
 	if (!navit_get_attr(nav, attr_transformation, &transformation, NULL))
 		return;
-	//if (this->use_overlay) {
-		graphics_draw_mode(opc->osd_item.gr, draw_mode_begin);
-		item_pos.x=0;
-		item_pos.y=0;
-		graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_bg, &item_pos, opc->osd_item.w, opc->osd_item.h);
-	/*} else {
-		item_pos=opc->osd_item.p;
-	}*/
+
+	graphics_draw_mode(opc->osd_item.gr, draw_mode_begin);
+	item_pos.x=0;
+	item_pos.y=0;
+	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_bg, &item_pos, opc->osd_item.w, opc->osd_item.h);
+
 	scale_line_start=item_pos;
 	scale_line_start.y+=opc->osd_item.h/2;
 	scale_line_start.x+=(opc->osd_item.w-width_reduced)/2;
@@ -3951,14 +3949,14 @@ osd_scale_draw(struct osd_priv_common *opc, struct navit *nav)
 	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_fg, p+6, 4,opc->osd_item.h/5+4);
 	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_fg, p+7, p[1].x-p[0].x, 4);
 	graphics_draw_rectangle(opc->osd_item.gr, opc->osd_item.graphic_fg, p+8, 4,opc->osd_item.h/5+4);
-	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, p, 2);
-	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, p+2, 2);
-	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, p+4, 2);
+	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text, p, 2);
+	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text, p+2, 2);
+	graphics_draw_lines(opc->osd_item.gr, opc->osd_item.graphic_fg_text, p+4, 2);
 	text=format_distance(scale_length_on_map, "", imperial);
 	graphics_get_text_bbox(opc->osd_item.gr, opc->osd_item.font, text, 0x10000, 0, bbox, 0);
 	p[0].x=(opc->osd_item.w-bbox[2].x)/2+item_pos.x;
 	p[0].y=item_pos.y+opc->osd_item.h-opc->osd_item.h/10;
-	graphics_draw_text(opc->osd_item.gr, opc->osd_item.graphic_fg_text /*this->black*/, opc->osd_item.graphic_fg, opc->osd_item.font, text, &p[0], 0x10000, 0);
+	graphics_draw_text(opc->osd_item.gr, opc->osd_item.graphic_fg_text, opc->osd_item.graphic_fg, opc->osd_item.font, text, &p[0], 0x10000, 0);
 	g_free(text);
 	if (this->use_overlay)
 		graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
@@ -3988,15 +3986,6 @@ osd_scale_init(struct osd_priv_common *opc, struct navit *nav)
 
 	osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
 	
-	/*} else {
-		osd_set_std_config(nav, &opc->osd_item);
-		osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
-		opc->osd_item.gr=gra;
-		opc->osd_item.font = graphics_font_new(opc->osd_item.gr, opc->osd_item.font_size, 1);
-		opc->osd_item.graphic_fg=graphics_gc_new(opc->osd_item.gr);
-	}//*/
-	//this->black=graphics_gc_new(opc->osd_item.gr);
-	//graphics_gc_set_foreground(this->black, &opc->osd_item.text_color);
 	graphics_add_callback(gra, this->draw_cb=callback_new_attr_2(callback_cast(osd_scale_draw), attr_postdraw, opc, nav));
 	if (navit_get_ready(nav) == 3)
 		osd_scale_draw(opc, nav);


### PR DESCRIPTION
This PR shall fix [trac-1202](http://trac.navit-project.org/ticket/1202).
After looking into it again after a year, I could fix the behavior for Image and Scale.

Additionally I renamed the OSD flags to what they probably do.

I took a new branch (with typo -.- ) because we do not want to see all commit from the past  year. 

#235 can stay closed.