### PR TITLE
Cleanup:android: re-attach return type to function declaration

### DIFF
--- a/navit/android/src/org/navitproject/navit/NavitSensors.java
+++ b/navit/android/src/org/navitproject/navit/NavitSensors.java
@@ -39,12 +39,10 @@ public class NavitSensors implements SensorEventListener {
         callbackid=cbid;
     }
 
-    public void
-    onAccuracyChanged(Sensor sensor, int accuracy) {
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
     }
 
-    public void
-    onSensorChanged(SensorEvent sev) {
+    public void onSensorChanged(SensorEvent sev) {
         // Log.e("NavitSensor","Type:" + sev.sensor.getType() + " X:" + sev.values[0] + " Y:"+sev.values[1]+" Z:"+sev.values[2]);
         SensorCallback(callbackid, sev.sensor.getType(), sev.values[0], sev.values[1], sev.values[2]);
     }


### PR DESCRIPTION
As mentionned in https://github.com/navit-gps/navit/pull/569#issuecomment-392873905
there was a miss in the reformatting.
