### PR TITLE
fix:maptool:coverity #262887 - leaked_storage: Variable f going out of scope leaks the storage it points to.

### DIFF
--- a/navit/maptool/buffer.c
+++ b/navit/maptool/buffer.c
@@ -71,13 +71,14 @@ load_buffer(char *filename, struct buffer *b, long long offset, long long size)
 	}
 	b->size=b->malloced=size;
 	dbg_assert(b->size>0);
-	
+
 	fseeko(f, offset, SEEK_SET);
 	b->base=g_malloc(b->size);
 	if (fread(b->base, b->size, 1, f) == 0){
 		dbg(lvl_warning, "fread failed");
+		fclose(f);
 		return 0;
-        }
+	}
 	fclose(f);
 	return 1;
 }


### PR DESCRIPTION
Closes: #597