### PR TITLE
New version for sailfish 0.5.1-r5

### DIFF
--- a/contrib/sailfish/build_on_sailfish_sdk.sh
+++ b/contrib/sailfish/build_on_sailfish_sdk.sh
@@ -4,7 +4,9 @@
 if [ -z ${VERSION_ID+x} ]; then echo "VERSION_ID not set. Forgot to export VERSION_ID?"; exit 1; fi
 
 #arm devices
+sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-install -R zypper in `cat navit-sailfish.spec | grep "^BuildRequires: " | sed -e "s/BuildRequires: //"`
 sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 #intel devices
+sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-install -R zypper in `cat navit-sailfish.spec | grep "^BuildRequires: " | sed -e "s/BuildRequires: //"`
 sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 

--- a/contrib/sailfish/navit-sailfish.spec
+++ b/contrib/sailfish/navit-sailfish.spec
@@ -10,14 +10,14 @@ Name: harbour-navit
 Summary: Open Source car navigation system
 #Version: %{navit_version}_%{git_version}
 Version: 0.5.1
-Release: 4
+Release: 5
 License: GPL
 Group: Applications/Productivity
-URL: http://navit-projet.org/
+URL: http://navit-project.org/
 
 #git is vor version info while building
 BuildRequires: git
-BuildRequires: gcc
+#BuildRequires: gcc
 BuildRequires: cmake
 BuildRequires: glib2-devel
 BuildRequires: gettext-devel
@@ -125,6 +125,9 @@ cmake  -DCMAKE_INSTALL_PREFIX:PATH=/usr \
 
 
 %changelog
+*Tue Oct 17 2017 metalstrolch 0.5.1-5
+- Update upstream
+
 *Tue Oct 17 2017 metalstrolch 0.5.1-4
 - Fix medium GUI icon size to cope with changed icon set on upstream
 - Update upstream


### PR DESCRIPTION
This bumps version for navit to 0.5.1-r5

This removes gcc from build dependencies

This automatically zyppers in build requirements as given in spec file
into sailfish build virtual machine. So no hand work required anymore.