### PR TITLE
Github: Add a template for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,2 @@
+### Thanks for opening an issue on Navit. Before submitting a bug report, please read the documentation on what to provide here:
+https://wiki.navit-project.org/index.php/Reporting_Bugs


### PR DESCRIPTION
Every time people will open an issue on Navit they will see a link to our wiki.