### PR TITLE
Add a script to update the contributors list from the git log

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,35 @@
+Cedric Paille <cedricpaille@gmail.com>                        Cedric PAILLE <cedricpaille@gmail.com>
+Charles Curley <charlescurley@users.noreply.github.com>       Charles Curley <charlescurley@charlescurley.com>
+gauthier60 <gauthier60@ffa7fe5e-494d-0410-b361-a75ebd5db220>  Gauthier60 <Gauthier60@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Joseph Herlant <aerostitch@users.noreply.github.com>          Joseph Herlant <herlantj@gmail.com>
+Marc Capdeville <mcapdeville@users.noreply.github.com>        Marc CAPDEVILLE <marc@icrea-technologies.fr>
+Marc Capdeville <mcapdeville@users.noreply.github.com>        mcapdeville <m.capdeville@no-log.org>
+Patrick Höhn <hoehnp@users.noreply.github.com>                Patrick Höhn <hoehnp@gmx.de>
+Pierre Grandin <pgrandin@users.noreply.github.com>            Pierre GRANDIN <pgrandin@users.noreply.github.com>
+Pierre Grandin <pgrandin@users.noreply.github.com>            Pierre GRANDIN <grandinp@altern.org>
+Pierre Grandin <pgrandin@users.noreply.github.com>            Pierre Grandin <grandinp@altern.org>
+Pierre Grandin <pgrandin@users.noreply.github.com>            Pierre Grandin <grandinp@gmail.com>
+Pierre Grandin <pgrandin@users.noreply.github.com>            kazer_ <kazer_@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Sebastian Leske <sebastian.leske@sleske.name>                 Sebastian Leske <Sebastian.Leske@sleske.name>
+Sebastian Leske <sebastian.leske@sleske.name>                 sleske <sleske@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Stefan Wildemann <metalstrolch@users.noreply.github.com>      Stefan Wildemann <gta04@metalstrolche.de>
+Stefan Wildemann <metalstrolch@users.noreply.github.com>      Stefan Wildemann <metalstrolch@metalstrolche.de>
+Stefan Wildemann <metalstrolch@users.noreply.github.com>      Stefan Wildemann <stefan.wildemann@metalstrolche.de>
+Stefan Wildemann <metalstrolch@users.noreply.github.com>      Wildemann Stefan <stefan.wildemann@corpuls.com>
+Michael Dankov <mdankov@users.noreply.github.com>             Michael Dankov <tryagain@navit-project.org>
+Michael Dankov <mdankov@users.noreply.github.com>             mdankov <mdankov@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Michael Dankov <mdankov@users.noreply.github.com>             mdankov <mdankov@users.noreply.github.com>
+youte62 <jeremylheureux@gmail.com>                            youte62 <jeremylheureux@gmailcom>
+Johan Fitié <jfitie@users.noreply.github.com>                 Johan Fitié <jfitie@gmail.com>
+jandegr <jandegr@users.noreply.github.com>                    jandegr <jandegr1@hotmail.com>
+jkoan <jkoan@users.noreply.github.com>                        jkoan <jkoan@gmx.de>
+mvglasow <mvglasow@users.noreply.github.com>                  mvglasow <michael -at- vonglasow.com>
+mvglasow <mvglasow@users.noreply.github.com>                  mvglasow <michael@vonglasow.com>
+mvglasow <mvglasow@users.noreply.github.com>                  mvglasow <mvglasow@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Manuel Hohmann <xenos1984@users.noreply.github.com>           xenos1984 <xenos1984@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Manuel Hohmann <xenos1984@users.noreply.github.com>           xenos1984 <mhohmann@physnet.uni-hamburg.de>
+Rikky <Rikky@ffa7fe5e-494d-0410-b361-a75ebd5db220>            rikky <rikky@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Robert Pohlink <pohlinkzei@users.noreply.github.com>          Robert Pohlink <pohlinkzei@gmx-topmail.de>
+Robert Pohlink <pohlinkzei@users.noreply.github.com>          pohlinkzei <pohlinkzei@gmx-topmail.de>
+Michael Farmbauer <horwitz@users.sourceforge.net>             horwitz <horwitz@ffa7fe5e-494d-0410-b361-a75ebd5db220>
+Martin Schaller <martin-s@users.sourceforge.net>              martin-s <martin-s@ffa7fe5e-494d-0410-b361-a75ebd5db220>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,69 @@
-Michael Farmbauer <horwitz@users.sourceforge.net>
-Martin Schaller <martin-s@users.sourceforge.net>
-Pierre Grandin <kazer_@users.sourceforge.net>
-Alexander Atanasov <aatanasov@gmail.com>
+# Active contributors:
+Charles Curley
+jandegr
+jkoan
+Johan Fitié
+Joseph Herlant
+lains
+Marc Capdeville
+Michael Dankov
+mvglasow
+naggety
+Patrick Höhn
+Pierre Grandin
+Robert Pohlink
+Sebastian Leske
+Stefan Wildemann
+Timo
+trldp
+youte62
 
-And all the Navit Team members and contributors.
-See http://wiki.navit-project.org/index.php/Navit_project_members_and_contributors for the full list!
+# Retired contributors:
+afaber
+akashihi
+anhanguera
+aurel_j
+bjasspa
+bodenseepingu
+bustersnyvel
+carcinoma
+Cedric PAILLE
+christeck
+eiten
+gauthier60
+geoghegan
+ghenzo
+gotwo
+greg
+hafting
+hawke666
+kelvinzhao
+klausg
+korrosa
+latouche
+Martin Schaller
+mattcallow
+Michael Farmbauer
+niccolo
+norad
+OmegA_MRS
+pavel
+plum_
+rikky
+Rikky
+Robotaxi
+rphlx
+sanderd17
+seralph
+singesang
+spaetz
+steven_s
+tegzed
+tinloaf
+woglinde
+worldcitizen
+xenos1984
+zaxl
+zintor
+zoff99
+zoniq

--- a/AUTHORS
+++ b/AUTHORS
@@ -27,7 +27,7 @@ bjasspa
 bodenseepingu
 bustersnyvel
 carcinoma
-Cedric PAILLE
+Cedric Paille
 christeck
 eiten
 gauthier60
@@ -41,6 +41,7 @@ kelvinzhao
 klausg
 korrosa
 latouche
+Manuel Hohmann
 Martin Schaller
 mattcallow
 Michael Farmbauer
@@ -49,7 +50,6 @@ norad
 OmegA_MRS
 pavel
 plum_
-rikky
 Rikky
 Robotaxi
 rphlx
@@ -62,7 +62,6 @@ tegzed
 tinloaf
 woglinde
 worldcitizen
-xenos1984
 zaxl
 zintor
 zoff99

--- a/ci/generate_contributors.sh
+++ b/ci/generate_contributors.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# ###########################################################################################################
+# This script generates a AUTHORS file in the current directory based on the
+# output of the git log command. It splits the contributors in 2 groups:
+#  * The "active contributors" are the contributors that authored commits over the last 2 years
+#  * The "retired contributors" are the contributors that have authored commits but not over the last 2 years
+# ###########################################################################################################
+
+# This map is used to map the old authors to the new ones to avoid duplicates
+declare -A authorsMap=(
+  ["Pierre GRANDIN"]="Pierre Grandin"
+  ["kazer_"]="Pierre Grandin"
+  ["Patrick Höhn"]="Patrick Höhn"
+  ["Wildemann Stefan"]="Stefan Wildemann"
+  ["pohlinkzei"]="Robert Pohlink"
+  ["mdankov"]="Michael Dankov"
+  ["sleske"]="Sebastian Leske"
+  ["mcapdeville"]="Marc Capdeville"
+  ["Marc CAPDEVILLE"]="Marc Capdeville"
+  ["Gauthier60"]="gauthier60"
+  ["horwitz"]="Michael Farmbauer"
+  ["martin-s"]="Martin Schaller"
+)
+declare -A CONTRIBUTORS=()
+declare -a authors=()
+TWO_YEARS_AGO=`date +%s --date="2 years ago"`
+retiredTitleWritten=false
+
+git log --encoding=utf-8 --full-history --date=short "--format=format:%ad;%an" |
+{
+  echo "# Active contributors:" > AUTHORS
+  while read -r line; do
+    IFS=';'; arrLine=($line); unset IFS;
+    author=${arrLine[1]}
+    commitDate=`date +%s --date="${arrLine[0]}"`
+  
+    # Exclude circleci
+    if [[ $author =~ [Cc]ircle\s*[Cc][Ii] ]]; then
+      continue
+    fi
+  
+    # indicates that the commits are now older than 2 years so we print the
+    # sorted list of active contributors and reset the authors array
+    if [ "$retiredTitleWritten" = false ]; then
+      if [ $TWO_YEARS_AGO -ge $commitDate ]; then
+        IFS=$'\n' sorted=($(sort <<<"${authors[*]}"))
+        printf "%s\n" "${sorted[@]}" >> AUTHORS
+        authors=()
+        echo -e "\n# Retired contributors:" >> AUTHORS
+        retiredTitleWritten=true
+      fi
+    fi
+  
+    # Remapping authors
+    if [ -n "${authorsMap[${author}]}" ]; then
+      author=${authorsMap[${author}]}
+    fi
+  
+    # using the map as an easy way to check if the author has already been listed
+    if [ -z "${CONTRIBUTORS[${author}]}" ]; then
+      CONTRIBUTORS[${author}]=${arrLine[0]}
+      authors+=("${author}")
+    fi
+  done
+  # We are still in the subprocess scope so we can print the sorted list of
+  # retired contributors
+  IFS=$'\n' sorted=($(sort <<<"${authors[*]}"))
+  printf "%s\n" "${sorted[@]}" >> AUTHORS
+}

--- a/ci/generate_contributors.sh
+++ b/ci/generate_contributors.sh
@@ -6,29 +6,15 @@ set -e
 # output of the git log command. It splits the contributors in 2 groups:
 #  * The "active contributors" are the contributors that authored commits over the last 2 years
 #  * The "retired contributors" are the contributors that have authored commits but not over the last 2 years
+# Note: it uses git's mailmap functionnality to get a clean list of users
 # ###########################################################################################################
 
-# This map is used to map the old authors to the new ones to avoid duplicates
-declare -A authorsMap=(
-  ["Pierre GRANDIN"]="Pierre Grandin"
-  ["kazer_"]="Pierre Grandin"
-  ["Patrick Höhn"]="Patrick Höhn"
-  ["Wildemann Stefan"]="Stefan Wildemann"
-  ["pohlinkzei"]="Robert Pohlink"
-  ["mdankov"]="Michael Dankov"
-  ["sleske"]="Sebastian Leske"
-  ["mcapdeville"]="Marc Capdeville"
-  ["Marc CAPDEVILLE"]="Marc Capdeville"
-  ["Gauthier60"]="gauthier60"
-  ["horwitz"]="Michael Farmbauer"
-  ["martin-s"]="Martin Schaller"
-)
 declare -A CONTRIBUTORS=()
 declare -a authors=()
 TWO_YEARS_AGO=`date +%s --date="2 years ago"`
 retiredTitleWritten=false
 
-git log --encoding=utf-8 --full-history --date=short "--format=format:%ad;%an" |
+git log --encoding=utf-8 --full-history --date=short --use-mailmap "--format=format:%ad;%aN" |
 {
   echo "# Active contributors:" > AUTHORS
   while read -r line; do
@@ -51,11 +37,6 @@ git log --encoding=utf-8 --full-history --date=short "--format=format:%ad;%an" |
         echo -e "\n# Retired contributors:" >> AUTHORS
         retiredTitleWritten=true
       fi
-    fi
-  
-    # Remapping authors
-    if [ -n "${authorsMap[${author}]}" ]; then
-      author=${authorsMap[${author}]}
     fi
   
     # using the map as an easy way to check if the author has already been listed


### PR DESCRIPTION
Hi guys,

This PR adds a script to update the AUTHORS file based on the git lofs.
It has a mechanism to remap the users identified as duplicates and identified retired contributors as the ones without any commit over the last 2 years.
Also updated the AUTHORS file at the same time so you'll see the result.
Let me know what you think about it.

Thanks!
Joseph