### PR TITLE
Fix:debug:Correction on segfault in debug_vprintf() introduced in 221f783e

### DIFF
--- a/navit/debug.c
+++ b/navit/debug.c
@@ -308,14 +308,14 @@ debug_vprintf(dbg_level level, const char *module, const int mlen, const char *f
 #if defined HAVE_API_WIN32_CE
 #define vsnprintf _vsnprintf
 #endif
-		gchar *fmt_newline;
+		vsnprintf(debug_message+strlen(debug_message),sizeof(debug_message)-1-strlen(debug_message),fmt,ap);
 #ifdef HAVE_API_WIN32_BASE
-		fmt_newline = g_strconcat(fmt, "\r\n");
-#else
-		fmt_newline = g_strconcat(fmt, "\n");
+		if (strlen(debug_message)<sizeof(debug_message))
+			debug_message[strlen(debug_message)] = '\r';	/* For Windows platforms, add \r at the end of the buffer (if any room) */
 #endif
-		vsnprintf(debug_message+strlen(debug_message),4095-strlen(debug_message),fmt_newline,ap);
-		g_free(fmt_newline);
+		if (strlen(debug_message)<sizeof(debug_message))
+			debug_message[strlen(debug_message)] = '\n';	/* Add \n at the end of the buffer (if any room) */
+		debug_message[sizeof(debug_message)-1] = '\0';	/* Force NUL-termination of the string (if buffer size contraints did not allow for full string to fit */
 #ifdef DEBUG_WIN32_CE_MESSAGEBOX
 		mbstowcs(muni, debug_message, strlen(debug_message)+1);
 		MessageBoxW(NULL, muni, TEXT("Navit - Error"), MB_APPLMODAL|MB_OK|MB_ICONERROR);


### PR DESCRIPTION
When using the dbg(log_error, ...) function, I now get segfaults.
The bug has been introduced at commit 221f783ea1caaaab2f5ceadc6b0fb3e720aac3df
g_strconcat's arguments should be a list of pointers, the last has to be NULL.
I have reworked the append so that it does not require a temporary allocation of the format string, but rather adds EOL characters manually.
I changed the hardcoded 4095 to a sizeof() call which is more future-proof in case the buffer size is updated in the future.
I finally, I also force \0 termination of the resulting string (maybe there could be issues if the message is longer than the 4095 bytes of the buffer). Please review this last point as it is maybe not really needed.