### PR TITLE
Change:CI:Move doxygen to the build workflow to only run it when the build succeeds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,12 +172,6 @@ jobs:
           command: export GIT_TERMINAL_PROMPT=0 && git push origin $CIRCLE_SHA1:refs/heads/master
 workflows:
   version: 2
-  doxygen:
-    jobs:
-      - run_doxygen:
-          filters:
-            branches:
-              only: /^trunk$/
   build_all:
     jobs:
       - build_linux
@@ -187,6 +181,18 @@ workflows:
       - build_wince
       - build_tomtom_minimal
       - build_tomtom_plugin
+      - run_doxygen:
+          requires:
+            - build_linux
+            - build_android_arm
+            - build_android_x86
+            - build_win32
+            - build_wince
+            - build_tomtom_minimal
+            - build_tomtom_plugin
+          filters:
+            branches:
+              only: /^trunk$/
       - merge_trunk_in_master:
           requires:
             - build_linux


### PR DESCRIPTION
@jkoan pointed out with good reasons that it would be better to only run the doxygen job when the builds are all passing. This is the corresponding PR.

Putting @pgrandin as reviewer to make sure there were no specific reasons to put this one in a separate workflow.