### PR TITLE
Android lint check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2
 defaults: &defaults
   docker:
     - image: ubuntu:14.04
-
 jobs:
   build_linux:
     <<: *defaults
@@ -56,7 +55,7 @@ jobs:
           name: Install cmake gettext libsaxonb-java librsvg2-bin
           command: |
             sudo apt-get install cmake gettext libsaxonb-java librsvg2-bin
-            cmake ./ -Dsvg2png_scaling:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96
+            cmake ./ -Dsvg2png_scaling:STRING=-1,128 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96
       - run:
           name: Process icons
           command: |
@@ -105,15 +104,21 @@ jobs:
           command: ./gradlew assembleDebug
       - run:
           name: Run Tests
-          command: ./gradlew tasks --all
+          command: |
+            ln -s navit/navit.dtd navit.dtd
+            ls -la
+            ./gradlew tasks --all
+            ./gradlew lint test
       - store_artifacts:
           path: navit/android/build/outputs/apk
           destination: apk
       - store_artifacts:
           path: navit/android/build/outputs/logs
           destination: logs
-      - store_test_results:
-          path: navit/android/build/test-results  
+      - store_artifacts:
+          name: Store reports
+          path: navit/android/build/reports
+          destination: reports
   build_win32:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           name: Install cmake gettext libsaxonb-java librsvg2-bin
           command: |
             sudo apt-get install cmake gettext libsaxonb-java librsvg2-bin
-            cmake ./ -Dsvg2png_scaling:STRING=-1,128 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96
+            cmake ./ -Dsvg2png_scaling:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96
       - run:
           name: Process icons
           command: |

--- a/navit/android/build.gradle
+++ b/navit/android/build.gradle
@@ -10,8 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        ndk { // because mips was a problem with ndk 14
-              // and no need for, 'x86_64' and , 'armeabi' and , 'arm64-v8a'
+        ndk { // need for now for 'x86_64' and , 'armeabi' and , 'arm64-v8a'
             abiFilters 'x86', 'armeabi-v7a'
         }
         externalNativeBuild {
@@ -19,7 +18,6 @@ android {
                 arguments '-DUSE_PLUGINS=n', '-DBUILD_MAPTOOL=n', '-DXSL_PROCESSING=n', '-DSAMPLE_MAP=n'
             }
         }
-        // https://github.com/googlesamples/android-ndk/blob/master/native-media/app/build.gradle
     }
     buildTypes {
         release {
@@ -27,15 +25,19 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        disable 'UnusedResources'
+        abortOnError true
+    }
     sourceSets {
-	    	main {
-		    	manifest.srcFile "AndroidManifest.xml"
-			    java.srcDirs = ["src"]
-			    resources.srcDirs = ["src"]
-			    renderscript.srcDirs = ["src"]
-			    res.srcDirs = ["res"]
+        main {
+            manifest.srcFile "AndroidManifest.xml"
+            java.srcDirs = ["src"]
+            resources.srcDirs = ["src"]
+            renderscript.srcDirs = ["src"]
+            res.srcDirs = ["res"]
             }
-	}
+    }
     externalNativeBuild {
         cmake {
             path '../../CMakeLists.txt'

--- a/navit/android/res/values-v19/styles.xml
+++ b/navit/android/res/values-v19/styles.xml
@@ -5,16 +5,7 @@
         NavitBaseTheme from BOTH res/values/styles.xml and
         res/values-v19/styles.xml on API 19+ devices.
     -->
-    <style name="NavitBaseTheme" parent="android:Theme.Holo">
-
-        <!-- Main theme colors -->
-        <!-- your app branding color for the app bar -->
-        <item name="android:colorPrimary">@color/navitYellow500</item>
-        <!-- darker variant for the status bar and contextual app bars -->
-        <item name="android:colorPrimaryDark">@color/navitYellow700</item>
-        <!-- theme UI controls like checkboxes and text fields -->
-        <item name="android:colorAccent">@color/navitBlue500</item>
-    </style>
+    <style name="NavitBaseTheme" parent="android:Theme.Holo"/>
 
     <!--
         Main Activity theme for API 19+. This theme completely replaces

--- a/navit/android/res/values/styles.xml
+++ b/navit/android/res/values/styles.xml
@@ -1,32 +1,4 @@
 <resources>
-
-    <!--
-        Base application theme, dependent on API level. This theme is replaced
-        by NavitBaseTheme from res/values-vXX/styles.xml on newer devices.
-    -->
-    <style name="NavitBaseTheme" parent="android:Theme.Holo">
-        <!--
-            Theme customizations available in newer API levels can go in
-            res/values-vXX/styles.xml, while customizations related to
-            backward-compatibility can go here.
-        -->
-    </style>
-
-    <!-- Theme for Navit's main Activity. -->
-    <style name="NavitTheme" parent="NavitBaseTheme">
-        <!-- All customizations that are NOT specific to a particular API-level can go here. -->
-    </style>
-
-    <!-- TODO complete list of shades for both colors -->
-    <!--
-			 Primary color is derived average of icon colors (500 in Android parlance):
-			 213 164  19  #d5a411  hsl  45    92    84
-			 
-			 Dark color is normally the 600 color (i.e. slightly darker than 500)
-			 209 155  19  #d19b13  hsl  43    91    82
-    -->
-
-
     <!-- Yellow from Navit icon background (300 and 700 are the extremes of the gradient, 500 is the average, 900 is the line color) -->
     <color name="navitYellow300">#e9cb14</color>
     <color name="navitYellow500">#d5a411</color>
@@ -38,5 +10,4 @@
     <color name="navitBlue300">#329eff</color>
     <color name="navitBlue500">#1a6cb6</color>
     <color name="navitBlue900">#1f3157</color>
-
 </resources>


### PR DESCRIPTION
This adds lint error checking to the Android builds, the result is uploaded in the artefacts, sample https://7955-30791823-gh.circle-artifacts.com/0/reports/lint-results.html
The CI will fail if errors are found, warnings pass.

Also fixes the last Lint errors appearing in the above report (API mismatches) and now CI succeeds with this as report https://7964-30791823-gh.circle-artifacts.com/0/reports/lint-results.html

The fix for the <19 basetheme will make it look just like other apps on your device, from the 19+ values the entries requiring 21+ are removed.