### PR TITLE
fix:config:Fix dtd to allow real xmlint

### DIFF
--- a/navit/navit.dtd
+++ b/navit/navit.dtd
@@ -17,7 +17,7 @@
 <!ATTLIST log flush_size CDATA #IMPLIED>
 <!ATTLIST log flush_time CDATA #IMPLIED>
 <!ATTLIST log attr_types CDATA #IMPLIED>
-<!ELEMENT navit (graphics,gui+,log*,osd*,vehicle*,tracking,vehicleprofile*,route,navigation,speech,mapset+,layout+)*>
+<!ELEMENT navit (graphics,gui+,log*,osd*,vehicle*,tracking?,vehicleprofile*,route,navigation,speech,mapset+,layer+,layout+) >
 <!ATTLIST navit center CDATA #REQUIRED>
 <!ATTLIST navit zoom CDATA #REQUIRED>
 <!ATTLIST navit tracking CDATA #REQUIRED>


### PR DESCRIPTION
This PR fixes the navit.dtd

Test Command:
xmllint --noout --dtdvalid navit/navit.dtd navit/navit_shipped.xml

Output before:
> `navit/navit_shipped.xml:36: element navit: validity error : Element navit content does not follow the DTD, expecting (graphics , gui+ , log* , osd* , vehicle* , tracking , vehicleprofile* , route , navigation , speech , mapset+ , layout+)*, got (graphics gui gui log osd osd osd osd osd osd vehicle vehicle tracking vehicleprofile vehicleprofile vehicleprofile vehicleprofile vehicleprofile vehicleprofile vehicleprofile vehicleprofile route navigation speech mapset mapset mapset mapset layer layout layout layout layout layout layout layout )
> Document navit/navit_shipped.xml does not validate against navit/navit.dtd`
RC: 3

After the Patch:

> ` `
RC: 0