### PR TITLE
cleanup:wince:remove unused ConvertUTF.h header

### DIFF
--- a/navit/vehicle/wince/vehicle_wince.c
+++ b/navit/vehicle/wince/vehicle_wince.c
@@ -42,7 +42,6 @@
 #include <winioctl.h>
 #include <winbase.h>
 #include <wchar.h>
-#include "support/win32/ConvertUTF.h"
 
 /**
  * @defgroup vehicle-wince Vehicle WinCE


### PR DESCRIPTION
In #575 I noticed that this header seems unused, so cleaning it up.