### PR TITLE
Update:CI:Make sure that all the scripts in the ci folder have a shebang and use set -e

### DIFF
--- a/ci/build_win32.sh
+++ b/ci/build_win32.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+set -e
 apt-get update && apt-get install -y mingw32 mingw32-binutils mingw32-runtime default-jdk nsis libsaxonb-java
 
 mkdir win32

--- a/ci/import_translations.sh
+++ b/ci/import_translations.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 # Let's check if there is files in the import queue
 [ -d po/import_queue/ ] || exit 0
 

--- a/ci/merge_i18n_update.sh
+++ b/ci/merge_i18n_update.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 message=`git log -1 --pretty=%B`
 git config --global user.name "CircleCI"
 git config --global user.email circleci@navit-project.org

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 ARCH="arm"
 
 cd ~/

--- a/ci/setup_android.sh
+++ b/ci/setup_android.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 apt-get update && apt-get install -y software-properties-common
 add-apt-repository -y ppa:openjdk-r/ppa
 apt-get update && apt-get install -y openjdk-8-jdk wget expect git curl libsaxonb-java ant

--- a/ci/setup_android.sh
+++ b/ci/setup_android.sh
@@ -10,7 +10,7 @@ export ANDROID_SDK_HOME=/opt/android-sdk-linux
 export ANDROID_HOME=/opt/android-sdk-linux
 
 cd /opt && wget -q https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz -O android-sdk.tgz
-cd /opt && tar -xvzf android-sdk.tgz
+cd /opt && tar -xvzf android-sdk.tgz --no-same-owner
 cd /opt && rm -f android-sdk.tgz
 
 export PATH=${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools:/opt/tools

--- a/ci/setup_common_requirements.sh
+++ b/ci/setup_common_requirements.sh
@@ -1,1 +1,4 @@
+#!/bin/sh
+set -e
+
 apt-get update && apt-get install -y wget unzip cmake build-essential gettext imagemagick util-linux git ssh

--- a/ci/xdotools.sh
+++ b/ci/xdotools.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+set -e
 sudo apt-get install xdotool
 # Use xinput test 4 when running x11vnc on the circleci server to find mouse coordinates
 


### PR DESCRIPTION
Updated all the ci scripts to have a shebang and use `set -e` except for `ci/update_download_center.sh` who has a retry mechanism that prevents us from using `set -e`.

Also fixes an error happening when extracting the android sdk as the owner of the extracted files is not the same as in the tarball.