### PR TITLE
CI xxsmal cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           name: Setup requirements
           command: |
             bash ci/setup_common_requirements.sh
-            apt-get install -y libpng12-dev librsvg2-bin libfreetype6-dev libdbus-glib-1-dev libgtk2.0-dev curl
+            apt-get install -y libpng12-dev libfreetype6-dev libdbus-glib-1-dev libgtk2.0-dev curl
       - run:
           name: Build for Linux
           command: bash ci/build_linux.sh

--- a/ci/setup_common_requirements.sh
+++ b/ci/setup_common_requirements.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-apt-get update && apt-get install -y wget unzip cmake build-essential gettext imagemagick util-linux git ssh
+apt-get update && apt-get install -y wget unzip cmake build-essential gettext librsvg2-bin util-linux git ssh


### PR DESCRIPTION
I suppose we don't need both imagemagick and librsvg2-bin for the liunx build,
changed to librsvg2-bin for all.