### PR TITLE
Update:xmlconfig:Move from malloc/free/strncpy to g_malloc/g_free/g_strndup

### DIFF
--- a/navit/xmlconfig.c
+++ b/navit/xmlconfig.c
@@ -1019,7 +1019,7 @@ xi_text (xml_context *context,
 				struct xmldocument *doc=user_data;
 				struct xmlstate *curr, **state = doc->user_data;
 				struct attr attr;
-				char *text_dup = malloc(text_len+1);
+				char *text_dup = g_malloc(text_len+1);
 
 				curr=*state;
 				strncpy(text_dup, text, text_len);
@@ -1028,7 +1028,7 @@ xi_text (xml_context *context,
 				attr.u.str=text_dup;
 				if (curr->object_func && curr->object_func->add_attr && curr->element_attr.u.data)
 					curr->object_func->add_attr(curr->element_attr.u.data, &attr);
-				free(text_dup);
+				g_free(text_dup);
 				return;
 			}
 		}

--- a/navit/xmlconfig.c
+++ b/navit/xmlconfig.c
@@ -784,9 +784,7 @@ strncmp_len(const char *s1, int s1len, const char *s2)
 {
 	int ret;
 #if 0
-	char c[s1len+1];
-	strncpy(c, s1, s1len);
-	c[s1len]='\0';
+	char *c = g_strndup(s1, s1len);
 	dbg(lvl_debug,"'%s' vs '%s'", c, s2);
 #endif
 
@@ -828,10 +826,7 @@ xpointer_test(const char *test, int len, struct xistate *elem)
 	char c;
 	const char *tmp[16];
 #if 0
-	char test2[len+1];
-
-	strncpy(test2, test, len);
-	test2[len]='\0';
+	char *test2 = g_strndup(test, len);
 	dbg(lvl_debug,"%s", test2);
 #endif
 	if (!len)
@@ -1019,11 +1014,9 @@ xi_text (xml_context *context,
 				struct xmldocument *doc=user_data;
 				struct xmlstate *curr, **state = doc->user_data;
 				struct attr attr;
-				char *text_dup = g_malloc(text_len+1);
 
 				curr=*state;
-				strncpy(text_dup, text, text_len);
-				text_dup[text_len]='\0';
+				char *text_dup = g_strndup(text, text_len);
 				attr.type=attr_xml_text;
 				attr.u.str=text_dup;
 				if (curr->object_func && curr->object_func->add_attr && curr->element_attr.u.data)

--- a/navit/xmlconfig.c
+++ b/navit/xmlconfig.c
@@ -783,11 +783,6 @@ static int
 strncmp_len(const char *s1, int s1len, const char *s2)
 {
 	int ret;
-#if 0
-	char *c = g_strndup(s1, s1len);
-	dbg(lvl_debug,"'%s' vs '%s'", c, s2);
-#endif
-
 	ret=strncmp(s1, s2, s1len);
 	if (ret)
 		return ret;
@@ -825,10 +820,6 @@ xpointer_test(const char *test, int len, struct xistate *elem)
 	int eq,i,count,vlen,cond_req=1,cond=0;
 	char c;
 	const char *tmp[16];
-#if 0
-	char *test2 = g_strndup(test, len);
-	dbg(lvl_debug,"%s", test2);
-#endif
 	if (!len)
 		return 0;
 	c=test[len-1];


### PR DESCRIPTION
So I wasn't sure if we should g_strndup instead of strncpy or directly g_strdup and drop the string length altogether. Any thoughts?
Also does the xml support utf8? In this case I would have to use g_utf8_strncpy.
Thanks!