### PR TITLE
Display imperial (feet) in the Points of Interest (POI) window.

### DIFF
--- a/navit/gui/gtk/gui_gtk_poi.c
+++ b/navit/gui/gtk/gui_gtk_poi.c
@@ -111,26 +111,26 @@ model_poi (struct gtk_poi_search *search)
 	struct pcoord pc;
 	struct mapset_handle *h;
 	int search_distance_meters; /* distance to search the POI database, in meters, from the center of the screen. */
-        int idist; /* idist appears to be the distance in meters from the center of the screen to a POI. */
+	int idist; /* idist appears to be the distance in meters from the center of the screen to a POI. */
 	struct map *m;
 	struct map_rect *mr;
 	struct item *item;
 	struct point cursor_position;
 	enum item_type selected;
 
-        /* Respect the Imperial attribute as we enlighten the user. */
+	/* Respect the Imperial attribute as we enlighten the user. */
 	struct attr attr;
-        int imperial = FALSE;  /* default to using metric measures. */
-        if (navit_get_attr(gtk_poi_search.nav, attr_imperial, &attr, NULL))
-            imperial=attr.u.num;
+	int imperial = FALSE;  /* default to using metric measures. */
+	if (navit_get_attr(gtk_poi_search.nav, attr_imperial, &attr, NULL))
+	    imperial=attr.u.num;
 
-        if (imperial == FALSE) {
-                /* Input is in kilometers */
-                search_distance_meters=1000*atoi((char *) gtk_entry_get_text(GTK_ENTRY(search->entry_distance)));
-        } else {
-                /* Input is in miles. */
-                search_distance_meters=atoi((char *) gtk_entry_get_text(GTK_ENTRY(search->entry_distance)))/METERS_TO_MILES;
-        }
+	if (imperial == FALSE) {
+		/* Input is in kilometers */
+		search_distance_meters=1000*atoi((char *) gtk_entry_get_text(GTK_ENTRY(search->entry_distance)));
+	} else {
+		/* Input is in miles. */
+		search_distance_meters=atoi((char *) gtk_entry_get_text(GTK_ENTRY(search->entry_distance)))/METERS_TO_MILES;
+	}
 
 	cursor_position.x=navit_get_width(search->nav)/2;
 	cursor_position.y=navit_get_height(search->nav)/2;
@@ -162,19 +162,15 @@ model_poi (struct gtk_poi_search *search)
 					gtk_list_store_append(search->store_poi, &iter);
 					get_compass_direction(direction,transform_get_angle_delta(&center,&coord_item,0),1);
 
-                                        /* If the user has selected
-                                         * imperial, translate idist
-                                         * from meters to feet. We
-                                         * convert to feet only
-                                         * because the code sorts on
-                                         * the numeric value of the
-                                         * distance, so it doesn't
-                                         * like two different
-                                         * units. Possible future
-                                         * enhancement? */
-                                        if (imperial != FALSE) {
-                                                idist = idist * (FEET_PER_METER); /* convert meters to feet. */
-                                        }
+                                        /**
+                                         * If the user has selected imperial, translate idist from meters to
+                                         * feet. We convert to feet only, and not miles, because the code
+                                         * sorts on the numeric value of the distance, so it doesn't like two
+                                         * different units. Possible future enhancement?
+                                         */
+					if (imperial != FALSE) {
+						idist = idist * (FEET_PER_METER); /* convert meters to feet. */
+					}
 
 					gtk_list_store_set(search->store_poi, &iter, 0,direction, 1,idist,
 						2,g_strdup(label_attr.u.str), 3,coord_item.x, 4,coord_item.y ,-1);

--- a/navit/gui/gtk/gui_gtk_poi.c
+++ b/navit/gui/gtk/gui_gtk_poi.c
@@ -134,7 +134,7 @@ model_poi (struct gtk_poi_search *search)
 
 	cursor_position.x=navit_get_width(search->nav)/2;
 	cursor_position.y=navit_get_height(search->nav)/2;
-	gtk_label_set_text(GTK_LABEL(search->label_distance),_("Distance from screen center (km)"));
+	gtk_label_set_text(GTK_LABEL(search->label_distance),_("Select a search radius from screen center"));
 
 	transform_reverse(navit_get_trans(search->nav), &cursor_position, &center);
 	pc.pro = transform_get_projection(navit_get_trans(search->nav));

--- a/po/af.po.in
+++ b/po/af.po.in
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ar.po.in
+++ b/po/ar.po.in
@@ -1695,7 +1695,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ast.po.in
+++ b/po/ast.po.in
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/be.po.in
+++ b/po/be.po.in
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/bg.po.in
+++ b/po/bg.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/bs.po.in
+++ b/po/bs.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ca.po.in
+++ b/po/ca.po.in
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ckb.po.in
+++ b/po/ckb.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/cs.po.in
+++ b/po/cs.po.in
@@ -1685,8 +1685,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Nakupování"
 
-msgid "Distance from screen center (km)"
-msgstr "Vzdálenost od středu mapy (km)"
+msgid "Select a search radius from screen center"
+msgstr "Vzdálenost od středu mapy"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/cy.po.in
+++ b/po/cy.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/da.po.in
+++ b/po/da.po.in
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/de.po.in
+++ b/po/de.po.in
@@ -1714,8 +1714,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Einkaufen"
 
-msgid "Distance from screen center (km)"
-msgstr "Entfernung vom Bildschirmmittelpunkt (km)"
+msgid "Select a search radius from screen center"
+msgstr "Entfernung vom Bildschirmmittelpunkt"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/de_CH.po.in
+++ b/po/de_CH.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/el.po.in
+++ b/po/el.po.in
@@ -1670,7 +1670,7 @@ msgstr "Ταξί"
 msgid "Shopping"
 msgstr "Αγορές"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/en.po.in
+++ b/po/en.po.in
@@ -1670,7 +1670,7 @@ msgid "Shopping"
 msgstr ""
 
 msgid "Distance from screen center (km)"
-msgstr ""
+msgstr "Select a search radius from screen center"
 
 #, c-format
 msgid "POI %s. %s"
@@ -1695,7 +1695,7 @@ msgid "Select a category"
 msgstr ""
 
 msgid "Select a distance to look for (km)"
-msgstr ""
+msgstr "Select a search radius from screen center"
 
 msgid "Select a POI"
 msgstr ""
@@ -1709,8 +1709,9 @@ msgstr ""
 msgid "Direction"
 msgstr ""
 
+# TRANSLATORS: This is the distance to a Point of Interest (POI) in the POI window. It will be feet (imperial) or, meters (metric), depending on the user's preference.
 msgid "Distance(m)"
-msgstr ""
+msgstr "Distance"
 
 msgid "Name"
 msgstr ""

--- a/po/en.po.in
+++ b/po/en.po.in
@@ -1669,8 +1669,8 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
-msgstr "Select a search radius from screen center"
+msgid "Select a search radius from screen center"
+msgstr ""
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/en_AU.po.in
+++ b/po/en_AU.po.in
@@ -1666,8 +1666,8 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
-msgstr "Select a search radius from screen center"
+msgid "Select a search radius from screen center"
+msgstr ""
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/en_AU.po.in
+++ b/po/en_AU.po.in
@@ -1667,7 +1667,7 @@ msgid "Shopping"
 msgstr ""
 
 msgid "Distance from screen center (km)"
-msgstr ""
+msgstr "Select a search radius from screen center"
 
 #, c-format
 msgid "POI %s. %s"
@@ -1692,7 +1692,7 @@ msgid "Select a category"
 msgstr ""
 
 msgid "Select a distance to look for (km)"
-msgstr ""
+msgstr "Select a search radius from screen center"
 
 msgid "Select a POI"
 msgstr ""
@@ -1706,8 +1706,9 @@ msgstr ""
 msgid "Direction"
 msgstr ""
 
+# TRANSLATORS: This is the distance to a Point of Interest (POI) in the POI window. It will be feet (imperial) or, meters (metric), depending on the user's preference.
 msgid "Distance(m)"
-msgstr ""
+msgstr "Distance"
 
 msgid "Name"
 msgstr ""

--- a/po/en_CA.po.in
+++ b/po/en_CA.po.in
@@ -1664,7 +1664,7 @@ msgid "Shopping"
 msgstr ""
 
 msgid "Distance from screen center (km)"
-msgstr ""
+msgstr "Select a search radius from screen center"
 
 #, c-format
 msgid "POI %s. %s"
@@ -1689,7 +1689,7 @@ msgid "Select a category"
 msgstr ""
 
 msgid "Select a distance to look for (km)"
-msgstr ""
+msgstr "Select a search radius from screen center"
 
 msgid "Select a POI"
 msgstr ""
@@ -1703,8 +1703,9 @@ msgstr ""
 msgid "Direction"
 msgstr ""
 
+# TRANSLATORS: This is the distance to a Point of Interest (POI) in the POI window. It will be feet (imperial) or, meters (metric), depending on the user's preference.
 msgid "Distance(m)"
-msgstr ""
+msgstr "Distance"
 
 msgid "Name"
 msgstr ""

--- a/po/en_CA.po.in
+++ b/po/en_CA.po.in
@@ -1663,8 +1663,8 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
-msgstr "Select a search radius from screen center"
+msgid "Select a search radius from screen center"
+msgstr ""
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/en_GB.po.in
+++ b/po/en_GB.po.in
@@ -1683,7 +1683,7 @@ msgid "Shopping"
 msgstr "Shopping"
 
 msgid "Distance from screen center (km)"
-msgstr "Distance from screen centre (km)"
+msgstr "Select a search radius from screen center"
 
 #, c-format
 msgid "POI %s. %s"
@@ -1708,7 +1708,7 @@ msgid "Select a category"
 msgstr "Select a category"
 
 msgid "Select a distance to look for (km)"
-msgstr "Select a distance to look for (km)"
+msgstr "Select a search radius from screen center"
 
 msgid "Select a POI"
 msgstr "Select a POI"
@@ -1722,8 +1722,9 @@ msgstr "Category"
 msgid "Direction"
 msgstr "Direction"
 
+# TRANSLATORS: This is the distance to a Point of Interest (POI) in the POI window. It will be feet (imperial) or, meters (metric), depending on the user's preference.
 msgid "Distance(m)"
-msgstr "Distance(m)"
+msgstr "Distance"
 
 msgid "Name"
 msgstr "Name"

--- a/po/en_GB.po.in
+++ b/po/en_GB.po.in
@@ -1682,8 +1682,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Shopping"
 
-msgid "Distance from screen center (km)"
-msgstr "Select a search radius from screen center"
+msgid "Select a search radius from screen center"
+msgstr ""
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/eo.po.in
+++ b/po/eo.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/es.po.in
+++ b/po/es.po.in
@@ -1696,8 +1696,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Shopping"
 
-msgid "Distance from screen center (km)"
-msgstr "Distancia del centro de la pantalla (km)"
+msgid "Select a search radius from screen center"
+msgstr "Distancia del centro de la pantalla"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/et.po.in
+++ b/po/et.po.in
@@ -1670,7 +1670,7 @@ msgstr "Takso"
 msgid "Shopping"
 msgstr "kauplus"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/eu.po.in
+++ b/po/eu.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/fa.po.in
+++ b/po/fa.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/fi.po.in
+++ b/po/fi.po.in
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/fil.po.in
+++ b/po/fil.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/fo.po.in
+++ b/po/fo.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/fr.po.in
+++ b/po/fr.po.in
@@ -1712,8 +1712,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Achats"
 
-msgid "Distance from screen center (km)"
-msgstr "Distance du centre de l'écran (km)"
+msgid "Select a search radius from screen center"
+msgstr "Distance du centre de l'écran"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/fr_CH.po.in
+++ b/po/fr_CH.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/fy.po.in
+++ b/po/fy.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/gl.po.in
+++ b/po/gl.po.in
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/he.po.in
+++ b/po/he.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/hi.po.in
+++ b/po/hi.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/hr.po.in
+++ b/po/hr.po.in
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/hu.po.in
+++ b/po/hu.po.in
@@ -1682,7 +1682,7 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Bevásárlás"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/id.po.in
+++ b/po/id.po.in
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/it.po.in
+++ b/po/it.po.in
@@ -1684,8 +1684,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Negozi"
 
-msgid "Distance from screen center (km)"
-msgstr "Distanza dal centro dello schermo (km)"
+msgid "Select a search radius from screen center"
+msgstr "Distanza dal centro dello schermo"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/ja.po.in
+++ b/po/ja.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/jv.po.in
+++ b/po/jv.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/kk.po.in
+++ b/po/kk.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/kn.po.in
+++ b/po/kn.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ko.po.in
+++ b/po/ko.po.in
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ku.po.in
+++ b/po/ku.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/lb.po.in
+++ b/po/lb.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/lt.po.in
+++ b/po/lt.po.in
@@ -1676,8 +1676,8 @@ msgstr "Taksi"
 msgid "Shopping"
 msgstr "Parduotuvė"
 
-msgid "Distance from screen center (km)"
-msgstr "Atstumas nuo ekrano vidaus (km)"
+msgid "Select a search radius from screen center"
+msgstr "Atstumas nuo ekrano vidaus"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/lv.po.in
+++ b/po/lv.po.in
@@ -1674,8 +1674,8 @@ msgstr "Taksometrs"
 msgid "Shopping"
 msgstr "Iepirkšanās"
 
-msgid "Distance from screen center (km)"
-msgstr "Attālums no ekrāna centra (km)"
+msgid "Select a search radius from screen center"
+msgstr "Attālums no ekrāna centra"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/mk.po.in
+++ b/po/mk.po.in
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ml.po.in
+++ b/po/ml.po.in
@@ -1666,7 +1666,7 @@ msgstr "ടാക്സി സ്റ്റാന്റ്"
 msgid "Shopping"
 msgstr "കച്ചവടസ്ഥാപനം"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr "സ്ക്രീനിന്റെ നടുവില്‍ നിന്നുള്ള ദൂരം (കി. മി. )"
 
 #, c-format

--- a/po/mn.po.in
+++ b/po/mn.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/mr.po.in
+++ b/po/mr.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/nb.po.in
+++ b/po/nb.po.in
@@ -1672,7 +1672,7 @@ msgstr "Drosje"
 msgid "Shopping"
 msgstr "Handleområde"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/nds.po.in
+++ b/po/nds.po.in
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/nl.po.in
+++ b/po/nl.po.in
@@ -1686,8 +1686,8 @@ msgstr "Taxi"
 msgid "Shopping"
 msgstr "Winkelen"
 
-msgid "Distance from screen center (km)"
-msgstr "Afstand vanaf schem midden (km)"
+msgid "Select a search radius from screen center"
+msgstr "Afstand vanaf schem midden"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/nn.po.in
+++ b/po/nn.po.in
@@ -1666,7 +1666,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/pl.po.in
+++ b/po/pl.po.in
@@ -1684,7 +1684,7 @@ msgstr "Postój taksówek"
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/pms.po.in
+++ b/po/pms.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/pt.po.in
+++ b/po/pt.po.in
@@ -1689,8 +1689,8 @@ msgstr "Táxi"
 msgid "Shopping"
 msgstr "Compras"
 
-msgid "Distance from screen center (km)"
-msgstr "Distância ao centro do ecrã (km)"
+msgid "Select a search radius from screen center"
+msgstr "Distância ao centro do ecrã"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/pt_BR.po.in
+++ b/po/pt_BR.po.in
@@ -1693,8 +1693,8 @@ msgstr "Táxi"
 msgid "Shopping"
 msgstr "Comprando"
 
-msgid "Distance from screen center (km)"
-msgstr "Distância do centro da tela (km)"
+msgid "Select a search radius from screen center"
+msgstr "Distância do centro da tela"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/ro.po.in
+++ b/po/ro.po.in
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ru.po.in
+++ b/po/ru.po.in
@@ -1692,7 +1692,7 @@ msgstr "Такси"
 msgid "Shopping"
 msgstr "Магазин"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr "Расстояние от центра экрана (км)"
 
 #, c-format

--- a/po/sc.po.in
+++ b/po/sc.po.in
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/si.po.in
+++ b/po/si.po.in
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/sk.po.in
+++ b/po/sk.po.in
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/sl.po.in
+++ b/po/sl.po.in
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/sq.po.in
+++ b/po/sq.po.in
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/sr.po.in
+++ b/po/sr.po.in
@@ -1678,8 +1678,8 @@ msgstr "Такси"
 msgid "Shopping"
 msgstr "Куповина"
 
-msgid "Distance from screen center (km)"
-msgstr "Растојање од средишта екрана (km)"
+msgid "Select a search radius from screen center"
+msgstr "Растојање од средишта екрана"
 
 #, c-format
 msgid "POI %s. %s"

--- a/po/sv.po.in
+++ b/po/sv.po.in
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/sw.po.in
+++ b/po/sw.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ta.po.in
+++ b/po/ta.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/te.po.in
+++ b/po/te.po.in
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/th.po.in
+++ b/po/th.po.in
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/tr.po.in
+++ b/po/tr.po.in
@@ -1685,7 +1685,7 @@ msgstr "Taksi"
 msgid "Shopping"
 msgstr "Alışveriş"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/uk.po.in
+++ b/po/uk.po.in
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/ur.po.in
+++ b/po/ur.po.in
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/vi.po.in
+++ b/po/vi.po.in
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/zh_CN.po.in
+++ b/po/zh_CN.po.in
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/zh_HK.po.in
+++ b/po/zh_HK.po.in
@@ -1666,7 +1666,7 @@ msgstr ""
 msgid "Shopping"
 msgstr ""
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr ""
 
 #, c-format

--- a/po/zh_TW.po.in
+++ b/po/zh_TW.po.in
@@ -1665,7 +1665,7 @@ msgstr "計程車"
 msgid "Shopping"
 msgstr "購物處"
 
-msgid "Distance from screen center (km)"
+msgid "Select a search radius from screen center"
 msgstr "距螢幕中心的距離 (公里)"
 
 #, c-format


### PR DESCRIPTION
1) Changed the translation string for "Distance(m)" from "" to "Distance". Rational: the "m" is ambiguous, it could be meters or miles. However, in the POI context, feet are more likely than miles. So take it out entirely. I did it this way rather than run sed on the entire collection of po input files.

2) The display code sorts the entries by distance. It has no way of knowing if "5" is five miles or five feet. So we leave the distances in feet or meters (depending on the setting for imperial). Allowing kilometers or miles might be a future enhancement.

3) See bug 556 (https://github.com/navit-gps/navit/issues/556). Rather than remove the spurious one as part of this fix, I will leave that to later. But both now have the same English "translation", "Select a search radius from screen center". This hides the problem, at least from English users. This affects all four en_*.po.in files.

4) Someone who knows more than I do about the translation strings might have a better idea. Particularly, is there a graceful way to indicate the input units, either miles or kilometers?

	modified:   navit/gui/gtk/gui_gtk_poi.c
	modified:   po/en.po.in
	modified:   po/en_AU.po.in
	modified:   po/en_CA.po.in
	modified:   po/en_GB.po.in

Thanks for contributing to Navit!
Before opening a pull request on navit, make sure your commit message follows our guidelines:
https://wiki.navit-project.org/index.php/Commit_guidelines

and that your code is compliant with out coding style guidelines:
https://wiki.navit-project.org/index.php/Programming_guidelines
