### PR TITLE
Add:build:Add cmake4eclipse artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+/.settings/
+/build/
+/.cproject
 /.gitk-tmp.*
+/.project
 /CMakeLists.txt.user*


### PR DESCRIPTION
After upgrading to Eclipse Oxygen (previously on Luna) and encountering several issues, I learned that CMake’s project generator for Eclipse is unmaintained and Eclipse’s maintainers advise against using it, as there have been issues with it. The recommendation is to use cmake4eclipse instead.

I have tried it and found it not only fixes the issues I was experiencing, but also does away with the limitations we had in the past:
* Source files no longer appear in two different places in the tree, leaving you to wonder which is the correct one to edit
* As `CMakeLists.txt` is the single source of truths, changes to the CMake setup take effect instantly (presumably—not yet tested in practice)
* Team features (git access from Eclipse) are now available

I have created a draft for an updated installation guide at https://wiki.navit-project.org/index.php/User:Mvglasow/Eclipse.

However, this setup writes a few files to the Navit source tree: build artifacts go into a subdir of it, and there are a few Eclipse housekeeping files. This pull request extends `.gitignore` to prevent these things from polluting our source tree (these files contain local configuration and should not be committed).