### PR TITLE
Cleanup:global:force the re-attach the return type to the function declaration

### DIFF
--- a/navit/android.c
+++ b/navit/android.c
@@ -67,8 +67,7 @@ int android_find_static_method(jclass class, char *name, char *args, jmethodID *
 }
 
 JNIEXPORT void JNICALL Java_org_navitproject_navit_Navit_NavitMain( JNIEnv* env, jobject thiz, jobject activity,
-        jobject lang, int version,
-        jobject display_density_string, jobject path,  jobject map_path) {
+        jobject lang, int version, jobject display_density_string, jobject path,  jobject map_path) {
     const char *langstr;
     const char *displaydensitystr;
     const char *map_file_path;
@@ -108,16 +107,14 @@ JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_SizeChangedCall
 }
 
 JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_PaddingChangedCallback(JNIEnv* env, jobject thiz,
-        int id, int left, int top,
-        int right, int bottom) {
+        int id, int left, int top, int right, int bottom) {
     dbg(lvl_debug,"enter %p %d %d %d %d",(struct callback *)id, left, top, right, bottom);
     if (id)
         callback_call_4((struct callback *)id, left, top, right, bottom);
 }
 
 JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_ButtonCallback( JNIEnv* env, jobject thiz, int id,
-        int pressed, int button,
-        int x, int y) {
+        int pressed, int button, int x, int y) {
     dbg(lvl_debug,"enter %p %d %d",(struct callback *)id,pressed,button);
     if (id)
         callback_call_4((struct callback *)id,pressed,button,x,y);
@@ -170,8 +167,7 @@ JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitWatch_WatchCallback( JNI
 }
 
 JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitSensors_SensorCallback( JNIEnv* env, jobject thiz, int id,
-        int sensor, float x,
-        float y, float z) {
+        int sensor, float x, float y, float z) {
     dbg(lvl_debug,"enter %p %p %f %f %f",thiz, (void *)id,x,y,z);
     callback_call_4((struct callback *)id, sensor, &x, &y, &z);
 }
@@ -668,8 +664,7 @@ static void start_search(struct android_search_priv *search_priv, const char *se
 }
 
 JNIEXPORT jlong JNICALL Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackStartAddressSearch( JNIEnv* env,
-        jobject thiz,
-        int partial, jobject country, jobject str) {
+        jobject thiz, int partial, jobject country, jobject str) {
     struct attr attr;
     const char *search_string =(*env)->GetStringUTFChars(env, str, NULL);
     dbg(lvl_debug,"search '%s'", search_string);
@@ -720,8 +715,7 @@ JNIEXPORT jlong JNICALL Java_org_navitproject_navit_NavitAddressSearchActivity_C
 }
 
 JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackCancelAddressSearch( JNIEnv* env,
-        jobject thiz,
-        jlong handle) {
+        jobject thiz, jlong handle) {
     struct android_search_priv *priv = (void*)(long)handle;
 
     if (priv)

--- a/navit/android.c
+++ b/navit/android.c
@@ -37,8 +37,7 @@ struct android_search_priv {
     int found;
 };
 
-int
-android_find_class_global(char *name, jclass *ret) {
+int android_find_class_global(char *name, jclass *ret) {
     *ret=(*jnienv)->FindClass(jnienv, name);
     if (! *ret) {
         dbg(lvl_error,"Failed to get Class %s",name);
@@ -48,8 +47,7 @@ android_find_class_global(char *name, jclass *ret) {
     return 1;
 }
 
-int
-android_find_method(jclass class, char *name, char *args, jmethodID *ret) {
+int android_find_method(jclass class, char *name, char *args, jmethodID *ret) {
     *ret = (*jnienv)->GetMethodID(jnienv, class, name, args);
     if (*ret == NULL) {
         dbg(lvl_error,"Failed to get Method %s with signature %s",name,args);
@@ -59,8 +57,7 @@ android_find_method(jclass class, char *name, char *args, jmethodID *ret) {
 }
 
 
-int
-android_find_static_method(jclass class, char *name, char *args, jmethodID *ret) {
+int android_find_static_method(jclass class, char *name, char *args, jmethodID *ret) {
     *ret = (*jnienv)->GetStaticMethodID(jnienv, class, name, args);
     if (*ret == NULL) {
         dbg(lvl_error,"Failed to get static Method %s with signature %s",name,args);
@@ -69,8 +66,8 @@ android_find_static_method(jclass class, char *name, char *args, jmethodID *ret)
     return 1;
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_Navit_NavitMain( JNIEnv* env, jobject thiz, jobject activity, jobject lang, int version,
+JNIEXPORT void JNICALL Java_org_navitproject_navit_Navit_NavitMain( JNIEnv* env, jobject thiz, jobject activity,
+        jobject lang, int version,
         jobject display_density_string, jobject path,  jobject map_path) {
     const char *langstr;
     const char *displaydensitystr;
@@ -98,44 +95,43 @@ Java_org_navitproject_navit_Navit_NavitMain( JNIEnv* env, jobject thiz, jobject 
     (*env)->ReleaseStringUTFChars(env, path, strings);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_Navit_NavitDestroy( JNIEnv* env) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_Navit_NavitDestroy( JNIEnv* env) {
     dbg(lvl_debug, "shutdown navit");
     exit(0);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitGraphics_SizeChangedCallback( JNIEnv* env, jobject thiz, int id, int w, int h) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_SizeChangedCallback( JNIEnv* env, jobject thiz, int id,
+        int w, int h) {
     dbg(lvl_debug,"enter %p %d %d",(struct callback *)id,w,h);
     if (id)
         callback_call_2((struct callback *)id,w,h);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitGraphics_PaddingChangedCallback(JNIEnv* env, jobject thiz, int id, int left, int top,
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_PaddingChangedCallback(JNIEnv* env, jobject thiz,
+        int id, int left, int top,
         int right, int bottom) {
     dbg(lvl_debug,"enter %p %d %d %d %d",(struct callback *)id, left, top, right, bottom);
     if (id)
         callback_call_4((struct callback *)id, left, top, right, bottom);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitGraphics_ButtonCallback( JNIEnv* env, jobject thiz, int id, int pressed, int button,
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_ButtonCallback( JNIEnv* env, jobject thiz, int id,
+        int pressed, int button,
         int x, int y) {
     dbg(lvl_debug,"enter %p %d %d",(struct callback *)id,pressed,button);
     if (id)
         callback_call_4((struct callback *)id,pressed,button,x,y);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitGraphics_MotionCallback( JNIEnv* env, jobject thiz, int id, int x, int y) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_MotionCallback( JNIEnv* env, jobject thiz, int id,
+        int x, int y) {
     dbg(lvl_debug,"enter %p %d %d",(struct callback *)id,x,y);
     if (id)
         callback_call_2((struct callback *)id,x,y);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitGraphics_KeypressCallback( JNIEnv* env, jobject thiz, int id, jobject str) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitGraphics_KeypressCallback( JNIEnv* env, jobject thiz, int id,
+        jobject str) {
     const char *s;
     dbg(lvl_debug,"enter %p %p",(struct callback *)id,str);
     s=(*env)->GetStringUTFChars(env, str, NULL);
@@ -145,47 +141,43 @@ Java_org_navitproject_navit_NavitGraphics_KeypressCallback( JNIEnv* env, jobject
     (*env)->ReleaseStringUTFChars(env, str, s);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitTimeout_TimeoutCallback( JNIEnv* env, jobject thiz, int id) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitTimeout_TimeoutCallback( JNIEnv* env, jobject thiz, int id) {
     void (*event_handler)(void *) = *(void **)id;
     dbg(lvl_debug,"enter %p %p",thiz, (void *)id);
     event_handler((void*)id);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitVehicle_VehicleCallback( JNIEnv * env, jobject thiz, int id, jobject location) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitVehicle_VehicleCallback( JNIEnv * env, jobject thiz, int id,
+        jobject location) {
     callback_call_1((struct callback *)id, (void *)location);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitIdle_IdleCallback( JNIEnv* env, jobject thiz, int id) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitIdle_IdleCallback( JNIEnv* env, jobject thiz, int id) {
     dbg(lvl_debug,"enter %p %p",thiz, (void *)id);
     callback_call_0((struct callback *)id);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitWatch_poll( JNIEnv* env, jobject thiz, int func, int fd, int cond) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitWatch_poll( JNIEnv* env, jobject thiz, int func, int fd,
+        int cond) {
     void (*pollfunc)(JNIEnv *env, int fd, int cond)=(void *)func;
 
     pollfunc(env, fd, cond);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitWatch_WatchCallback( JNIEnv* env, jobject thiz, int id) {
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitWatch_WatchCallback( JNIEnv* env, jobject thiz, int id) {
     dbg(lvl_debug,"enter %p %p",thiz, (void *)id);
     callback_call_0((struct callback *)id);
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitSensors_SensorCallback( JNIEnv* env, jobject thiz, int id, int sensor, float x,
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitSensors_SensorCallback( JNIEnv* env, jobject thiz, int id,
+        int sensor, float x,
         float y, float z) {
     dbg(lvl_debug,"enter %p %p %f %f %f",thiz, (void *)id,x,y,z);
     callback_call_4((struct callback *)id, sensor, &x, &y, &z);
 }
 
 // type: 0=town, 1=street, 2=House#
-void
-android_return_search_result(struct jni_object *jni_o, int type, struct pcoord *location, const char *address) {
+void android_return_search_result(struct jni_object *jni_o, int type, struct pcoord *location, const char *address) {
     struct coord_geo geo_location;
     struct coord c;
     jstring jaddress = NULL;
@@ -201,8 +193,8 @@ android_return_search_result(struct jni_object *jni_o, int type, struct pcoord *
     (*env)->DeleteLocalRef(jni_o->env, jaddress);
 }
 
-JNIEXPORT jstring JNICALL
-Java_org_navitproject_navit_NavitGraphics_CallbackLocalizedString( JNIEnv* env, jobject thiz, jobject str) {
+JNIEXPORT jstring JNICALL Java_org_navitproject_navit_NavitGraphics_CallbackLocalizedString( JNIEnv* env, jobject thiz,
+        jobject str) {
     const char *s;
     const char *localized_str;
 
@@ -220,8 +212,8 @@ Java_org_navitproject_navit_NavitGraphics_CallbackLocalizedString( JNIEnv* env, 
     return js;
 }
 
-JNIEXPORT jint JNICALL
-Java_org_navitproject_navit_NavitGraphics_CallbackMessageChannel( JNIEnv* env, jobject thiz, int channel, jobject str) {
+JNIEXPORT jint JNICALL Java_org_navitproject_navit_NavitGraphics_CallbackMessageChannel( JNIEnv* env, jobject thiz,
+        int channel, jobject str) {
     struct attr attr;
     const char *s;
     jint ret = 0;
@@ -380,8 +372,8 @@ Java_org_navitproject_navit_NavitGraphics_CallbackMessageChannel( JNIEnv* env, j
     return ret;
 }
 
-JNIEXPORT jstring JNICALL
-Java_org_navitproject_navit_NavitGraphics_GetDefaultCountry( JNIEnv* env, jobject thiz, int channel, jobject str) {
+JNIEXPORT jstring JNICALL Java_org_navitproject_navit_NavitGraphics_GetDefaultCountry( JNIEnv* env, jobject thiz,
+        int channel, jobject str) {
     struct attr search_attr, country_name, country_iso2, *country_attr;
     struct tracking *tracking;
     struct search_list_result *res;
@@ -418,8 +410,7 @@ Java_org_navitproject_navit_NavitGraphics_GetDefaultCountry( JNIEnv* env, jobjec
     return return_string;
 }
 
-JNIEXPORT jobjectArray JNICALL
-Java_org_navitproject_navit_NavitGraphics_GetAllCountries( JNIEnv* env, jobject thiz) {
+JNIEXPORT jobjectArray JNICALL Java_org_navitproject_navit_NavitGraphics_GetAllCountries( JNIEnv* env, jobject thiz) {
     struct attr search_attr;
     struct search_list_result *res;
     GList* countries = NULL;
@@ -469,8 +460,7 @@ Java_org_navitproject_navit_NavitGraphics_GetAllCountries( JNIEnv* env, jobject 
     return all_countries;
 }
 
-static char *
-postal_str(struct search_list_result *res, int level) {
+static char *postal_str(struct search_list_result *res, int level) {
     char *ret=NULL;
     if (res->town->common.postal)
         ret=res->town->common.postal;
@@ -491,8 +481,7 @@ postal_str(struct search_list_result *res, int level) {
     return ret;
 }
 
-static char *
-district_str(struct search_list_result *res, int level) {
+static char *district_str(struct search_list_result *res, int level) {
     char *ret=NULL;
     if (res->town->common.district_name)
         ret=res->town->common.district_name;
@@ -507,8 +496,7 @@ district_str(struct search_list_result *res, int level) {
     return ret;
 }
 
-static char *
-town_str(struct search_list_result *res, int level) {
+static char *town_str(struct search_list_result *res, int level) {
     char *town=res->town->common.town_name;
     char *district=district_str(res, level);
     char *postal=postal_str(res, level);
@@ -528,8 +516,7 @@ town_str(struct search_list_result *res, int level) {
                            county);
 }
 
-static void
-android_search_end(struct android_search_priv *search_priv) {
+static void android_search_end(struct android_search_priv *search_priv) {
     dbg(lvl_debug, "End search");
     JNIEnv* env = search_priv->search_result_obj.env;
     if (search_priv->idle_ev) {
@@ -559,8 +546,7 @@ static enum attr_type android_search_level[] = {
     attr_house_number
 };
 
-static void
-android_search_idle(struct android_search_priv *search_priv) {
+static void android_search_idle(struct android_search_priv *search_priv) {
     dbg(lvl_debug, "enter android_search_idle");
 
     struct search_list_result *res = search_list_get_result(search_priv->search_list);
@@ -634,8 +620,7 @@ android_search_idle(struct android_search_priv *search_priv) {
     dbg(lvl_info, "leave");
 }
 
-static char *
-search_fix_spaces(const char *str) {
+static char *search_fix_spaces(const char *str) {
     int i;
     int len=strlen(str);
     char c,*s,*d,*ret=g_strdup(str);
@@ -682,8 +667,8 @@ static void start_search(struct android_search_priv *search_priv, const char *se
     dbg(lvl_debug,"leave");
 }
 
-JNIEXPORT jlong JNICALL
-Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackStartAddressSearch( JNIEnv* env, jobject thiz,
+JNIEXPORT jlong JNICALL Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackStartAddressSearch( JNIEnv* env,
+        jobject thiz,
         int partial, jobject country, jobject str) {
     struct attr attr;
     const char *search_string =(*env)->GetStringUTFChars(env, str, NULL);
@@ -734,8 +719,8 @@ Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackStartAddressSearc
     return (jlong)(long)search_priv;
 }
 
-JNIEXPORT void JNICALL
-Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackCancelAddressSearch( JNIEnv* env, jobject thiz,
+JNIEXPORT void JNICALL Java_org_navitproject_navit_NavitAddressSearchActivity_CallbackCancelAddressSearch( JNIEnv* env,
+        jobject thiz,
         jlong handle) {
     struct android_search_priv *priv = (void*)(long)handle;
 

--- a/navit/announcement.c
+++ b/navit/announcement.c
@@ -38,25 +38,21 @@ announcement_new(struct attr *parent, struct attr **attrs) {
     return this_;
 }
 
-int
-announcement_get_attr(struct announcement *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int announcement_get_attr(struct announcement *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     return attr_generic_get_attr(this_->attrs, NULL, type, attr, iter);
 }
 
-int
-announcement_set_attr(struct announcement *this_, struct attr *attr) {
+int announcement_set_attr(struct announcement *this_, struct attr *attr) {
     this_->attrs=attr_generic_set_attr(this_->attrs, attr);
     return 1;
 }
 
-int
-announcement_add_attr(struct announcement *this_, struct attr *attr) {
+int announcement_add_attr(struct announcement *this_, struct attr *attr) {
     this_->attrs=attr_generic_add_attr(this_->attrs, attr);
     return 1;
 }
 
-int
-announcement_remove_attr(struct announcement *this_, struct attr *attr) {
+int announcement_remove_attr(struct announcement *this_, struct attr *attr) {
     this_->attrs=attr_generic_remove_attr(this_->attrs, attr);
     return 1;
 }

--- a/navit/atom.c
+++ b/navit/atom.c
@@ -3,15 +3,13 @@
 
 static GHashTable *atom_hash;
 
-char *
-atom_lookup(char *name) {
+char *atom_lookup(char *name) {
     if (!atom_hash)
         return NULL;
     return g_hash_table_lookup(atom_hash,name);
 }
 
-char *
-atom(char *name) {
+char *atom(char *name) {
     char *id=atom_lookup(name);
     if (id)
         return id;
@@ -22,7 +20,6 @@ atom(char *name) {
     return id;
 }
 
-void
-atom_init(void) {
+void atom_init(void) {
     atom_hash=g_hash_table_new(g_str_hash, g_str_equal);
 }

--- a/navit/attr.c
+++ b/navit/attr.c
@@ -67,8 +67,7 @@ static struct attr_name attr_names[]= {
 
 static GHashTable *attr_hash;
 
-void
-attr_create_hash(void) {
+void attr_create_hash(void) {
     int i;
     attr_hash=g_hash_table_new(g_str_hash, g_str_equal);
     for (i=0 ; i < sizeof(attr_names)/sizeof(struct attr_name) ; i++) {
@@ -76,8 +75,7 @@ attr_create_hash(void) {
     }
 }
 
-void
-attr_destroy_hash(void) {
+void attr_destroy_hash(void) {
     g_hash_table_destroy(attr_hash);
     attr_hash=NULL;
 }
@@ -90,8 +88,7 @@ attr_destroy_hash(void) {
  * @param name The attribute name
  * @return The corresponding {@code attr_type}, or {@code attr_none} if the string specifies a nonexistent or invalid attribute type.
  */
-enum attr_type
-attr_from_name(const char *name) {
+enum attr_type attr_from_name(const char *name) {
     int i;
 
     if (attr_hash)
@@ -116,8 +113,7 @@ static int attr_match(enum attr_type search, enum attr_type found);
  * The calling function should create a copy of the string if it needs to alter it or relies on the
  * string being available permanently.
  */
-char *
-attr_to_name(enum attr_type attr) {
+char *attr_to_name(enum attr_type attr) {
     int i;
 
     for (i=0 ; i < sizeof(attr_names)/sizeof(struct attr_name) ; i++) {
@@ -310,8 +306,7 @@ attr_new_from_text(const char *name, const char *value) {
  * @param flags The flags as a number
  * @return The flags in human-readable form
  */
-static char *
-flags_to_text(int flags) {
+static char *flags_to_text(int flags) {
     char *ret=g_strdup_printf("0x%x:",flags);
     if (flags & AF_ONEWAY) ret=g_strconcat_printf(ret,"%sAF_ONEWAY",ret?"|":"");
     if (flags & AF_ONEWAYREV) ret=g_strconcat_printf(ret,"%sAF_ONEWAYREV",ret?"|":"");
@@ -364,8 +359,7 @@ flags_to_text(int flags) {
  * @return The attribute data in human-readable form. The caller is responsible for calling {@code g_free()} on
  * the result when it is no longer needed.
  */
-char *
-attr_to_text_ext(struct attr *attr, char *sep, enum attr_format fmt, enum attr_format def_fmt, struct map *map) {
+char *attr_to_text_ext(struct attr *attr, char *sep, enum attr_format fmt, enum attr_format def_fmt, struct map *map) {
     char *ret;
     enum attr_type type=attr->type;
 
@@ -489,8 +483,7 @@ attr_to_text_ext(struct attr *attr, char *sep, enum attr_format fmt, enum attr_f
  * @param map The translation map, see {@code attr_to_text_ext()}
  * @param pretty Not used
  */
-char *
-attr_to_text(struct attr *attr, struct map *map, int pretty) {
+char *attr_to_text(struct attr *attr, struct map *map, int pretty) {
     return attr_to_text_ext(attr, NULL, attr_format_default, attr_format_default, map);
 }
 
@@ -519,8 +512,7 @@ attr_search(struct attr **attrs, struct attr *last, enum attr_type attr) {
     return NULL;
 }
 
-static int
-attr_match(enum attr_type search, enum attr_type found) {
+static int attr_match(enum attr_type search, enum attr_type found) {
     switch (search) {
     case attr_any:
         return 1;
@@ -562,9 +554,8 @@ attr_match(enum attr_type search, enum attr_type found) {
  * @param iter An iterator. This parameter may be NULL.
  * @return True if a matching attribute was found, false if not.
  */
-int
-attr_generic_get_attr(struct attr **attrs, struct attr **def_attrs, enum attr_type type, struct attr *attr,
-                      struct attr_iter *iter) {
+int attr_generic_get_attr(struct attr **attrs, struct attr **def_attrs, enum attr_type type, struct attr *attr,
+                          struct attr_iter *iter) {
     while (attrs && *attrs) {
         if (attr_match(type,(*attrs)->type)) {
             *attr=**attrs;
@@ -716,8 +707,7 @@ attr_generic_remove_attr(struct attr **attrs, struct attr *attr) {
     return curr;
 }
 
-enum attr_type
-attr_type_begin(enum attr_type type) {
+enum attr_type attr_type_begin(enum attr_type type) {
     if (type < attr_type_item_begin)
         return attr_none;
     if (type < attr_type_int_begin)
@@ -747,8 +737,7 @@ attr_type_begin(enum attr_type type) {
     return attr_none;
 }
 
-int
-attr_data_size(struct attr *attr) {
+int attr_data_size(struct attr *attr) {
     if (attr->type == attr_none)
         return 0;
     if (attr->type >= attr_type_string_begin && attr->type <= attr_type_string_end)
@@ -785,8 +774,7 @@ attr_data_size(struct attr *attr) {
     return 0;
 }
 
-void *
-attr_data_get(struct attr *attr) {
+void *attr_data_get(struct attr *attr) {
     if ((attr->type >= attr_type_int_begin && attr->type <= attr_type_int_end) ||
             (attr->type >= attr_type_item_type_begin && attr->type <= attr_type_item_type_end))
         return &attr->u.num;
@@ -795,8 +783,7 @@ attr_data_get(struct attr *attr) {
     return attr->u.data;
 }
 
-void
-attr_data_set(struct attr *attr, void *data) {
+void attr_data_set(struct attr *attr, void *data) {
     if ((attr->type >= attr_type_int_begin && attr->type <= attr_type_int_end) ||
             (attr->type >= attr_type_item_type_begin && attr->type <= attr_type_item_type_end))
         attr->u.num=*((int *)data);
@@ -804,8 +791,7 @@ attr_data_set(struct attr *attr, void *data) {
         attr->u.data=data;
 }
 
-void
-attr_data_set_le(struct attr * attr, void * data) {
+void attr_data_set_le(struct attr * attr, void * data) {
     if ((attr->type >= attr_type_int_begin && attr->type <= attr_type_int_end) ||
             (attr->type >= attr_type_item_type_begin && attr->type <= attr_type_item_type_end))
         attr->u.num=le32_to_cpu(*((int *)data));
@@ -819,8 +805,7 @@ attr_data_set_le(struct attr * attr, void * data) {
 
 }
 
-static void
-attr_free_content_do(struct attr *attr) {
+static void attr_free_content_do(struct attr *attr) {
     if (!attr)
         return;
     if (HAS_OBJECT_FUNC(attr->type)) {
@@ -834,20 +819,17 @@ attr_free_content_do(struct attr *attr) {
         g_free(attr->u.data);
 }
 
-void
-attr_free_content(struct attr *attr) {
+void attr_free_content(struct attr *attr) {
     attr_free_content_do(attr);
     memset(attr,0,sizeof(*attr));
 }
 
-void
-attr_free(struct attr *attr) {
+void attr_free(struct attr *attr) {
     attr_free_content_do(attr);
     g_free(attr);
 }
 
-void
-attr_dup_content(struct attr *src, struct attr *dst) {
+void attr_dup_content(struct attr *src, struct attr *dst) {
     int size;
     dst->type=src->type;
     if (src->type >= attr_type_int_begin && src->type <= attr_type_int_end)
@@ -888,8 +870,7 @@ attr_dup(struct attr *attr) {
  *
  * @param attrs The attribute list to free
  */
-void
-attr_list_free(struct attr **attrs) {
+void attr_list_free(struct attr **attrs) {
     int count=0;
     while (attrs && attrs[count]) {
         attr_free(attrs[count++]);
@@ -924,8 +905,7 @@ attr_list_dup(struct attr **attrs) {
     return ret;
 }
 
-int
-attr_from_line(char *line, char *name, int *pos, char *val_ret, char *name_ret) {
+int attr_from_line(char *line, char *name, int *pos, char *val_ret, char *name_ret) {
     int len=0,quoted;
     char *p,*e,*n;
 
@@ -985,8 +965,7 @@ attr_from_line(char *line, char *name, int *pos, char *val_ret, char *name_ret) 
  *
  * @return True if the attribute type was found, false if it was not found or if {@code types} is empty
  */
-int
-attr_types_contains(enum attr_type *types, enum attr_type type) {
+int attr_types_contains(enum attr_type *types, enum attr_type type) {
     while (types && *types != attr_none) {
         if (*types == type)
             return 1;
@@ -1007,8 +986,7 @@ attr_types_contains(enum attr_type *types, enum attr_type type) {
  *
  * @return True if the attribute type was found, false if it was not found, {@code deflt} if types is empty.
  */
-int
-attr_types_contains_default(enum attr_type *types, enum attr_type type, int deflt) {
+int attr_types_contains_default(enum attr_type *types, enum attr_type type, int deflt) {
     if (!types) {
         return deflt;
     }

--- a/navit/autoload/osso/osso.c
+++ b/navit/autoload/osso/osso.c
@@ -19,8 +19,7 @@ struct cb_hw_state_trail {
     osso_hw_state_t *state;
 };
 
-static void
-osso_display_on(struct navit *this_) {
+static void osso_display_on(struct navit *this_) {
     osso_return_t err;
     err = osso_display_blanking_pause(osso_context);
     dbg(lvl_warning, "Unblank result: ",
@@ -29,8 +28,7 @@ osso_display_on(struct navit *this_) {
                                  "Invalid context"));
 }
 
-static gboolean
-osso_cb_hw_state_idle(struct cb_hw_state_trail * params) {
+static gboolean osso_cb_hw_state_idle(struct cb_hw_state_trail * params) {
     dbg(lvl_debug, "(inact=%d, save=%d, shut=%d, memlow=%d, state=%d)",
         params->state->system_inactivity_ind,
         params->state->save_unsaved_data_ind, params->state->shutdown_ind,
@@ -53,8 +51,7 @@ osso_cb_hw_state_idle(struct cb_hw_state_trail * params) {
  * * @param  data ptr to private data
  * * @returns nothing
  **/
-static void
-osso_cb_hw_state(osso_hw_state_t * state, gpointer data) {
+static void osso_cb_hw_state(osso_hw_state_t * state, gpointer data) {
     struct navit *nav = (struct navit*)data;
     struct cb_hw_state_trail *params = g_new(struct cb_hw_state_trail,1);
     params->nav=nav;
@@ -63,8 +60,7 @@ osso_cb_hw_state(osso_hw_state_t * state, gpointer data) {
     g_idle_add((GSourceFunc) osso_cb_hw_state_idle, params);
 }
 
-static void
-osso_navit(struct navit *nav, int add) {
+static void osso_navit(struct navit *nav, int add) {
     dbg(lvl_debug, "Installing osso context for org.navit_project.navit");
     osso_context = osso_initialize("org.navit_project.navit", version, TRUE, NULL);
     if (osso_context == NULL) {
@@ -78,8 +74,7 @@ osso_navit(struct navit *nav, int add) {
     }
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     //struct callback *cb;
 
     dbg(lvl_info, "enter");
@@ -88,7 +83,6 @@ plugin_init(void) {
     config_add_attr(config, &callback);
 }
 
-void
-plugin_deinit(void) {
+void plugin_deinit(void) {
     osso_deinitialize(osso_context);
 }

--- a/navit/binding/dbus/binding_dbus.c
+++ b/navit/binding/dbus/binding_dbus.c
@@ -80,8 +80,7 @@ struct dbus_callback {
     char *signal;
 };
 
-static char *
-object_new(char *type, void *object) {
+static char *object_new(char *type, void *object) {
     int id;
     char *ret;
     dbg(lvl_debug,"enter %s", type);
@@ -96,13 +95,11 @@ object_new(char *type, void *object) {
     return (ret);
 }
 
-static void *
-object_get(const char *path) {
+static void *object_get(const char *path) {
     return g_hash_table_lookup(object_hash, path);
 }
 
-static void
-object_destroy(const char *path, void *object) {
+static void object_destroy(const char *path, void *object) {
     if (!path && !object)
         return;
     if (!object)
@@ -113,8 +110,7 @@ object_destroy(const char *path, void *object) {
     g_hash_table_remove(object_hash_rev, object);
 }
 
-static void *
-resolve_object(const char *opath, char *type) {
+static void *resolve_object(const char *opath, char *type) {
     char *prefix;
     const char *oprefix;
     void *ret=NULL;
@@ -213,8 +209,7 @@ resolve_object(const char *opath, char *type) {
     return NULL;
 }
 
-static void *
-object_get_from_message_arg(DBusMessageIter *iter, char *type) {
+static void *object_get_from_message_arg(DBusMessageIter *iter, char *type) {
     char *opath;
 
     if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_OBJECT_PATH)
@@ -224,13 +219,11 @@ object_get_from_message_arg(DBusMessageIter *iter, char *type) {
     return resolve_object(opath, type);
 }
 
-static void *
-object_get_from_message(DBusMessage *message, char *type) {
+static void *object_get_from_message(DBusMessage *message, char *type) {
     return resolve_object(dbus_message_get_path(message), type);
 }
 
-static enum attr_type
-attr_type_get_from_message(DBusMessageIter *iter) {
+static enum attr_type attr_type_get_from_message(DBusMessageIter *iter) {
     char *attr_type;
 
     if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_STRING)
@@ -240,16 +233,14 @@ attr_type_get_from_message(DBusMessageIter *iter) {
     return attr_from_name(attr_type);
 }
 
-static void
-encode_variant_string(DBusMessageIter *iter, char *str) {
+static void encode_variant_string(DBusMessageIter *iter, char *str) {
     DBusMessageIter variant;
     dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, DBUS_TYPE_STRING_AS_STRING, &variant);
     dbus_message_iter_append_basic(&variant, DBUS_TYPE_STRING, &str);
     dbus_message_iter_close_container(iter, &variant);
 }
 
-static void
-encode_dict_string_variant_string(DBusMessageIter *iter, char *key, char *value) {
+static void encode_dict_string_variant_string(DBusMessageIter *iter, char *key, char *value) {
     DBusMessageIter dict;
     dbus_message_iter_open_container(iter, DBUS_TYPE_DICT_ENTRY, NULL, &dict);
     dbus_message_iter_append_basic(&dict, DBUS_TYPE_STRING, &key);
@@ -257,8 +248,7 @@ encode_dict_string_variant_string(DBusMessageIter *iter, char *key, char *value)
     dbus_message_iter_close_container(iter, &dict);
 }
 
-static int
-encode_attr(DBusMessageIter *iter1, struct attr *attr) {
+static int encode_attr(DBusMessageIter *iter1, struct attr *attr) {
     char *name=attr_to_name(attr->type);
     DBusMessageIter iter2,iter3;
     dbus_message_iter_append_basic(iter1, DBUS_TYPE_STRING, &name);
@@ -305,8 +295,7 @@ encode_attr(DBusMessageIter *iter1, struct attr *attr) {
 }
 
 
-static DBusHandlerResult
-empty_reply(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult empty_reply(DBusConnection *connection, DBusMessage *message) {
     DBusMessage *reply;
 
     reply = dbus_message_new_method_return(message);
@@ -317,8 +306,7 @@ empty_reply(DBusConnection *connection, DBusMessage *message) {
 }
 
 
-static DBusHandlerResult
-dbus_error(DBusConnection *connection, DBusMessage *message, char *error, char *msg) {
+static DBusHandlerResult dbus_error(DBusConnection *connection, DBusMessage *message, char *error, char *msg) {
     DBusMessage *reply;
 
     reply = dbus_message_new_error(message, error, msg);
@@ -327,34 +315,28 @@ dbus_error(DBusConnection *connection, DBusMessage *message, char *error, char *
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-static DBusHandlerResult
-dbus_error_invalid_attr_type(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult dbus_error_invalid_attr_type(DBusConnection *connection, DBusMessage *message) {
     return dbus_error(connection, message, DBUS_ERROR_INVALID_ARGS, "attribute type invalid");
 }
 
-static DBusHandlerResult
-dbus_error_invalid_parameter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult dbus_error_invalid_parameter(DBusConnection *connection, DBusMessage *message) {
     return dbus_error(connection, message, DBUS_ERROR_INVALID_ARGS, "parameter invalid");
 }
 
-static DBusHandlerResult
-dbus_error_invalid_object_path(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult dbus_error_invalid_object_path(DBusConnection *connection, DBusMessage *message) {
     return dbus_error(connection, message, DBUS_ERROR_BAD_ADDRESS, "object path invalid");
 }
 
-static DBusHandlerResult
-dbus_error_invalid_object_path_parameter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult dbus_error_invalid_object_path_parameter(DBusConnection *connection, DBusMessage *message) {
     return dbus_error(connection, message, DBUS_ERROR_BAD_ADDRESS, "object path parameter invalid");
 }
 
-static DBusHandlerResult
-dbus_error_navigation_not_configured(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult dbus_error_navigation_not_configured(DBusConnection *connection, DBusMessage *message) {
     return dbus_error(connection, message, DBUS_ERROR_FAILED,
                       "navigation is not configured (no <navigation> element in config file?)");
 }
 
-static DBusHandlerResult
-dbus_error_no_data_available(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult dbus_error_no_data_available(DBusConnection *connection, DBusMessage *message) {
 #if 1
     return dbus_error(connection, message, DBUS_ERROR_FILE_NOT_FOUND, "no data available");
 #else
@@ -363,8 +345,7 @@ dbus_error_no_data_available(DBusConnection *connection, DBusMessage *message) {
 }
 
 #if 0
-static void
-dbus_dump_iter(char *prefix, DBusMessageIter *iter) {
+static void dbus_dump_iter(char *prefix, DBusMessageIter *iter) {
     char *prefixr,*vals;
     int arg,vali;
     DBusMessageIter iterr;
@@ -413,8 +394,7 @@ dbus_dump_iter(char *prefix, DBusMessageIter *iter) {
     }
 }
 
-static void
-dbus_dump(DBusMessage *message) {
+static void dbus_dump(DBusMessage *message) {
     DBusMessageIter iter;
 
     dbus_message_iter_init(message, &iter);
@@ -431,8 +411,7 @@ dbus_dump(DBusMessage *message) {
  * @param pc Pointer where the data should get stored
  * @returns Returns 1 when everything went right, otherwise 0
  */
-static int
-pcoord_get_from_message(DBusMessage *message, DBusMessageIter *iter, struct pcoord *pc) {
+static int pcoord_get_from_message(DBusMessage *message, DBusMessageIter *iter, struct pcoord *pc) {
 
     if(!strcmp(dbus_message_iter_get_signature(iter), "s")) {
         char *coordstring;
@@ -476,8 +455,7 @@ pcoord_get_from_message(DBusMessage *message, DBusMessageIter *iter, struct pcoo
 
 }
 
-static void
-pcoord_encode(DBusMessageIter *iter, struct pcoord *pc) {
+static void pcoord_encode(DBusMessageIter *iter, struct pcoord *pc) {
     DBusMessageIter iter2;
     dbus_message_iter_open_container(iter,DBUS_TYPE_STRUCT,NULL,&iter2);
     if (pc) {
@@ -493,8 +471,7 @@ pcoord_encode(DBusMessageIter *iter, struct pcoord *pc) {
     dbus_message_iter_close_container(iter, &iter2);
 }
 
-static enum attr_type
-decode_attr_type_from_iter(DBusMessageIter *iter) {
+static enum attr_type decode_attr_type_from_iter(DBusMessageIter *iter) {
     char *attr_type;
     enum attr_type ret;
 
@@ -507,8 +484,7 @@ decode_attr_type_from_iter(DBusMessageIter *iter) {
     return ret;
 }
 
-static int
-decode_attr_from_iter(DBusMessageIter *iter, struct attr *attr) {
+static int decode_attr_from_iter(DBusMessageIter *iter, struct attr *attr) {
     DBusMessageIter iterattr, iterstruct;
     int ret=1;
     double d;
@@ -628,28 +604,25 @@ decode_attr_from_iter(DBusMessageIter *iter, struct attr *attr) {
     return 0;
 }
 
-static int
-decode_attr(DBusMessage *message, struct attr *attr) {
+static int decode_attr(DBusMessage *message, struct attr *attr) {
     DBusMessageIter iter;
 
     dbus_message_iter_init(message, &iter);
     return decode_attr_from_iter(&iter, attr);
 }
 
-static void
-destroy_attr(struct attr *attr) {
+static void destroy_attr(struct attr *attr) {
     if(attr->type > attr_type_double_begin && attr->type < attr_type_double_end) {
         g_free(attr->u.numd);
     }
 }
 
-static char *
-get_iter_name(char *type) {
+static char *get_iter_name(char *type) {
     return g_strdup_printf("%s_attr_iter",type);
 }
 
-static DBusHandlerResult
-request_attr_iter(DBusConnection *connection, DBusMessage *message, char *type, struct attr_iter *(*func)(void)) {
+static DBusHandlerResult request_attr_iter(DBusConnection *connection, DBusMessage *message, char *type,
+        struct attr_iter *(*func)(void)) {
     DBusMessage *reply;
     char *iter_name;
     char *opath;
@@ -667,9 +640,8 @@ request_attr_iter(DBusConnection *connection, DBusMessage *message, char *type, 
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-static DBusHandlerResult
-request_attr_iter_destroy(DBusConnection *connection, DBusMessage *message, char *type,
-                          void (*func)(struct attr_iter *)) {
+static DBusHandlerResult request_attr_iter_destroy(DBusConnection *connection, DBusMessage *message, char *type,
+        void (*func)(struct attr_iter *)) {
     struct attr_iter *attr_iter;
     DBusMessageIter iter;
     char *iter_name;
@@ -686,8 +658,8 @@ request_attr_iter_destroy(DBusConnection *connection, DBusMessage *message, char
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_destroy(DBusConnection *connection, DBusMessage *message, char *type, void *data, void (*func)(void *)) {
+static DBusHandlerResult request_destroy(DBusConnection *connection, DBusMessage *message, char *type, void *data,
+        void (*func)(void *)) {
     if (!data)
         data=object_get_from_message(message, type);
     if (!data)
@@ -699,8 +671,8 @@ request_destroy(DBusConnection *connection, DBusMessage *message, char *type, vo
 }
 
 
-static DBusHandlerResult
-request_dup(DBusConnection *connection, DBusMessage *message, char *type, void *data, void *(*func)(void *)) {
+static DBusHandlerResult request_dup(DBusConnection *connection, DBusMessage *message, char *type, void *data,
+                                     void *(*func)(void *)) {
     DBusMessage *reply;
     char *opath;
     void *obj;
@@ -719,9 +691,9 @@ request_dup(DBusConnection *connection, DBusMessage *message, char *type, void *
 }
 
 
-static DBusHandlerResult
-request_get_attr(DBusConnection *connection, DBusMessage *message, char *type, void *data, int (*func)(void *data,
-                 enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
+static DBusHandlerResult request_get_attr(DBusConnection *connection, DBusMessage *message, char *type, void *data,
+        int (*func)(void *data,
+                    enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
     DBusMessage *reply;
     DBusMessageIter iter;
     struct attr attr;
@@ -754,9 +726,9 @@ request_get_attr(DBusConnection *connection, DBusMessage *message, char *type, v
 
 }
 
-static DBusHandlerResult
-request_command(DBusConnection *connection, DBusMessage *message, char *type, void *data, int (*func)(void *data,
-                enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
+static DBusHandlerResult request_command(DBusConnection *connection, DBusMessage *message, char *type, void *data,
+        int (*func)(void *data,
+                    enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
     DBusMessageIter iter;
     struct attr attr;
     char *command;
@@ -779,9 +751,9 @@ request_command(DBusConnection *connection, DBusMessage *message, char *type, vo
 
 }
 
-static DBusHandlerResult
-request_set_add_remove_attr(DBusConnection *connection, DBusMessage *message, char *type, void *data,
-                            int (*func)(void *data, struct attr *attr)) {
+static DBusHandlerResult request_set_add_remove_attr(DBusConnection *connection, DBusMessage *message, char *type,
+        void *data,
+        int (*func)(void *data, struct attr *attr)) {
     struct attr attr;
     int ret;
 
@@ -805,8 +777,7 @@ request_set_add_remove_attr(DBusConnection *connection, DBusMessage *message, ch
 /* callback */
 
 
-static void
-dbus_callback_emit_signal(struct dbus_callback *dbus_callback) {
+static void dbus_callback_emit_signal(struct dbus_callback *dbus_callback) {
     DBusMessage* msg;
     msg = dbus_message_new_signal(object_path, service_name, dbus_callback->signal);
     if (msg) {
@@ -816,20 +787,17 @@ dbus_callback_emit_signal(struct dbus_callback *dbus_callback) {
     }
 }
 
-static void
-request_callback_destroy_do(struct dbus_callback *data) {
+static void request_callback_destroy_do(struct dbus_callback *data) {
     callback_destroy(data->callback);
     g_free(data->signal);
     g_free(data);
 }
 
-static DBusHandlerResult
-request_callback_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_callback_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_destroy(connection, message, "callback", NULL, (void (*)(void *)) request_callback_destroy_do);
 }
 
-static DBusHandlerResult
-request_callback_new(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_callback_new(DBusConnection *connection, DBusMessage *message) {
     DBusMessageIter iter;
     DBusMessage *reply;
     struct dbus_callback *callback;
@@ -858,19 +826,16 @@ request_callback_new(DBusConnection *connection, DBusMessage *message) {
 }
 
 /* config */
-static DBusHandlerResult
-request_config_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_config_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "config", config, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))config_get_attr);
 }
 
-static DBusHandlerResult
-request_config_attr_iter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_config_attr_iter(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter(connection, message, "config", (struct attr_iter * (*)(void))config_attr_iter_new);
 }
 
-static DBusHandlerResult
-request_config_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_config_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter_destroy(connection, message, "config", (void (*)(struct attr_iter *))config_attr_iter_destroy);
 }
 
@@ -878,8 +843,7 @@ request_config_attr_iter_destroy(DBusConnection *connection, DBusMessage *messag
 
 /* graphics */
 
-static DBusHandlerResult
-request_graphics_get_data(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_graphics_get_data(DBusConnection *connection, DBusMessage *message) {
     struct graphics *graphics;
     char *data;
     struct graphics_data_image *image;
@@ -912,30 +876,26 @@ request_graphics_get_data(DBusConnection *connection, DBusMessage *message) {
 
 /* gui */
 
-static DBusHandlerResult
-request_gui_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_gui_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "gui", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))gui_get_attr);
 }
 
-static DBusHandlerResult
-request_gui_command(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_gui_command(DBusConnection *connection, DBusMessage *message) {
     return request_command(connection, message, "gui", NULL, (int (*)(void *, enum attr_type, struct attr *,
                            struct attr_iter *))gui_get_attr);
 }
 
 
 
-static DBusHandlerResult
-request_graphics_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_graphics_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "graphics", NULL, (int (*)(void *,
                                        struct attr *))graphics_set_attr);
 }
 
 /* layout */
 
-static DBusHandlerResult
-request_layout_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_layout_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "layout", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))layout_get_attr);
 }
@@ -944,20 +904,17 @@ request_layout_get_attr(DBusConnection *connection, DBusMessage *message) {
 
 /* map */
 
-static DBusHandlerResult
-request_map_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_map_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "map", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))map_get_attr);
 }
 
 
-static DBusHandlerResult
-request_map_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_map_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "map", NULL, (int (*)(void *, struct attr *))map_set_attr);
 }
 
-static DBusHandlerResult
-request_map_dump(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_map_dump(DBusConnection *connection, DBusMessage *message) {
     DBusMessageIter iter;
     struct map *map;
 
@@ -982,110 +939,93 @@ request_map_dump(DBusConnection *connection, DBusMessage *message) {
 
 /* mapset */
 
-static DBusHandlerResult
-request_mapset_attr_iter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_mapset_attr_iter(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter(connection, message, "mapset", (struct attr_iter * (*)(void))mapset_attr_iter_new);
 }
 
-static DBusHandlerResult
-request_mapset_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_mapset_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter_destroy(connection, message, "mapset", (void (*)(struct attr_iter *))mapset_attr_iter_destroy);
 }
 
-static DBusHandlerResult
-request_mapset_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_mapset_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "mapset", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))mapset_get_attr);
 }
 
 /* navigation */
 
-static DBusHandlerResult
-request_navigation_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navigation_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "navigation", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))navigation_get_attr);
 }
 
 /* osd */
 
-static DBusHandlerResult
-request_osd_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_osd_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "osd", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))osd_get_attr);
 }
 
 
-static DBusHandlerResult
-request_osd_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_osd_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "osd", NULL, (int (*)(void *, struct attr *))osd_set_attr);
 }
 
 /* roadprofile */
 
-static DBusHandlerResult
-request_roadprofile_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_roadprofile_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "roadprofile", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))roadprofile_get_attr);
 }
 
 
-static DBusHandlerResult
-request_roadprofile_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_roadprofile_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "roadprofile", NULL, (int (*)(void *,
                                        struct attr *))roadprofile_set_attr);
 }
 
-static DBusHandlerResult
-request_roadprofile_attr_iter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_roadprofile_attr_iter(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter(connection, message, "roadprofile", (struct attr_iter * (*)(void))roadprofile_attr_iter_new);
 }
 
-static DBusHandlerResult
-request_roadprofile_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_roadprofile_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter_destroy(connection, message, "roadprofile",
                                      (void (*)(struct attr_iter *))roadprofile_attr_iter_destroy);
 }
 
 /* route */
 
-static DBusHandlerResult
-request_route_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_route_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "route", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))route_get_attr);
 }
 
 
-static DBusHandlerResult
-request_route_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_route_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "route", NULL, (int (*)(void *, struct attr *))route_set_attr);
 }
 
-static DBusHandlerResult
-request_route_add_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_route_add_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "route", NULL, (int (*)(void *, struct attr *))route_add_attr);
 }
 
-static DBusHandlerResult
-request_route_remove_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_route_remove_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "route", NULL, (int (*)(void *,
                                        struct attr *))route_remove_attr);
 }
 
-static DBusHandlerResult
-request_route_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_route_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_destroy(connection, message, "route", NULL, (void (*)(void *)) route_destroy);
 }
 
-static DBusHandlerResult
-request_route_dup(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_route_dup(DBusConnection *connection, DBusMessage *message) {
     return request_dup(connection, message, "route", NULL, (void *(*)(void *)) route_dup);
 }
 
 
 /* navit */
 
-static DBusHandlerResult
-request_navit_draw(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_draw(DBusConnection *connection, DBusMessage *message) {
     struct navit *navit;
 
     navit=object_get_from_message(message, "navit");
@@ -1106,8 +1046,7 @@ request_navit_draw(DBusConnection *connection, DBusMessage *message) {
  * @param p Pointer where the data should get stored
  * @returns Returns 1 when everything went right, otherwise 0
  */
-static int
-point_get_from_message(DBusMessage *message, DBusMessageIter *iter, struct point *p) {
+static int point_get_from_message(DBusMessage *message, DBusMessageIter *iter, struct point *p) {
     DBusMessageIter iter2;
 
     dbg(lvl_debug,"%s", dbus_message_iter_get_signature(iter));
@@ -1141,8 +1080,7 @@ point_get_from_message(DBusMessage *message, DBusMessageIter *iter, struct point
  * @returns An empty reply if everything went right, otherwise DBUS_HANDLER_RESULT_NOT_YET_HANDLED
  */
 
-static DBusHandlerResult
-request_navit_add_message(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_add_message(DBusConnection *connection, DBusMessage *message) {
     struct navit *navit;
     char *usermessage;
 
@@ -1168,8 +1106,7 @@ request_navit_add_message(DBusConnection *connection, DBusMessage *message) {
  * @returns An empty reply if everything went right, otherwise DBUS_HANDLER_RESULT_NOT_YET_HANDLED
  */
 
-static DBusHandlerResult
-request_navit_set_center(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_set_center(DBusConnection *connection, DBusMessage *message) {
     struct pcoord pc;
     struct navit *navit;
     DBusMessageIter iter;
@@ -1193,8 +1130,7 @@ request_navit_set_center(DBusConnection *connection, DBusMessage *message) {
  * @param message The DBusMessage containing the x and y value
  * @returns An empty reply if everything went right, otherwise DBUS_HANDLER_RESULT_NOT_YET_HANDLED
  */
-static DBusHandlerResult
-request_navit_set_center_screen(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_set_center_screen(DBusConnection *connection, DBusMessage *message) {
     struct point p;
     struct navit *navit;
     DBusMessageIter iter;
@@ -1217,8 +1153,7 @@ request_navit_set_center_screen(DBusConnection *connection, DBusMessage *message
  * @param message The DBusMessage containing the name of the layout
  * @returns An empty reply if everything went right, otherwise DBUS_HANDLER_RESULT_NOT_YET_HANDLED
  */
-static DBusHandlerResult
-request_navit_set_layout(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_set_layout(DBusConnection *connection, DBusMessage *message) {
     char *new_layout_name;
     struct navit *navit;
     struct attr attr;
@@ -1246,8 +1181,7 @@ request_navit_set_layout(DBusConnection *connection, DBusMessage *message) {
  * @param message The DBusMessage
  * @returns An empty reply if everything went right, otherwise DBUS_HANDLER_RESULT_NOT_YET_HANDLED
  */
-static DBusHandlerResult
-request_navit_quit(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_quit(DBusConnection *connection, DBusMessage *message) {
     dbg(lvl_debug,"Got a quit request from DBUS");
     struct attr navit;
     navit.type=attr_navit;
@@ -1264,8 +1198,7 @@ request_navit_quit(DBusConnection *connection, DBusMessage *message) {
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_navit_zoom(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_zoom(DBusConnection *connection, DBusMessage *message) {
     int factor;
     struct point p, *pp=NULL;
     struct navit *navit;
@@ -1296,8 +1229,7 @@ request_navit_zoom(DBusConnection *connection, DBusMessage *message) {
 
 }
 
-static DBusHandlerResult
-request_navit_zoom_to_route(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_zoom_to_route(DBusConnection *connection, DBusMessage *message) {
     struct navit *navit;
     DBusMessageIter iter;
 
@@ -1321,8 +1253,7 @@ request_navit_zoom_to_route(DBusConnection *connection, DBusMessage *message) {
  * @param message The DBusMessage including the `filename` parameter
  * @returns An empty reply if everything went right, otherwise `DBUS_HANDLER_RESULT_NOT_YET_HANDLED`
  */
-static DBusHandlerResult
-request_navit_route_export_gpx(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_route_export_gpx(DBusConnection *connection, DBusMessage *message) {
     char * filename;
     struct navit *navit;
     DBusMessageIter iter;
@@ -1387,8 +1318,7 @@ request_navit_route_export_gpx(DBusConnection *connection, DBusMessage *message)
  * @param message The DBusMessage including the 'filename' parameter
  * @returns An empty reply if everything went right, otherwise DBUS_HANDLER_RESULT_NOT_YET_HANDLED
  */
-static DBusHandlerResult
-request_navit_route_export_geojson(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_route_export_geojson(DBusConnection *connection, DBusMessage *message) {
     char * filename;
     struct point p;
     struct navit *navit;
@@ -1470,8 +1400,7 @@ request_navit_route_export_geojson(DBusConnection *connection, DBusMessage *mess
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_navit_block(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_block(DBusConnection *connection, DBusMessage *message) {
     int mode;
     struct navit *navit;
     DBusMessageIter iter;
@@ -1489,8 +1418,7 @@ request_navit_block(DBusConnection *connection, DBusMessage *message) {
 
 }
 
-static DBusHandlerResult
-request_navit_resize(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_resize(DBusConnection *connection, DBusMessage *message) {
     struct navit *navit;
     int w, h;
     DBusMessageIter iter;
@@ -1520,14 +1448,12 @@ request_navit_resize(DBusConnection *connection, DBusMessage *message) {
 
 }
 
-static DBusHandlerResult
-request_navit_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "navit", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))navit_get_attr);
 }
 
-static DBusHandlerResult
-request_navit_attr_iter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_attr_iter(DBusConnection *connection, DBusMessage *message) {
     DBusMessage *reply;
     struct attr_iter *attr_iter=navit_attr_iter_new();
     char *opath=object_new("navit_attr_iter",attr_iter);
@@ -1539,8 +1465,7 @@ request_navit_attr_iter(DBusConnection *connection, DBusMessage *message) {
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-static DBusHandlerResult
-request_navit_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
     struct attr_iter *attr_iter;
     DBusMessageIter iter;
 
@@ -1554,24 +1479,20 @@ request_navit_attr_iter_destroy(DBusConnection *connection, DBusMessage *message
 }
 
 
-static DBusHandlerResult
-request_navit_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "navit", NULL, (int (*)(void *, struct attr *))navit_set_attr);
 }
 
-static DBusHandlerResult
-request_navit_add_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_add_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "navit", NULL, (int (*)(void *, struct attr *))navit_add_attr);
 }
 
-static DBusHandlerResult
-request_navit_remove_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_remove_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "navit", NULL, (int (*)(void *,
                                        struct attr *))navit_remove_attr);
 }
 
-static DBusHandlerResult
-request_navit_set_position(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_set_position(DBusConnection *connection, DBusMessage *message) {
     struct pcoord pc;
     struct navit *navit;
     DBusMessageIter iter;
@@ -1588,8 +1509,7 @@ request_navit_set_position(DBusConnection *connection, DBusMessage *message) {
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_navit_set_destination(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_set_destination(DBusConnection *connection, DBusMessage *message) {
     struct pcoord pc;
     struct navit *navit;
     DBusMessageIter iter;
@@ -1611,8 +1531,7 @@ request_navit_set_destination(DBusConnection *connection, DBusMessage *message) 
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_navit_clear_destination(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_clear_destination(DBusConnection *connection, DBusMessage *message) {
     struct navit *navit;
 
     navit = object_get_from_message(message, "navit");
@@ -1622,8 +1541,7 @@ request_navit_clear_destination(DBusConnection *connection, DBusMessage *message
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_navit_evaluate(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_navit_evaluate(DBusConnection *connection, DBusMessage *message) {
     struct navit *navit;
     char *command;
     char *result;
@@ -1652,21 +1570,18 @@ request_navit_evaluate(DBusConnection *connection, DBusMessage *message) {
 
 /* search_list */
 
-static DBusHandlerResult
-request_search_list_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_search_list_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_destroy(connection, message, "search_list", NULL, (void (*)(void *)) search_list_destroy);
 }
 
-static void
-request_search_list_common(struct search_list_common *slc, DBusMessageIter *iter4) {
+static void request_search_list_common(struct search_list_common *slc, DBusMessageIter *iter4) {
     if (slc->postal)
         encode_dict_string_variant_string(iter4, "postal", slc->postal);
     if (slc->postal_mask)
         encode_dict_string_variant_string(iter4, "postal_mask", slc->postal_mask);
 }
 
-static DBusHandlerResult
-request_search_list_get_result(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_search_list_get_result(DBusConnection *connection, DBusMessage *message) {
     struct search_list *search_list;
     struct search_list_result *result;
     DBusMessage *reply;
@@ -1740,8 +1655,7 @@ request_search_list_get_result(DBusConnection *connection, DBusMessage *message)
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-static DBusHandlerResult
-request_search_list_new(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_search_list_new(DBusConnection *connection, DBusMessage *message) {
     DBusMessageIter iter;
     DBusMessage *reply;
     struct mapset *mapset;
@@ -1761,8 +1675,7 @@ request_search_list_new(DBusConnection *connection, DBusMessage *message) {
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-static DBusHandlerResult
-request_search_list_search(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_search_list_search(DBusConnection *connection, DBusMessage *message) {
     DBusMessageIter iter;
     struct search_list *search_list;
     struct attr attr;
@@ -1782,8 +1695,7 @@ request_search_list_search(DBusConnection *connection, DBusMessage *message) {
     return empty_reply(connection, message);
 }
 
-static DBusHandlerResult
-request_search_list_select(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_search_list_select(DBusConnection *connection, DBusMessage *message) {
     DBusMessageIter iter;
     struct search_list *search_list;
     int id, mode;
@@ -1809,8 +1721,7 @@ request_search_list_select(DBusConnection *connection, DBusMessage *message) {
 
 /* tracking */
 
-static DBusHandlerResult
-request_tracking_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_tracking_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "tracking", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))tracking_get_attr);
 }
@@ -1819,8 +1730,7 @@ request_tracking_get_attr(DBusConnection *connection, DBusMessage *message) {
 
 /* vehicle */
 
-static DBusHandlerResult
-request_vehicle_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_vehicle_set_attr(DBusConnection *connection, DBusMessage *message) {
     struct vehicle *vehicle;
     struct attr attr;
     int ret;
@@ -1839,27 +1749,23 @@ request_vehicle_set_attr(DBusConnection *connection, DBusMessage *message) {
 
 /* vehicleprofile */
 
-static DBusHandlerResult
-request_vehicleprofile_get_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_vehicleprofile_get_attr(DBusConnection *connection, DBusMessage *message) {
     return request_get_attr(connection, message, "vehicleprofile", NULL, (int (*)(void *, enum attr_type, struct attr *,
                             struct attr_iter *))vehicleprofile_get_attr);
 }
 
 
-static DBusHandlerResult
-request_vehicleprofile_set_attr(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_vehicleprofile_set_attr(DBusConnection *connection, DBusMessage *message) {
     return request_set_add_remove_attr(connection, message, "vehicleprofile", NULL, (int (*)(void *,
                                        struct attr *))vehicleprofile_set_attr);
 }
 
-static DBusHandlerResult
-request_vehicleprofile_attr_iter(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_vehicleprofile_attr_iter(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter(connection, message, "vehicleprofile",
                              (struct attr_iter * (*)(void))vehicleprofile_attr_iter_new);
 }
 
-static DBusHandlerResult
-request_vehicleprofile_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
+static DBusHandlerResult request_vehicleprofile_attr_iter_destroy(DBusConnection *connection, DBusMessage *message) {
     return request_attr_iter_destroy(connection, message, "vehicleprofile",
                                      (void (*)(struct attr_iter *))vehicleprofile_attr_iter_destroy);
 }
@@ -1953,8 +1859,7 @@ struct dbus_method {
     {".vehicleprofile","attr_iter_destroy","o",   "attr_iter",                               "",   "",      request_vehicleprofile_attr_iter_destroy},
 };
 
-static char *
-introspect_path(const char *object) {
+static char *introspect_path(const char *object) {
     char *ret;
     int i;
     char *def=".default_";
@@ -1982,8 +1887,7 @@ introspect_path(const char *object) {
     return ret;
 }
 
-static char *
-generate_navitintrospectxml(const char *object) {
+static char *generate_navitintrospectxml(const char *object) {
     int i,methods_size,n=0;
     char *navitintrospectxml;
     char *path=introspect_path(object);
@@ -2030,8 +1934,7 @@ generate_navitintrospectxml(const char *object) {
     return navitintrospectxml;
 }
 
-static DBusHandlerResult
-navit_handler_func(DBusConnection *connection, DBusMessage *message, void *user_data) {
+static DBusHandlerResult navit_handler_func(DBusConnection *connection, DBusMessage *message, void *user_data) {
     int i;
     char *path;
     dbg(lvl_debug,"type=%s interface=%s path=%s member=%s signature=%s",
@@ -2071,8 +1974,7 @@ static DBusObjectPathVTable dbus_navit_vtable = {
 };
 
 #if 0
-DBusHandlerResult
-filter(DBusConnection *connection, DBusMessage *message, void *user_data) {
+DBusHandlerResult filter(DBusConnection *connection, DBusMessage *message, void *user_data) {
     dbg(lvl_debug,"type=%s interface=%s path=%s member=%s signature=%s",
         dbus_message_type_to_string(dbus_message_get_type(message)), dbus_message_get_interface(message),
         dbus_message_get_path(message), dbus_message_get_member(message), dbus_message_get_signature(message));
@@ -2082,8 +1984,7 @@ filter(DBusConnection *connection, DBusMessage *message, void *user_data) {
 }
 #endif
 
-static int
-dbus_cmd_send_signal(struct navit *navit, char *command, struct attr **in, struct attr ***out) {
+static int dbus_cmd_send_signal(struct navit *navit, char *command, struct attr **in, struct attr ***out) {
     DBusMessage* msg;
     char *opath=object_new("navit",navit);
     char *interface=g_strdup_printf("%s%s", service_name, ".navit");
@@ -2116,8 +2017,7 @@ static struct command_table commands[] = {
 };
 
 
-static void
-dbus_main_navit(struct navit *navit, int added) {
+static void dbus_main_navit(struct navit *navit, int added) {
     struct attr attr;
     if (added==1) {
         DBusMessage* msg;

--- a/navit/binding/dbus/binding_dbus.c
+++ b/navit/binding/dbus/binding_dbus.c
@@ -692,8 +692,7 @@ static DBusHandlerResult request_dup(DBusConnection *connection, DBusMessage *me
 
 
 static DBusHandlerResult request_get_attr(DBusConnection *connection, DBusMessage *message, char *type, void *data,
-        int (*func)(void *data,
-                    enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
+        int (*func)(void *data, enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
     DBusMessage *reply;
     DBusMessageIter iter;
     struct attr attr;
@@ -727,8 +726,7 @@ static DBusHandlerResult request_get_attr(DBusConnection *connection, DBusMessag
 }
 
 static DBusHandlerResult request_command(DBusConnection *connection, DBusMessage *message, char *type, void *data,
-        int (*func)(void *data,
-                    enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
+        int (*func)(void *data, enum attr_type type, struct attr *attr, struct attr_iter *iter)) {
     DBusMessageIter iter;
     struct attr attr;
     char *command;
@@ -752,8 +750,7 @@ static DBusHandlerResult request_command(DBusConnection *connection, DBusMessage
 }
 
 static DBusHandlerResult request_set_add_remove_attr(DBusConnection *connection, DBusMessage *message, char *type,
-        void *data,
-        int (*func)(void *data, struct attr *attr)) {
+        void *data, int (*func)(void *data, struct attr *attr)) {
     struct attr attr;
     int ret;
 

--- a/navit/binding/python/attr.c
+++ b/navit/binding/python/attr.c
@@ -27,8 +27,7 @@ typedef struct {
     struct attr *attr;
 } attrObject;
 
-static PyObject *
-attr_func(attrObject *self, PyObject *args) {
+static PyObject *attr_func(attrObject *self, PyObject *args) {
     const char *file;
     int ret;
     if (!PyArg_ParseTuple(args, "s", &file))
@@ -45,13 +44,11 @@ static PyMethodDef attr_methods[] = {
 };
 
 
-static PyObject *
-attr_getattr_py(PyObject *self, char *name) {
+static PyObject *attr_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(attr_methods, self, name);
 }
 
-static void
-attr_destroy_py(attrObject *self) {
+static void attr_destroy_py(attrObject *self) {
     if (! self->ref)
         attr_free(self->attr);
 }
@@ -69,8 +66,7 @@ attr_py_get(PyObject *self) {
     return ((attrObject *)self)->attr;
 }
 
-PyObject *
-attr_new_py(PyObject *self, PyObject *args) {
+PyObject *attr_new_py(PyObject *self, PyObject *args) {
     attrObject *ret;
     const char *name,*value;
     if (!PyArg_ParseTuple(args, "ss", &name, &value))
@@ -81,8 +77,7 @@ attr_new_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-PyObject *
-attr_new_py_ref(struct attr *attr) {
+PyObject *attr_new_py_ref(struct attr *attr) {
     attrObject *ret;
 
     ret=PyObject_NEW(attrObject, &attr_Type);

--- a/navit/binding/python/binding_python.c
+++ b/navit/binding/python/binding_python.c
@@ -79,8 +79,7 @@ PyTypeObject map_Type = {
 
 /* *** coord *** */
 
-static PyObject *
-coord_new_py(PyObject *self, PyObject *args) {
+static PyObject *coord_new_py(PyObject *self, PyObject *args) {
     coordObject *ret;
     int x,y;
     if (!PyArg_ParseTuple(args, "ii:navit.coord",&x,&y))
@@ -90,8 +89,7 @@ coord_new_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-static void
-coord_destroy_py(coordObject *self) {
+static void coord_destroy_py(coordObject *self) {
     coord_destroy(self->c);
 }
 
@@ -116,8 +114,7 @@ PyTypeObject coord_rect_Type = {
     .tp_dealloc=(destructor)coord_rect_destroy_py,
 };
 
-static PyObject *
-coord_rect_new_py(PyObject *self, PyObject *args) {
+static PyObject *coord_rect_new_py(PyObject *self, PyObject *args) {
     coord_rectObject *ret;
     coordObject *lu,*rd;
     if (!PyArg_ParseTuple(args, "O!O!:navit.coord_rect_rect",&coord_Type,&lu,&coord_Type,&rd))
@@ -127,8 +124,7 @@ coord_rect_new_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-static void
-coord_rect_destroy_py(coord_rectObject *self) {
+static void coord_rect_destroy_py(coord_rectObject *self) {
     coord_rect_destroy(self->r);
 }
 
@@ -153,8 +149,7 @@ PyTypeObject map_rect_Type = {
     .tp_dealloc=(destructor)map_rect_destroy_py,
 };
 
-static PyObject *
-map_rect_new_py(mapObject *self, PyObject *args) {
+static PyObject *map_rect_new_py(mapObject *self, PyObject *args) {
     map_rectObject *ret;
     coord_rectObject *r;
     if (!PyArg_ParseTuple(args, "O!:navit.map_rect_rect",&coord_rect_Type,&r))
@@ -164,16 +159,14 @@ map_rect_new_py(mapObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-static void
-map_rect_destroy_py(map_rectObject *self) {
+static void map_rect_destroy_py(map_rectObject *self) {
     map_rect_destroy(self->mr);
 }
 
 
 /* *** map *** */
 
-static PyObject *
-map_dump_file_py(mapObject *self, PyObject *args) {
+static PyObject *map_dump_file_py(mapObject *self, PyObject *args) {
     const char *s;
     if (!PyArg_ParseTuple(args, "s",&s))
         return NULL;
@@ -182,8 +175,7 @@ map_dump_file_py(mapObject *self, PyObject *args) {
 }
 
 
-static PyObject *
-map_set_attr_py(mapObject *self, PyObject *args) {
+static PyObject *map_set_attr_py(mapObject *self, PyObject *args) {
     PyObject *attr;
     if (!PyArg_ParseTuple(args, "O!", &attr_Type, &attr))
         return NULL;
@@ -200,14 +192,12 @@ static PyMethodDef map_methods[] = {
     {NULL, NULL },
 };
 
-static PyObject *
-map_getattr_py(PyObject *self, char *name) {
+static PyObject *map_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(map_methods, self, name);
 }
 
 
-static PyObject *
-map_new_py(PyObject *self, PyObject *args) {
+static PyObject *map_new_py(PyObject *self, PyObject *args) {
     mapObject *ret;
     char *type, *filename;
 
@@ -219,8 +209,7 @@ map_new_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-PyObject *
-map_py_ref(struct map *map) {
+PyObject *map_py_ref(struct map *map) {
     mapObject *ret;
     ret=PyObject_NEW(mapObject, &map_Type);
     ret->m=map;
@@ -228,8 +217,7 @@ map_py_ref(struct map *map) {
     return (PyObject *)ret;
 }
 
-static void
-map_destroy_py(mapObject *self) {
+static void map_destroy_py(mapObject *self) {
     if (!self->ref)
         map_destroy(self->m);
 }
@@ -258,8 +246,7 @@ PyTypeObject mapset_Type = {
     .tp_getattr=mapset_getattr_py,
 };
 
-static PyObject *
-mapset_add_py(mapsetObject *self, PyObject *args) {
+static PyObject *mapset_add_py(mapsetObject *self, PyObject *args) {
     mapObject *map;
     if (!PyArg_ParseTuple(args, "O:navit.mapset", &map))
         return NULL;
@@ -275,13 +262,11 @@ static PyMethodDef mapset_methods[] = {
     {NULL, NULL },
 };
 
-static PyObject *
-mapset_getattr_py(PyObject *self, char *name) {
+static PyObject *mapset_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(mapset_methods, self, name);
 }
 
-static PyObject *
-mapset_new_py(PyObject *self, PyObject *args) {
+static PyObject *mapset_new_py(PyObject *self, PyObject *args) {
     mapsetObject *ret;
     if (!PyArg_ParseTuple(args, ":navit.mapset"))
         return NULL;
@@ -290,13 +275,11 @@ mapset_new_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-static void
-mapset_destroy_py(mapsetObject *self) {
+static void mapset_destroy_py(mapsetObject *self) {
     mapset_destroy(self->ms);
 }
 
-static PyObject *
-config_load_py(PyObject *self, PyObject *args) {
+static PyObject *config_load_py(PyObject *self, PyObject *args) {
     const char *file;
     int ret;
     xmlerror *error;
@@ -319,8 +302,7 @@ static PyMethodDef navitMethods[]= {
 };
 
 
-PyObject *
-python_object_from_attr(struct attr *attr) {
+PyObject *python_object_from_attr(struct attr *attr) {
     switch (attr->type) {
     case attr_navigation:
         return navigation_py_ref(attr->u.navigation);
@@ -333,8 +315,7 @@ python_object_from_attr(struct attr *attr) {
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     int fd,size;
     char buffer[65536];
 

--- a/navit/binding/python/config.c
+++ b/navit/binding/python/config.c
@@ -25,8 +25,7 @@ typedef struct {
     PyObject_HEAD
 } configObject;
 
-static PyObject *
-config_navit(PyObject *self, PyObject *args) {
+static PyObject *config_navit(PyObject *self, PyObject *args) {
     struct attr navit;
     if (config_get_attr(config, attr_navit, &navit, NULL))
         return navit_py_ref(navit.u.navit);
@@ -41,13 +40,11 @@ static PyMethodDef config_methods[] = {
 };
 
 
-static PyObject *
-config_getattr_py(PyObject *self, char *name) {
+static PyObject *config_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(config_methods, self, name);
 }
 
-static void
-config_destroy_py(configObject *self) {
+static void config_destroy_py(configObject *self) {
 }
 
 PyTypeObject config_Type = {
@@ -58,8 +55,7 @@ PyTypeObject config_Type = {
     .tp_getattr=config_getattr_py,
 };
 
-PyObject *
-config_py(PyObject *self, PyObject *args) {
+PyObject *config_py(PyObject *self, PyObject *args) {
     configObject *ret;
 
     dbg(lvl_debug,"enter");

--- a/navit/binding/python/navigation.c
+++ b/navit/binding/python/navigation.c
@@ -25,8 +25,7 @@ typedef struct {
     struct navigation *navigation;
 } navigationObject;
 
-static PyObject *
-navigation_get_map_py(navigationObject *self, PyObject *args) {
+static PyObject *navigation_get_map_py(navigationObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
     return map_py_ref(navigation_get_map(self->navigation));
@@ -40,13 +39,11 @@ static PyMethodDef navigation_methods[] = {
 };
 
 
-static PyObject *
-navigation_getattr_py(PyObject *self, char *name) {
+static PyObject *navigation_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(navigation_methods, self, name);
 }
 
-static void
-navigation_destroy_py(navigationObject *self) {
+static void navigation_destroy_py(navigationObject *self) {
 }
 
 PyTypeObject navigation_Type = {
@@ -57,16 +54,14 @@ PyTypeObject navigation_Type = {
     .tp_getattr=navigation_getattr_py,
 };
 
-PyObject *
-navigation_py(PyObject *self, PyObject *args) {
+PyObject *navigation_py(PyObject *self, PyObject *args) {
     navigationObject *ret;
 
     ret=PyObject_NEW(navigationObject, &navigation_Type);
     return (PyObject *)ret;
 }
 
-PyObject *
-navigation_py_ref(struct navigation *navigation) {
+PyObject *navigation_py_ref(struct navigation *navigation) {
     navigationObject *ret;
 
     ret=PyObject_NEW(navigationObject, &navigation_Type);

--- a/navit/binding/python/navit.c
+++ b/navit/binding/python/navit.c
@@ -26,8 +26,7 @@ typedef struct {
     struct navit *navit;
 } navitObject;
 
-static PyObject *
-navit_set_attr_py(navitObject *self, PyObject *args) {
+static PyObject *navit_set_attr_py(navitObject *self, PyObject *args) {
     PyObject *attr;
     if (!PyArg_ParseTuple(args, "O!", &attr_Type, &attr))
         return NULL;
@@ -35,8 +34,7 @@ navit_set_attr_py(navitObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
-static PyObject *
-navit_get_attr_py(navitObject *self, PyObject *args) {
+static PyObject *navit_get_attr_py(navitObject *self, PyObject *args) {
     char *name;
     struct attr attr;
     if (!PyArg_ParseTuple(args, "s", &name))
@@ -49,8 +47,7 @@ navit_get_attr_py(navitObject *self, PyObject *args) {
     return python_object_from_attr(&attr);
 }
 
-static PyObject *
-navit_set_center_py(navitObject *self, PyObject *args) {
+static PyObject *navit_set_center_py(navitObject *self, PyObject *args) {
     PyObject *pcoord;
     if (!PyArg_ParseTuple(args, "O!", &pcoord_Type, &pcoord))
         return NULL;
@@ -58,8 +55,7 @@ navit_set_center_py(navitObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
-static PyObject *
-navit_set_destination_py(navitObject *self, PyObject *args) {
+static PyObject *navit_set_destination_py(navitObject *self, PyObject *args) {
     PyObject *pcoord;
     const char *description;
     int async;
@@ -69,8 +65,7 @@ navit_set_destination_py(navitObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
-static PyObject *
-navit_set_position_py(navitObject *self, PyObject *args) {
+static PyObject *navit_set_position_py(navitObject *self, PyObject *args) {
     PyObject *pcoord;
     if (!PyArg_ParseTuple(args, "O!", &pcoord_Type, &pcoord))
         return NULL;
@@ -79,8 +74,7 @@ navit_set_position_py(navitObject *self, PyObject *args) {
 }
 
 
-static PyObject *
-navit_zoom_to_route_py(navitObject *self, PyObject *args) {
+static PyObject *navit_zoom_to_route_py(navitObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
     navit_zoom_to_route(self->navit,0);
@@ -101,13 +95,11 @@ static PyMethodDef navit_methods[] = {
 };
 
 
-static PyObject *
-navit_getattr_py(PyObject *self, char *name) {
+static PyObject *navit_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(navit_methods, self, name);
 }
 
-static void
-navit_destroy_py(navitObject *self) {
+static void navit_destroy_py(navitObject *self) {
 }
 
 PyTypeObject navit_Type = {
@@ -118,8 +110,7 @@ PyTypeObject navit_Type = {
     .tp_getattr=navit_getattr_py,
 };
 
-PyObject *
-navit_py(PyObject *self, PyObject *args) {
+PyObject *navit_py(PyObject *self, PyObject *args) {
     navitObject *ret;
 
     dbg(lvl_debug,"enter");
@@ -127,8 +118,7 @@ navit_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-PyObject *
-navit_py_ref(struct navit *navit) {
+PyObject *navit_py_ref(struct navit *navit) {
     dbg(lvl_debug,"navit=%p", navit);
     navitObject *ret=PyObject_NEW(navitObject, &navit_Type);
     ret->navit=navit;

--- a/navit/binding/python/pcoord.c
+++ b/navit/binding/python/pcoord.c
@@ -25,8 +25,7 @@ typedef struct {
     struct pcoord pc;
 } pcoordObject;
 
-static PyObject *
-pcoord_func(pcoordObject *self, PyObject *args) {
+static PyObject *pcoord_func(pcoordObject *self, PyObject *args) {
     const char *file;
     int ret=0;
     if (!PyArg_ParseTuple(args, "s", &file))
@@ -42,13 +41,11 @@ static PyMethodDef pcoord_methods[] = {
 };
 
 
-static PyObject *
-pcoord_getattr_py(PyObject *self, char *name) {
+static PyObject *pcoord_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(pcoord_methods, self, name);
 }
 
-static void
-pcoord_destroy_py(pcoordObject *self) {
+static void pcoord_destroy_py(pcoordObject *self) {
 }
 
 PyTypeObject pcoord_Type = {
@@ -59,8 +56,7 @@ PyTypeObject pcoord_Type = {
     .tp_getattr=pcoord_getattr_py,
 };
 
-PyObject *
-pcoord_py(PyObject *self, PyObject *args) {
+PyObject *pcoord_py(PyObject *self, PyObject *args) {
     pcoordObject *ret;
     const char *str;
     enum projection pro;

--- a/navit/binding/python/route.c
+++ b/navit/binding/python/route.c
@@ -27,8 +27,7 @@ typedef struct {
     struct route *route;
 } routeObject;
 
-static PyObject *
-route_get_map_py(routeObject *self, PyObject *args) {
+static PyObject *route_get_map_py(routeObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
     return map_py_ref(route_get_map(self->route));
@@ -42,13 +41,11 @@ static PyMethodDef route_methods[] = {
 };
 
 
-static PyObject *
-route_getattr_py(PyObject *self, char *name) {
+static PyObject *route_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(route_methods, self, name);
 }
 
-static void
-route_destroy_py(routeObject *self) {
+static void route_destroy_py(routeObject *self) {
 }
 
 PyTypeObject route_Type = {
@@ -59,16 +56,14 @@ PyTypeObject route_Type = {
     .tp_getattr=route_getattr_py,
 };
 
-PyObject *
-route_py(PyObject *self, PyObject *args) {
+PyObject *route_py(PyObject *self, PyObject *args) {
     routeObject *ret;
 
     ret=PyObject_NEW(routeObject, &route_Type);
     return (PyObject *)ret;
 }
 
-PyObject *
-route_py_ref(struct route *route) {
+PyObject *route_py_ref(struct route *route) {
     routeObject *ret;
 
     ret=PyObject_NEW(routeObject, &route_Type);

--- a/navit/binding/python/template.c
+++ b/navit/binding/python/template.c
@@ -26,8 +26,7 @@ typedef struct {
     struct template *template;
 } templateObject;
 
-static PyObject *
-template_func(templateObject *self, PyObject *args) {
+static PyObject *template_func(templateObject *self, PyObject *args) {
     const char *file;
     int ret;
     if (!PyArg_ParseTuple(args, "s", &file))
@@ -44,13 +43,11 @@ static PyMethodDef template_methods[] = {
 };
 
 
-static PyObject *
-template_getattr_py(PyObject *self, char *name) {
+static PyObject *template_getattr_py(PyObject *self, char *name) {
     return Py_FindMethod(template_methods, self, name);
 }
 
-static void
-template_destroy_py(templateObject *self) {
+static void template_destroy_py(templateObject *self) {
     if (! self->ref)
         template_destroy(self->template);
 }
@@ -68,8 +65,7 @@ template_py_get(PyObject *self) {
     return ((templateObject *)self)->template;
 }
 
-PyObject *
-template_new_py(PyObject *self, PyObject *args) {
+PyObject *template_new_py(PyObject *self, PyObject *args) {
     templateObject *ret;
 
     ret=PyObject_NEW(templateObject, &template_Type);
@@ -78,8 +74,7 @@ template_new_py(PyObject *self, PyObject *args) {
     return (PyObject *)ret;
 }
 
-PyObject *
-template_new_py_ref(struct template *template) {
+PyObject *template_new_py_ref(struct template *template) {
     templateObject *ret;
 
     ret=PyObject_NEW(templateObject, &template_Type);

--- a/navit/binding/win32/binding_win32.c
+++ b/navit/binding/win32/binding_win32.c
@@ -57,8 +57,7 @@ struct win32_binding_private {
 /* TODO: do something meaningful here
  *
  */
-static int
-win32_cmd_send_signal(struct navit *navit, char *command, struct attr **in, struct attr ***out) {
+static int win32_cmd_send_signal(struct navit *navit, char *command, struct attr **in, struct attr ***out) {
     dbg(lvl_error,"this function is a stub");
     if (in) {
         while (*in) {
@@ -75,8 +74,7 @@ static struct command_table commands[] = {
 };
 
 
-static void
-win32_wm_copydata(struct win32_binding_private *this, int *hwndSender, COPYDATASTRUCT *cpd) {
+static void win32_wm_copydata(struct win32_binding_private *this, int *hwndSender, COPYDATASTRUCT *cpd) {
     struct attr navit;
     struct navit_binding_w32_msg *msg;
     navit.type=attr_navit;
@@ -104,8 +102,7 @@ win32_wm_copydata(struct win32_binding_private *this, int *hwndSender, COPYDATAS
     command_evaluate(&navit, msg->text);
 }
 
-static void
-win32_cb_graphics_ready(struct win32_binding_private *this, struct navit *navit) {
+static void win32_cb_graphics_ready(struct win32_binding_private *this, struct navit *navit) {
     struct graphics *gra;
     struct callback *gcb;
 
@@ -115,8 +112,7 @@ win32_cb_graphics_ready(struct win32_binding_private *this, struct navit *navit)
     graphics_add_callback(gra, gcb);
 }
 
-static void
-win32_main_navit(struct win32_binding_private *this, struct navit *navit, int added) {
+static void win32_main_navit(struct win32_binding_private *this, struct navit *navit, int added) {
     struct attr attr;
     dbg(lvl_debug,"enter");
     if (added==1) {

--- a/navit/bookmarks.c
+++ b/navit/bookmarks.c
@@ -156,8 +156,7 @@ static void bookmarks_clear_item(struct bookmark_item_priv *b_item) {
     g_free(b_item);
 }
 
-static void
-bookmarks_clear_hash(struct bookmarks *this_) {
+static void bookmarks_clear_hash(struct bookmarks *this_) {
     if (this_->mr) {
         map_rect_destroy(this_->mr);
     }
@@ -166,8 +165,7 @@ bookmarks_clear_hash(struct bookmarks *this_) {
     g_list_free(this_->bookmarks_list);
 }
 
-static void
-bookmarks_load_hash(struct bookmarks *this_) {
+static void bookmarks_load_hash(struct bookmarks *this_) {
     struct bookmark_item_priv *b_item;
     struct item *item;
     struct attr attr;
@@ -270,8 +268,7 @@ bookmarks_new(struct attr *parent, struct attr **attrs, struct transformation *t
     return this_;
 }
 
-void
-bookmarks_destroy(struct bookmarks *this_) {
+void bookmarks_destroy(struct bookmarks *this_) {
 
     bookmarks_clear_hash(this_);
 
@@ -293,13 +290,11 @@ bookmarks_get_map(struct bookmarks *this_) {
 enum projection bookmarks_get_projection(struct bookmarks *this_) {
     return map_projection(this_->bookmark);
 }
-void
-bookmarks_add_callback(struct bookmarks *this_, struct callback *cb) {
+void bookmarks_add_callback(struct bookmarks *this_, struct callback *cb) {
     callback_list_add(this_->attr_cbl, cb);
 }
 
-static int
-bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit,int replace) {
+static int bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit,int replace) {
     FILE *f;
     struct bookmark_item_priv *item,*parent_item;
     char *fullname;
@@ -391,8 +386,7 @@ bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit,int replac
  * full path. Should be freed using g_free.
  *
  */
-char*
-bookmarks_get_destination_file(gboolean create) {
+char* bookmarks_get_destination_file(gboolean create) {
     return g_strjoin(NULL, navit_get_user_data_directory(create), "/destination.txt", NULL);
 }
 
@@ -405,13 +399,11 @@ bookmarks_get_destination_file(gboolean create) {
  * arg: gboolean create: create the directory where the file is stored
  * if it does not exist
  */
-char*
-bookmarks_get_center_file(gboolean create) {
+char* bookmarks_get_center_file(gboolean create) {
     return g_strjoin(NULL, navit_get_user_data_directory(create), "/center.txt", NULL);
 }
 
-void
-bookmarks_set_center_from_file(struct bookmarks *this_, char *file) {
+void bookmarks_set_center_from_file(struct bookmarks *this_, char *file) {
     FILE *f;
     char *line = NULL;
 
@@ -433,8 +425,7 @@ bookmarks_set_center_from_file(struct bookmarks *this_, char *file) {
     return;
 }
 
-void
-bookmarks_write_center_to_file(struct bookmarks *this_, char *file) {
+void bookmarks_write_center_to_file(struct bookmarks *this_, char *file) {
     FILE *f;
     enum projection pro;
     struct coord *center;
@@ -451,8 +442,7 @@ bookmarks_write_center_to_file(struct bookmarks *this_, char *file) {
     return;
 }
 
-static void
-bookmarks_emit_dbus_signal(struct bookmarks *this_, struct pcoord *c, const char *description,int create) {
+static void bookmarks_emit_dbus_signal(struct bookmarks *this_, struct pcoord *c, const char *description,int create) {
     struct attr attr1,attr2,attr3,attr4,cb,*attr_list[5];
     int valid=0;
     attr1.type=attr_type;
@@ -480,8 +470,7 @@ bookmarks_emit_dbus_signal(struct bookmarks *this_, struct pcoord *c, const char
  * @param description A label which allows the user to later identify this bookmark
  * @returns nothing
  */
-int
-bookmarks_add_bookmark(struct bookmarks *this_, struct pcoord *pc, const char *description) {
+int bookmarks_add_bookmark(struct bookmarks *this_, struct pcoord *pc, const char *description) {
     struct bookmark_item_priv *b_item=g_new0(struct bookmark_item_priv,1);
     int result;
 
@@ -512,16 +501,14 @@ bookmarks_add_bookmark(struct bookmarks *this_, struct pcoord *pc, const char *d
     return result;
 }
 
-int
-bookmarks_cut_bookmark(struct bookmarks *this_, const char *label) {
+int bookmarks_cut_bookmark(struct bookmarks *this_, const char *label) {
     if (bookmarks_copy_bookmark(this_,label)) {
         return bookmarks_delete_bookmark(this_,label);
     }
 
     return FALSE;
 }
-int
-bookmarks_copy_bookmark(struct bookmarks *this_, const char *label) {
+int bookmarks_copy_bookmark(struct bookmarks *this_, const char *label) {
     bookmarks_item_rewind(this_);
     if (this_->current->children==NULL) {
         return 0;
@@ -543,8 +530,7 @@ bookmarks_copy_bookmark(struct bookmarks *this_, const char *label) {
     }
     return FALSE;
 }
-int
-bookmarks_paste_bookmark(struct bookmarks *this_) {
+int bookmarks_paste_bookmark(struct bookmarks *this_) {
     int result;
     struct bookmark_item_priv* b_item;
 
@@ -576,8 +562,7 @@ bookmarks_paste_bookmark(struct bookmarks *this_) {
 }
 
 
-int
-bookmarks_delete_bookmark(struct bookmarks *this_, const char *label) {
+int bookmarks_delete_bookmark(struct bookmarks *this_, const char *label) {
     int result;
 
     bookmarks_item_rewind(this_);
@@ -606,8 +591,7 @@ bookmarks_delete_bookmark(struct bookmarks *this_, const char *label) {
     return FALSE;
 }
 
-int
-bookmarks_rename_bookmark(struct bookmarks *this_, const char *oldName, const char* newName) {
+int bookmarks_rename_bookmark(struct bookmarks *this_, const char *oldName, const char* newName) {
     int result;
 
     bookmarks_item_rewind(this_);
@@ -678,8 +662,8 @@ static GList* read_former_destination_map_as_list(struct map *map) {
     return g_list_reverse(list);
 }
 
-static int
-destination_equal(struct former_destination* dest1, struct former_destination* dest2, int ignore_descriptions) {
+static int destination_equal(struct former_destination* dest1, struct former_destination* dest2,
+                             int ignore_descriptions) {
     if ((dest1->type == dest2->type) &&
             (ignore_descriptions || !strcmp(dest1->description, dest2->description)) &&
             (coord_equal((struct coord *)g_list_last(dest1->c)->data, (struct coord *)g_list_last(dest2->c)->data))) {
@@ -692,8 +676,8 @@ destination_equal(struct former_destination* dest1, struct former_destination* d
  * Find destination in given GList. If remove_found is non-zero, any matching items are removed and new beginning of the list is returned.
  * If remove_found is zero, last matching item is returned. In the latter case, description is ignored and can be NULL.
  */
-static GList*
-find_destination_in_list(struct former_destination* dest_to_remove, GList* former_destinations, int remove_found) {
+static GList* find_destination_in_list(struct former_destination* dest_to_remove, GList* former_destinations,
+                                       int remove_found) {
     GList* curr_el = former_destinations;
     GList* prev_el = NULL;
     GList* found_el = NULL;
@@ -721,8 +705,7 @@ find_destination_in_list(struct former_destination* dest_to_remove, GList* forme
 }
 
 
-static void
-write_former_destinations(GList* former_destinations, char *former_destination_file, enum projection proj) {
+static void write_former_destinations(GList* former_destinations, char *former_destination_file, enum projection proj) {
     FILE *f;
     GList* currdest = NULL;
     GList* c_list = NULL;
@@ -764,9 +747,8 @@ write_former_destinations(GList* former_destinations, char *former_destination_f
  *   to get description.
  * @param limit Limits the number of entries in the "backlog". Set to 0 for "infinite"
  */
-void
-bookmarks_append_destinations(struct map *former_destination_map, char *former_destination_file,
-                              struct pcoord *c, int count, enum item_type type, const char *description, int limit) {
+void bookmarks_append_destinations(struct map *former_destination_map, char *former_destination_file,
+                                   struct pcoord *c, int count, enum item_type type, const char *description, int limit) {
     struct former_destination *new_dest=NULL;
     GList* former_destinations = NULL;
     GList* former_destinations_shortened = NULL;

--- a/navit/bookmarks.c
+++ b/navit/bookmarks.c
@@ -747,8 +747,8 @@ static void write_former_destinations(GList* former_destinations, char *former_d
  *   to get description.
  * @param limit Limits the number of entries in the "backlog". Set to 0 for "infinite"
  */
-void bookmarks_append_destinations(struct map *former_destination_map, char *former_destination_file,
-                                   struct pcoord *c, int count, enum item_type type, const char *description, int limit) {
+void bookmarks_append_destinations(struct map *former_destination_map, char *former_destination_file, struct pcoord *c,
+                                   int count, enum item_type type, const char *description, int limit) {
     struct former_destination *new_dest=NULL;
     GList* former_destinations = NULL;
     GList* former_destinations_shortened = NULL;

--- a/navit/browserplugin.c
+++ b/navit/browserplugin.c
@@ -132,8 +132,7 @@ NP_Shutdown() {
     return NPERR_NO_ERROR;
 }
 
-NPError NPP_New(NPMIMEType pluginType, NPP instance, uint16_t mode, int16_t argc,
-                char *argn[], char *argv[], NPSavedData * saved) {
+NPError NPP_New(NPMIMEType pluginType, NPP instance, uint16_t mode, int16_t argc, char *argn[], char *argv[], NPSavedData * saved) {
     char *args[]= {"/usr/bin/navit",NULL};
     // Make sure we can render this plugin
     NPBool browserSupportsWindowless = false;
@@ -193,8 +192,7 @@ NPError NPP_SetWindow(NPP instance, NPWindow * window) {
     return NPERR_NO_ERROR;
 }
 
-NPError NPP_NewStream(NPP instance, NPMIMEType type, NPStream * stream,
-                      NPBool seekable, uint16_t * stype) {
+NPError NPP_NewStream(NPP instance, NPMIMEType type, NPStream * stream, NPBool seekable, uint16_t * stype) {
     return NPERR_GENERIC_ERROR;
 }
 
@@ -244,8 +242,7 @@ int16_t NPP_HandleEvent(NPP instance, void *event) {
     return 1;
 }
 
-void NPP_URLNotify(NPP instance, const char *URL, NPReason reason,
-                   void *notifyData) {
+void NPP_URLNotify(NPP instance, const char *URL, NPReason reason, void *notifyData) {
 
 }
 
@@ -307,8 +304,7 @@ enum attr_type variant_to_attr_type(const NPVariant *variant) {
 
 
 
-bool invoke(NPObject * npobj, NPIdentifier name, const NPVariant * args,
-            uint32_t argCount, NPVariant * result) {
+bool invoke(NPObject * npobj, NPIdentifier name, const NPVariant * args, uint32_t argCount, NPVariant * result) {
     struct NavitObject *obj = (struct NavitObject *) npobj;
     fprintf(stderr, "invoke\n");
     printIdentifier(name);
@@ -388,8 +384,7 @@ bool invoke(NPObject * npobj, NPIdentifier name, const NPVariant * args,
 }
 
 
-bool invokeDefault(NPObject * npobj, const NPVariant * args, uint32_t argCount,
-                   NPVariant * result) {
+bool invokeDefault(NPObject * npobj, const NPVariant * args, uint32_t argCount, NPVariant * result) {
     fprintf(stderr, "invokeDefault\n");
     return false;
 }

--- a/navit/browserplugin.c
+++ b/navit/browserplugin.c
@@ -59,8 +59,7 @@ typedef struct InstanceData {
 } InstanceData;
 
 
-static void
-fillPluginFunctionTable(NPPluginFuncs * pFuncs) {
+static void fillPluginFunctionTable(NPPluginFuncs * pFuncs) {
     pFuncs->version = 11;
     pFuncs->size = sizeof(*pFuncs);
     pFuncs->newp = NPP_New;
@@ -133,9 +132,8 @@ NP_Shutdown() {
     return NPERR_NO_ERROR;
 }
 
-NPError
-NPP_New(NPMIMEType pluginType, NPP instance, uint16_t mode, int16_t argc,
-        char *argn[], char *argv[], NPSavedData * saved) {
+NPError NPP_New(NPMIMEType pluginType, NPP instance, uint16_t mode, int16_t argc,
+                char *argn[], char *argv[], NPSavedData * saved) {
     char *args[]= {"/usr/bin/navit",NULL};
     // Make sure we can render this plugin
     NPBool browserSupportsWindowless = false;
@@ -164,15 +162,13 @@ NPP_New(NPMIMEType pluginType, NPP instance, uint16_t mode, int16_t argc,
     return NPERR_NO_ERROR;
 }
 
-NPError
-NPP_Destroy(NPP instance, NPSavedData ** save) {
+NPError NPP_Destroy(NPP instance, NPSavedData ** save) {
     InstanceData *instanceData = (InstanceData *) (instance->pdata);
     free(instanceData);
     return NPERR_NO_ERROR;
 }
 
-NPError
-NPP_SetWindow(NPP instance, NPWindow * window) {
+NPError NPP_SetWindow(NPP instance, NPWindow * window) {
     struct attr navit,graphics,windowid;
     InstanceData *instanceData = (InstanceData *) (instance->pdata);
     if (window->window == instanceData->window.window)
@@ -197,40 +193,33 @@ NPP_SetWindow(NPP instance, NPWindow * window) {
     return NPERR_NO_ERROR;
 }
 
-NPError
-NPP_NewStream(NPP instance, NPMIMEType type, NPStream * stream,
-              NPBool seekable, uint16_t * stype) {
+NPError NPP_NewStream(NPP instance, NPMIMEType type, NPStream * stream,
+                      NPBool seekable, uint16_t * stype) {
     return NPERR_GENERIC_ERROR;
 }
 
-NPError
-NPP_DestroyStream(NPP instance, NPStream * stream, NPReason reason) {
+NPError NPP_DestroyStream(NPP instance, NPStream * stream, NPReason reason) {
     return NPERR_GENERIC_ERROR;
 }
 
-int32_t
-NPP_WriteReady(NPP instance, NPStream * stream) {
+int32_t NPP_WriteReady(NPP instance, NPStream * stream) {
     return 0;
 }
 
-int32_t
-NPP_Write(NPP instance, NPStream * stream, int32_t offset, int32_t len,
-          void *buffer) {
+int32_t NPP_Write(NPP instance, NPStream * stream, int32_t offset, int32_t len,
+                  void *buffer) {
     return 0;
 }
 
-void
-NPP_StreamAsFile(NPP instance, NPStream * stream, const char *fname) {
+void NPP_StreamAsFile(NPP instance, NPStream * stream, const char *fname) {
 
 }
 
-void
-NPP_Print(NPP instance, NPPrint * platformPrint) {
+void NPP_Print(NPP instance, NPPrint * platformPrint) {
 
 }
 
-int16_t
-NPP_HandleEvent(NPP instance, void *event) {
+int16_t NPP_HandleEvent(NPP instance, void *event) {
 
 
     return 0;
@@ -255,9 +244,8 @@ NPP_HandleEvent(NPP instance, void *event) {
     return 1;
 }
 
-void
-NPP_URLNotify(NPP instance, const char *URL, NPReason reason,
-              void *notifyData) {
+void NPP_URLNotify(NPP instance, const char *URL, NPReason reason,
+                   void *notifyData) {
 
 }
 
@@ -269,16 +257,14 @@ struct NavitObject {
     struct attr attr;
 };
 
-void
-printIdentifier(NPIdentifier name) {
+void printIdentifier(NPIdentifier name) {
     NPUTF8 *str;
     str = sBrowserFuncs->utf8fromidentifier(name);
     fprintf(stderr, "%s\n", str);
     sBrowserFuncs->memfree(str);
 }
 
-NPObject *
-allocate(NPP npp, NPClass * aClass) {
+NPObject *allocate(NPP npp, NPClass * aClass) {
     struct NavitObject *ret = calloc(sizeof(struct NavitObject), 1);
     if (ret) {
         ret->class = aClass;
@@ -290,14 +276,12 @@ allocate(NPP npp, NPClass * aClass) {
 }
 
 
-void
-invalidate(NPObject * npobj) {
+void invalidate(NPObject * npobj) {
     fprintf(stderr, "invalidate\n");
 }
 
 
-bool
-hasMethod(NPObject * npobj, NPIdentifier name) {
+bool hasMethod(NPObject * npobj, NPIdentifier name) {
     fprintf(stderr, "hasMethod\n");
     printIdentifier(name);
     if (name == sBrowserFuncs->getstringidentifier("command"))
@@ -315,8 +299,7 @@ hasMethod(NPObject * npobj, NPIdentifier name) {
     return false;
 }
 
-enum attr_type
-variant_to_attr_type(const NPVariant *variant) {
+enum attr_type variant_to_attr_type(const NPVariant *variant) {
     if (NPVARIANT_IS_STRING(*variant))
         return attr_from_name(NPVARIANT_TO_STRING(*variant).utf8characters);
     return attr_none;
@@ -324,9 +307,8 @@ variant_to_attr_type(const NPVariant *variant) {
 
 
 
-bool
-invoke(NPObject * npobj, NPIdentifier name, const NPVariant * args,
-       uint32_t argCount, NPVariant * result) {
+bool invoke(NPObject * npobj, NPIdentifier name, const NPVariant * args,
+            uint32_t argCount, NPVariant * result) {
     struct NavitObject *obj = (struct NavitObject *) npobj;
     fprintf(stderr, "invoke\n");
     printIdentifier(name);
@@ -406,16 +388,14 @@ invoke(NPObject * npobj, NPIdentifier name, const NPVariant * args,
 }
 
 
-bool
-invokeDefault(NPObject * npobj, const NPVariant * args, uint32_t argCount,
-              NPVariant * result) {
+bool invokeDefault(NPObject * npobj, const NPVariant * args, uint32_t argCount,
+                   NPVariant * result) {
     fprintf(stderr, "invokeDefault\n");
     return false;
 }
 
 
-bool
-hasProperty(NPObject * npobj, NPIdentifier name) {
+bool hasProperty(NPObject * npobj, NPIdentifier name) {
     struct NavitObject *obj = (struct NavitObject *) npobj;
     fprintf(stderr, "hasProperty\n");
     printIdentifier(name);
@@ -430,8 +410,7 @@ hasProperty(NPObject * npobj, NPIdentifier name) {
 }
 
 
-bool
-getProperty(NPObject * npobj, NPIdentifier name, NPVariant * result) {
+bool getProperty(NPObject * npobj, NPIdentifier name, NPVariant * result) {
     struct NavitObject *obj = (struct NavitObject *) npobj;
     fprintf(stderr, "getProperty %p\n", obj);
     fprintf(stderr, "instanceData %p\n", obj->instanceData);
@@ -455,15 +434,13 @@ getProperty(NPObject * npobj, NPIdentifier name, NPVariant * result) {
 }
 
 
-bool
-setProperty(NPObject * npobj, NPIdentifier name, const NPVariant * value) {
+bool setProperty(NPObject * npobj, NPIdentifier name, const NPVariant * value) {
     fprintf(stderr, "setProperty\n");
     return false;
 }
 
 
-bool
-removeProperty(NPObject * npobj, NPIdentifier name) {
+bool removeProperty(NPObject * npobj, NPIdentifier name) {
     fprintf(stderr, "removeProperty\n");
     return false;
 }
@@ -501,8 +478,7 @@ struct NPClass navitclass2 = {
 };
 
 
-NPError
-NPP_GetValue(NPP instance, NPPVariable variable, void *value) {
+NPError NPP_GetValue(NPP instance, NPPVariable variable, void *value) {
     fprintf(stderr, "NPP_GetValue %d %d\n", variable,
             NPPVpluginScriptableNPObject);
     if (variable == NPPVpluginNeedsXEmbed) {
@@ -519,7 +495,6 @@ NPP_GetValue(NPP instance, NPPVariable variable, void *value) {
     return NPERR_GENERIC_ERROR;
 }
 
-NPError
-NPP_SetValue(NPP instance, NPNVariable variable, void *value) {
+NPError NPP_SetValue(NPP instance, NPNVariable variable, void *value) {
     return NPERR_GENERIC_ERROR;
 }

--- a/navit/cache.c
+++ b/navit/cache.c
@@ -29,8 +29,7 @@ struct cache {
     GHashTable *hash;
 };
 
-static void
-cache_entry_dump(struct cache *cache, struct cache_entry *entry) {
+static void cache_entry_dump(struct cache *cache, struct cache_entry *entry) {
     int i,size;
     dbg(lvl_debug,"Usage: %d size %d",entry->usage, entry->size);
     if (cache)
@@ -42,8 +41,7 @@ cache_entry_dump(struct cache *cache, struct cache_entry *entry) {
     }
 }
 
-static void
-cache_list_dump(char *str, struct cache *cache, struct cache_entry_list *list) {
+static void cache_list_dump(char *str, struct cache *cache, struct cache_entry_list *list) {
     struct cache_entry *first=list->first;
     dbg(lvl_debug,"dump %s %d",str, list->size);
     while (first) {
@@ -52,28 +50,24 @@ cache_list_dump(char *str, struct cache *cache, struct cache_entry_list *list) {
     }
 }
 
-static guint
-cache_hash4(gconstpointer key) {
+static guint cache_hash4(gconstpointer key) {
     int *id=(int *)key;
     return id[0];
 }
 
-static guint
-cache_hash20(gconstpointer key) {
+static guint cache_hash20(gconstpointer key) {
     int *id=(int *)key;
     return id[0]^id[1]^id[2]^id[3]^id[4];
 }
 
-static gboolean
-cache_equal4(gconstpointer a, gconstpointer b) {
+static gboolean cache_equal4(gconstpointer a, gconstpointer b) {
     int *ida=(int *)a;
     int *idb=(int *)b;
 
     return ida[0] == idb[0];
 }
 
-static gboolean
-cache_equal20(gconstpointer a, gconstpointer b) {
+static gboolean cache_equal20(gconstpointer a, gconstpointer b) {
     int *ida=(int *)a;
     int *idb=(int *)b;
 
@@ -106,13 +100,11 @@ cache_new(int id_size, int size) {
     return cache;
 }
 
-void
-cache_resize(struct cache *cache, int size) {
+void cache_resize(struct cache *cache, int size) {
     cache->size=size;
 }
 
-static void
-cache_insert_mru(struct cache *cache, struct cache_entry_list *list, struct cache_entry *entry) {
+static void cache_insert_mru(struct cache *cache, struct cache_entry_list *list, struct cache_entry *entry) {
     entry->prev=NULL;
     entry->next=list->first;
     entry->where=list;
@@ -126,8 +118,7 @@ cache_insert_mru(struct cache *cache, struct cache_entry_list *list, struct cach
         g_hash_table_insert(cache->hash, (gpointer)entry->id, entry);
 }
 
-static void
-cache_remove_from_list(struct cache_entry_list *list, struct cache_entry *entry) {
+static void cache_remove_from_list(struct cache_entry_list *list, struct cache_entry *entry) {
     if (entry->prev)
         entry->prev->next=entry->next;
     else
@@ -139,15 +130,13 @@ cache_remove_from_list(struct cache_entry_list *list, struct cache_entry *entry)
     list->size-=entry->size;
 }
 
-static void
-cache_remove(struct cache *cache, struct cache_entry *entry) {
+static void cache_remove(struct cache *cache, struct cache_entry *entry) {
     dbg(lvl_debug,"remove 0x%x 0x%x 0x%x 0x%x 0x%x", entry->id[0], entry->id[1], entry->id[2], entry->id[3], entry->id[4]);
     g_hash_table_remove(cache->hash, (gpointer)(entry->id));
     g_slice_free1(entry->size, entry);
 }
 
-static struct cache_entry *
-cache_remove_lru_helper(struct cache_entry_list *list) {
+static struct cache_entry *cache_remove_lru_helper(struct cache_entry_list *list) {
     struct cache_entry *last=list->last;
     if (! last)
         return NULL;
@@ -160,8 +149,7 @@ cache_remove_lru_helper(struct cache_entry_list *list) {
     return last;
 }
 
-static struct cache_entry *
-cache_remove_lru(struct cache *cache, struct cache_entry_list *list) {
+static struct cache_entry *cache_remove_lru(struct cache *cache, struct cache_entry_list *list) {
     struct cache_entry *last;
     int seen=0;
     while (list->last && list->last->usage && seen < list->size) {
@@ -181,8 +169,7 @@ cache_remove_lru(struct cache *cache, struct cache_entry_list *list) {
     return last;
 }
 
-void *
-cache_entry_new(struct cache *cache, void *id, int size) {
+void *cache_entry_new(struct cache *cache, void *id, int size) {
     struct cache_entry *ret;
     size+=cache->entry_size;
     cache->misses+=size;
@@ -193,15 +180,13 @@ cache_entry_new(struct cache *cache, void *id, int size) {
     return &ret->id[cache->id_size];
 }
 
-void
-cache_entry_destroy(struct cache *cache, void *data) {
+void cache_entry_destroy(struct cache *cache, void *data) {
     struct cache_entry *entry=(struct cache_entry *)((char *)data-cache->entry_size);
     dbg(lvl_debug,"destroy 0x%x 0x%x 0x%x 0x%x 0x%x", entry->id[0], entry->id[1], entry->id[2], entry->id[3], entry->id[4]);
     entry->usage--;
 }
 
-static struct cache_entry *
-cache_trim(struct cache *cache, struct cache_entry *entry) {
+static struct cache_entry *cache_trim(struct cache *cache, struct cache_entry *entry) {
     struct cache_entry *new_entry;
     dbg(lvl_debug,"trim 0x%x 0x%x 0x%x 0x%x 0x%x", entry->id[0], entry->id[1], entry->id[2], entry->id[3], entry->id[4]);
     dbg(lvl_debug,"Trim %x from %d -> %d", entry->id[0], entry->size, cache->size);
@@ -221,8 +206,7 @@ cache_trim(struct cache *cache, struct cache_entry *entry) {
     return new_entry;
 }
 
-static struct cache_entry *
-cache_move(struct cache *cache, struct cache_entry_list *old, struct cache_entry_list *new) {
+static struct cache_entry *cache_move(struct cache *cache, struct cache_entry_list *old, struct cache_entry_list *new) {
     struct cache_entry *entry;
     entry=cache_remove_lru(NULL, old);
     if (! entry)
@@ -232,8 +216,7 @@ cache_move(struct cache *cache, struct cache_entry_list *old, struct cache_entry
     return entry;
 }
 
-static int
-cache_replace(struct cache *cache) {
+static int cache_replace(struct cache *cache) {
     if (cache->t1.size >= MAX(1,cache->t1_target)) {
         dbg(lvl_debug,"replace 12");
         if (!cache_move(cache, &cache->t1, &cache->b1))
@@ -252,8 +235,7 @@ cache_replace(struct cache *cache) {
     return 1;
 }
 
-void
-cache_flush(struct cache *cache, void *id) {
+void cache_flush(struct cache *cache, void *id) {
     struct cache_entry *entry=g_hash_table_lookup(cache->hash, id);
     if (entry) {
         cache_remove_from_list(entry->where, entry);
@@ -261,8 +243,7 @@ cache_flush(struct cache *cache, void *id) {
     }
 }
 
-void
-cache_flush_data(struct cache *cache, void *data) {
+void cache_flush_data(struct cache *cache, void *data) {
     struct cache_entry *entry=(struct cache_entry *)((char *)data-cache->entry_size);
     if (entry) {
         cache_remove_from_list(entry->where, entry);
@@ -271,8 +252,7 @@ cache_flush_data(struct cache *cache, void *data) {
 }
 
 
-void *
-cache_lookup(struct cache *cache, void *id) {
+void *cache_lookup(struct cache *cache, void *id) {
     struct cache_entry *entry;
 
     dbg(lvl_debug,"get %d", ((int *)id)[0]);
@@ -324,8 +304,7 @@ cache_lookup(struct cache *cache, void *id) {
     }
 }
 
-void
-cache_insert(struct cache *cache, void *data) {
+void cache_insert(struct cache *cache, void *data) {
     struct cache_entry *entry=(struct cache_entry *)((char *)data-cache->entry_size);
     dbg(lvl_debug,"insert 0x%x 0x%x 0x%x 0x%x 0x%x", entry->id[0], entry->id[1], entry->id[2], entry->id[3], entry->id[4]);
     if (cache->insert == &cache->t1) {
@@ -347,15 +326,13 @@ cache_insert(struct cache *cache, void *data) {
     cache_insert_mru(cache, cache->insert, entry);
 }
 
-void *
-cache_insert_new(struct cache *cache, void *id, int size) {
+void *cache_insert_new(struct cache *cache, void *id, int size) {
     void *data=cache_entry_new(cache, id, size);
     cache_insert(cache, data);
     return data;
 }
 
-static void
-cache_stats(struct cache *cache) {
+static void cache_stats(struct cache *cache) {
     dbg(lvl_debug,"hits %d misses %d hitratio %d size %d entry_size %d id_size %d T1 target %d", cache->hits, cache->misses,
         cache->hits*100/(cache->hits+cache->misses), cache->size, cache->entry_size, cache->id_size, cache->t1_target);
     dbg(lvl_debug,"T1:%d B1:%d T2:%d B2:%d", cache->t1.size, cache->b1.size, cache->t2.size, cache->b2.size);
@@ -363,8 +340,7 @@ cache_stats(struct cache *cache) {
     cache->misses=0;
 }
 
-void
-cache_dump(struct cache *cache) {
+void cache_dump(struct cache *cache) {
     cache_stats(cache);
     cache_list_dump("T1", cache, &cache->t1);
     cache_list_dump("B1", cache, &cache->b1);

--- a/navit/callback.c
+++ b/navit/callback.c
@@ -88,20 +88,17 @@ callback_new_args(void (*func)(void), int count, ...) {
     return callback_new(func, count, p);
 }
 
-void
-callback_destroy(struct callback *cb) {
+void callback_destroy(struct callback *cb) {
     g_free(cb);
 }
 
-void
-callback_set_arg(struct callback *cb, int arg, void *p) {
+void callback_set_arg(struct callback *cb, int arg, void *p) {
     if (arg < 0 || arg > cb->pcount)
         return;
     cb->p[arg]=p;
 }
 
-void
-callback_list_add(struct callback_list *l, struct callback *cb) {
+void callback_list_add(struct callback_list *l, struct callback *cb) {
     l->list=g_list_prepend(l->list, cb);
 }
 
@@ -115,19 +112,16 @@ callback_list_add_new(struct callback_list *l, void (*func)(void), int pcount, v
     return ret;
 }
 
-void
-callback_list_remove(struct callback_list *l, struct callback *cb) {
+void callback_list_remove(struct callback_list *l, struct callback *cb) {
     l->list=g_list_remove(l->list, cb);
 }
 
-void
-callback_list_remove_destroy(struct callback_list *l, struct callback *cb) {
+void callback_list_remove_destroy(struct callback_list *l, struct callback *cb) {
     callback_list_remove(l, cb);
     g_free(cb);
 }
 
-void
-callback_call(struct callback *cb, int pcount, void **p) {
+void callback_call(struct callback *cb, int pcount, void **p) {
     int i;
     void *pf[8];
     if (! cb)
@@ -187,8 +181,7 @@ callback_call(struct callback *cb, int pcount, void **p) {
     }
 }
 
-void
-callback_call_args(struct callback *cb, int count, ...) {
+void callback_call_args(struct callback *cb, int count, ...) {
     int i;
     void **p=g_alloca(sizeof(void*)*count);
     va_list ap;
@@ -199,8 +192,7 @@ callback_call_args(struct callback *cb, int count, ...) {
     callback_call(cb, count, p);
 }
 
-void
-callback_list_call_attr(struct callback_list *l, enum attr_type type, int pcount, void **p) {
+void callback_list_call_attr(struct callback_list *l, enum attr_type type, int pcount, void **p) {
     GList *cbi;
     struct callback *cb;
 
@@ -218,8 +210,7 @@ callback_list_call_attr(struct callback_list *l, enum attr_type type, int pcount
 
 }
 
-void
-callback_list_call_attr_args(struct callback_list *cbl, enum attr_type type, int count, ...) {
+void callback_list_call_attr_args(struct callback_list *cbl, enum attr_type type, int count, ...) {
     int i;
     void **p=g_alloca(sizeof(void*)*count);
     va_list ap;
@@ -230,13 +221,11 @@ callback_list_call_attr_args(struct callback_list *cbl, enum attr_type type, int
     callback_list_call_attr(cbl, type, count, p);
 }
 
-void
-callback_list_call(struct callback_list *l, int pcount, void **p) {
+void callback_list_call(struct callback_list *l, int pcount, void **p) {
     callback_list_call_attr(l, attr_any, pcount, p);
 }
 
-void
-callback_list_call_args(struct callback_list *cbl, int count, ...) {
+void callback_list_call_args(struct callback_list *cbl, int count, ...) {
     int i;
     void **p=g_alloca(sizeof(void*)*count);
     va_list ap;
@@ -247,8 +236,7 @@ callback_list_call_args(struct callback_list *cbl, int count, ...) {
     callback_list_call(cbl, count, p);
 }
 
-void
-callback_list_destroy(struct callback_list *l) {
+void callback_list_destroy(struct callback_list *l) {
     GList *cbi;
     cbi=l->list;
     while (cbi) {

--- a/navit/command.c
+++ b/navit/command.c
@@ -1501,8 +1501,7 @@ void command_interpreter(struct attr *attr) {
 }
 #endif
 
-static void command_table_call(struct command_table *table, int count, void *data, char *command, struct attr **in,
-                               struct attr ***out, int *valid) {
+static void command_table_call(struct command_table *table, int count, void *data, char *command, struct attr **in, struct attr ***out, int *valid) {
     int i;
     for (i = 0 ; i < count ; i++) {
         if (!strcmp(command,table->command)) {

--- a/navit/command.c
+++ b/navit/command.c
@@ -153,8 +153,7 @@ char *command_error_to_text(int err) {
     }
 }
 
-static void
-result_free(struct result *res) {
+static void result_free(struct result *res) {
     if(res->allocated) {
         attr_free_content(&res->attr);
         res->allocated=0;
@@ -168,8 +167,7 @@ result_free(struct result *res) {
 
 static int command_register_callbacks(struct command_saved *cs);
 
-static const char *
-get_op(struct context *ctx, int test, ...) {
+static const char *get_op(struct context *ctx, int test, ...) {
     char *op;
     const char *ret=NULL;
     va_list ap;
@@ -197,13 +195,11 @@ is_int(struct result *res)
 	return 1;
 }*/
 
-static int
-is_double(struct result *res) {
+static int is_double(struct result *res) {
     return 0;
 }
 
-static void
-dump(struct result *res) {
+static void dump(struct result *res) {
 #if 0
     char object[res->varlen+1];
     char attribute[res->attrnlen+1];
@@ -218,8 +214,7 @@ dump(struct result *res) {
 #endif
 }
 
-static enum attr_type
-command_attr_type(struct result *res) {
+static enum attr_type command_attr_type(struct result *res) {
     char *attrn=g_alloca(sizeof(char)*(res->attrnlen+1));
 
     strncpy(attrn, res->attrn, res->attrnlen);
@@ -242,8 +237,8 @@ command_attr_type(struct result *res) {
  * @return True if a matching attribute was found, false if no matching attribute was found or an error
  * occurred
  */
-static int
-command_object_get_attr(struct context *ctx, struct attr *object, enum attr_type attr_type, struct attr *ret) {
+static int command_object_get_attr(struct context *ctx, struct attr *object, enum attr_type attr_type,
+                                   struct attr *ret) {
     int r;
     struct attr dup;
     struct object_func *func=object_func_lookup(object->type);
@@ -259,16 +254,14 @@ command_object_get_attr(struct context *ctx, struct attr *object, enum attr_type
         return r;
 }
 
-static int
-command_object_add_attr(struct context *ctx, struct attr *object, struct attr *attr) {
+static int command_object_add_attr(struct context *ctx, struct attr *object, struct attr *attr) {
     struct object_func *func=object_func_lookup(object->type);
     if (!object->u.data || !func || !func->add_attr)
         return 0;
     return func->add_attr(object->u.data, attr);
 }
 
-static int
-command_object_remove_attr(struct context *ctx, struct attr *object, struct attr *attr) {
+static int command_object_remove_attr(struct context *ctx, struct attr *object, struct attr *attr) {
     struct object_func *func=object_func_lookup(object->type);
     if (!object->u.data || !func || !func->remove_attr)
         return 0;
@@ -297,8 +290,7 @@ command_object_remove_attr(struct context *ctx, struct attr *object, struct attr
  * @param ctx The context
  * @param res The result
  */
-static void
-command_get_attr(struct context *ctx, struct result *res) {
+static void command_get_attr(struct context *ctx, struct result *res) {
     int result;
     struct result tmp= {{0,},};
     enum attr_type attr_type=command_attr_type(res);
@@ -325,8 +317,7 @@ command_get_attr(struct context *ctx, struct result *res) {
     dump(res);
 }
 
-static void
-command_set_attr(struct context *ctx, struct result *res, struct result *newres) {
+static void command_set_attr(struct context *ctx, struct result *res, struct result *newres) {
     enum attr_type attr_type=command_attr_type(res);
     struct object_func *func=object_func_lookup(res->attr.type);
     if (ctx->skip)
@@ -363,8 +354,7 @@ command_set_attr(struct context *ctx, struct result *res, struct result *newres)
  * @param ctx The context
  * @param res The result
  */
-static void
-resolve_object(struct context *ctx, struct result *res) {
+static void resolve_object(struct context *ctx, struct result *res) {
     if (res->attr.type == attr_none && res->varlen) {
         res->attr=*ctx->attr;
         res->attrn=res->var;
@@ -392,15 +382,13 @@ resolve_object(struct context *ctx, struct result *res) {
  * @param ctx The context
  * @param res The result
  */
-static void
-resolve(struct context *ctx, struct result *res) {
+static void resolve(struct context *ctx, struct result *res) {
     resolve_object(ctx, res);
     if (res->attrn)
         command_get_attr(ctx, res);
 }
 
-static double
-get_double(struct context *ctx, struct result *res) {
+static double get_double(struct context *ctx, struct result *res) {
     resolve(ctx, res);
     return res->val;
 }
@@ -426,8 +414,7 @@ get_double(struct context *ctx, struct result *res) {
  *
  * @return The result of the expression, see description.
  */
-static int
-get_int_bool(struct context *ctx, int is_bool, struct result *res) {
+static int get_int_bool(struct context *ctx, int is_bool, struct result *res) {
     resolve(ctx, res);
     if (res->attr.type == attr_none)
         return 0;
@@ -452,8 +439,7 @@ get_int_bool(struct context *ctx, int is_bool, struct result *res) {
  * This function is a wrapper around {@code get_int_bool()}. It is equivalent to
  * {@code get_int_bool(ctx, 0, res)}. See {@code get_int_bool()} for a description.
  */
-static int
-get_int(struct context *ctx, struct result *res) {
+static int get_int(struct context *ctx, struct result *res) {
     return get_int_bool(ctx, 0, res);
 }
 
@@ -463,35 +449,31 @@ get_int(struct context *ctx, struct result *res) {
  * This function is a wrapper around {@code get_int_bool()}. It is equivalent to
  * {@code get_int_bool(ctx, 1, res)}. See {@code get_int_bool()} for a description.
  */
-static int
-get_bool(struct context *ctx, struct result *res) {
+static int get_bool(struct context *ctx, struct result *res) {
     return !!get_int_bool(ctx, 1, res);
 }
 
 
-static char *
-get_string(struct context *ctx, struct result *res) {
+static char *get_string(struct context *ctx, struct result *res) {
     resolve(ctx, res);
     return attr_to_text(&res->attr, NULL, 0);
 }
 
-static void
-set_double(struct result *res, double val) {
+static void set_double(struct result *res, double val) {
     result_free(res);
     res->attr.type=attr_type_double_begin;
     res->attr.u.numd=&res->val;
     res->val=val;
 }
 
-static void
-set_int(struct result *res, int val) {
+static void set_int(struct result *res, int val) {
     result_free(res);
     res->attr.type=attr_type_int_begin;
     res->attr.u.num=val;
 }
 
-static void
-result_op(struct context *ctx, enum op_type op_type, const char *op, struct result *inout, struct result *in) {
+static void result_op(struct context *ctx, enum op_type op_type, const char *op, struct result *inout,
+                      struct result *in) {
     if (ctx->skip)
         return;
     switch (op_type) {
@@ -605,8 +587,7 @@ result_op(struct context *ctx, enum op_type op_type, const char *op, struct resu
     ctx->error=internal;
 }
 
-static void
-result_set(struct context *ctx, enum set_type set_type, const char *op, int len, struct result *out) {
+static void result_set(struct context *ctx, enum set_type set_type, const char *op, int len, struct result *out) {
     if (ctx->skip)
         return;
     switch (set_type) {
@@ -672,8 +653,7 @@ result_set(struct context *ctx, enum set_type set_type, const char *op, int len,
  * @param ctx The context to evaluate
  * @param res Points to a {@code struct res} in which the result will be stored
  */
-static void
-eval_value(struct context *ctx, struct result *res) {
+static void eval_value(struct context *ctx, struct result *res) {
     const char *op;
     int dots=0;
 
@@ -787,8 +767,7 @@ eval_value(struct context *ctx, struct result *res) {
  * has been retrieved (e.g. {@code vehicle} from {@code vehicle.position_speed}), the return value is 2.
  * If no object references were found, the return value is 0.
  */
-static int
-get_next_object(struct context *ctx, struct result *res) {
+static int get_next_object(struct context *ctx, struct result *res) {
 
     while (*ctx->expr) {
         res->varlen = 0;
@@ -813,8 +792,7 @@ get_next_object(struct context *ctx, struct result *res) {
     return 0;
 }
 
-static void
-eval_brace(struct context *ctx, struct result *res) {
+static void eval_brace(struct context *ctx, struct result *res) {
     if (get_op(ctx,0,"(",NULL)) {
         eval_comma(ctx, res);
         if (ctx->error) return;
@@ -825,8 +803,7 @@ eval_brace(struct context *ctx, struct result *res) {
     eval_value(ctx, res);
 }
 
-static void
-command_call_function(struct context *ctx, struct result *res) {
+static void command_call_function(struct context *ctx, struct result *res) {
     struct attr cbl,**list=NULL;
     char *function=g_alloca(sizeof(char)*(res->attrnlen+1));
     if (res->attrn)
@@ -916,8 +893,7 @@ command_call_function(struct context *ctx, struct result *res) {
     res->attrnlen=0;
 }
 
-static void
-eval_postfix(struct context *ctx, struct result *res) {
+static void eval_postfix(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
     const char *op;
 
@@ -983,8 +959,7 @@ eval_postfix(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_unary(struct context *ctx, struct result *res) {
+static void eval_unary(struct context *ctx, struct result *res) {
     const char *op;
     op=get_op(ctx,0,"~","!",NULL);
     if (op) {
@@ -995,8 +970,7 @@ eval_unary(struct context *ctx, struct result *res) {
         eval_postfix(ctx, res);
 }
 
-static void
-eval_multiplicative(struct context *ctx, struct result *res) {
+static void eval_multiplicative(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
     const char *op;
 
@@ -1012,8 +986,7 @@ eval_multiplicative(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_additive(struct context *ctx, struct result *res) {
+static void eval_additive(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
     const char *op;
 
@@ -1029,8 +1002,7 @@ eval_additive(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_equality(struct context *ctx, struct result *res) {
+static void eval_equality(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
     const char *op;
 
@@ -1047,8 +1019,7 @@ eval_equality(struct context *ctx, struct result *res) {
 }
 
 
-static void
-eval_bitwise_and(struct context *ctx, struct result *res) {
+static void eval_bitwise_and(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
 
     eval_equality(ctx, res);
@@ -1064,8 +1035,7 @@ eval_bitwise_and(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_bitwise_xor(struct context *ctx, struct result *res) {
+static void eval_bitwise_xor(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
 
     eval_bitwise_and(ctx, res);
@@ -1080,8 +1050,7 @@ eval_bitwise_xor(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_bitwise_or(struct context *ctx, struct result *res) {
+static void eval_bitwise_or(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
 
     eval_bitwise_xor(ctx, res);
@@ -1097,8 +1066,7 @@ eval_bitwise_or(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_logical_and(struct context *ctx, struct result *res) {
+static void eval_logical_and(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
 
     eval_bitwise_or(ctx, res);
@@ -1113,8 +1081,7 @@ eval_logical_and(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_logical_or(struct context *ctx, struct result *res) {
+static void eval_logical_or(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
 
     eval_logical_and(ctx, res);
@@ -1129,8 +1096,7 @@ eval_logical_or(struct context *ctx, struct result *res) {
     }
 }
 
-static void
-eval_conditional(struct context *ctx, struct result *res) {
+static void eval_conditional(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
     int cond=0;
     int skip;
@@ -1174,8 +1140,7 @@ eval_conditional(struct context *ctx, struct result *res) {
 
 /* = *= /= %= += -= >>= <<= &= ^= |= */
 
-static void
-eval_assignment(struct context *ctx, struct result *res) {
+static void eval_assignment(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
     eval_conditional(ctx, res);
     if (ctx->error) return;
@@ -1195,8 +1160,7 @@ eval_assignment(struct context *ctx, struct result *res) {
 }
 
 /* , */
-static void
-eval_comma(struct context *ctx, struct result *res) {
+static void eval_comma(struct context *ctx, struct result *res) {
     struct result tmp= {{0,},};
 
     eval_assignment(ctx, res);
@@ -1210,8 +1174,7 @@ eval_comma(struct context *ctx, struct result *res) {
     }
 }
 
-static struct attr **
-eval_list(struct context *ctx) {
+static struct attr ** eval_list(struct context *ctx) {
     struct result tmp= {{0,},};
 
     struct attr **ret=NULL;
@@ -1250,8 +1213,7 @@ void command(struct attr *attr, char *expr) {
 }
 #endif
 
-static void
-command_evaluate_to(struct attr *attr, const char *expr, struct context *ctx, struct result *res) {
+static void command_evaluate_to(struct attr *attr, const char *expr, struct context *ctx, struct result *res) {
     result_free(res);
     memset(res, 0, sizeof(*res));
     memset(ctx, 0, sizeof(*ctx));
@@ -1260,8 +1222,7 @@ command_evaluate_to(struct attr *attr, const char *expr, struct context *ctx, st
     eval_comma(ctx,res);
 }
 
-enum attr_type
-command_evaluate_to_attr(struct attr *attr, char *expr, int *error, struct attr *ret) {
+enum attr_type command_evaluate_to_attr(struct attr *attr, char *expr, int *error, struct attr *ret) {
     struct result res={{0,},};
     struct context ctx;
     command_evaluate_to(attr, expr, &ctx, &res);
@@ -1273,8 +1234,7 @@ command_evaluate_to_attr(struct attr *attr, char *expr, int *error, struct attr 
     return command_attr_type(&res);
 }
 
-void
-command_evaluate_to_void(struct attr *attr, char *expr, int *error) {
+void command_evaluate_to_void(struct attr *attr, char *expr, int *error) {
     struct result res= {{0,},};
     struct context ctx;
     command_evaluate_to(attr, expr, &ctx, &res);
@@ -1286,8 +1246,7 @@ command_evaluate_to_void(struct attr *attr, char *expr, int *error) {
 
 }
 
-char *
-command_evaluate_to_string(struct attr *attr, char *expr, int *error) {
+char *command_evaluate_to_string(struct attr *attr, char *expr, int *error) {
     struct result res= {{0,},};
     struct context ctx;
     char *ret=NULL;
@@ -1308,8 +1267,7 @@ command_evaluate_to_string(struct attr *attr, char *expr, int *error) {
         return ret;
 }
 
-int
-command_evaluate_to_int(struct attr *attr, char *expr, int *error) {
+int command_evaluate_to_int(struct attr *attr, char *expr, int *error) {
     struct result res= {{0,},};
     struct context ctx;
     int ret=0;
@@ -1330,8 +1288,7 @@ command_evaluate_to_int(struct attr *attr, char *expr, int *error) {
         return ret;
 }
 
-int
-command_evaluate_to_boolean(struct attr *attr, const char *expr, int *error) {
+int command_evaluate_to_boolean(struct attr *attr, const char *expr, int *error) {
     struct result res= {{0,},};
     struct context ctx;
     int ret=0;
@@ -1359,8 +1316,7 @@ command_evaluate_to_boolean(struct attr *attr, const char *expr, int *error) {
         return ret;
 }
 
-int
-command_evaluate_to_length(const char *expr, int *error) {
+int command_evaluate_to_length(const char *expr, int *error) {
     struct attr attr;
     struct result res= {{0,},};
     struct context ctx;
@@ -1376,8 +1332,7 @@ command_evaluate_to_length(const char *expr, int *error) {
     return 0;
 }
 
-static int
-command_evaluate_single(struct context *ctx) {
+static int command_evaluate_single(struct context *ctx) {
     struct result res= {{0,},},tmp= {{0,},};
     const char *op,*a,*f,*end;
     enum attr_type attr_type;
@@ -1505,8 +1460,7 @@ command_evaluate_single(struct context *ctx) {
     }
 }
 
-void
-command_evaluate(struct attr *attr, const char *expr) {
+void command_evaluate(struct attr *attr, const char *expr) {
     /* Once the eval has started we can't rely anymore on the content of
      * expr which may be freed when the calling widget is destroyed by a
      * subsequent command call. Hence the g_strdup. */
@@ -1533,8 +1487,7 @@ command_evaluate(struct attr *attr, const char *expr) {
 }
 
 #if 0
-void
-command_interpreter(struct attr *attr) {
+void command_interpreter(struct attr *attr) {
     char buffer[4096];
     int size;
     for (;;) {
@@ -1548,9 +1501,8 @@ command_interpreter(struct attr *attr) {
 }
 #endif
 
-static void
-command_table_call(struct command_table *table, int count, void *data, char *command, struct attr **in,
-                   struct attr ***out, int *valid) {
+static void command_table_call(struct command_table *table, int count, void *data, char *command, struct attr **in,
+                               struct attr ***out, int *valid) {
     int i;
     for (i = 0 ; i < count ; i++) {
         if (!strcmp(command,table->command)) {
@@ -1562,21 +1514,18 @@ command_table_call(struct command_table *table, int count, void *data, char *com
     }
 }
 
-void
-command_add_table_attr(struct command_table *table, int count, void *data, struct attr *attr) {
+void command_add_table_attr(struct command_table *table, int count, void *data, struct attr *attr) {
     attr->type=attr_callback;
     attr->u.callback=callback_new_attr_3(callback_cast(command_table_call),attr_command, table, count, data);
 }
 
-void
-command_add_table(struct callback_list *cbl, struct command_table *table, int count, void *data) {
+void command_add_table(struct callback_list *cbl, struct command_table *table, int count, void *data) {
     struct attr attr;
     command_add_table_attr(table, count, data, &attr);
     callback_list_add(cbl, attr.u.callback);
 }
 
-void
-command_saved_set_cb (struct command_saved *cs, struct callback *cb) {
+void command_saved_set_cb (struct command_saved *cs, struct callback *cb) {
     cs->cb = cb;
 }
 
@@ -1586,13 +1535,11 @@ command_saved_set_cb (struct command_saved *cs, struct callback *cb) {
  * This function is a wrapper around {@code get_int()}. It is equivalent to
  * {@code get_int(&cs->ctx, &cs->res)}. See {@code get_int()} for a description.
  */
-int
-command_saved_get_int (struct command_saved *cs) {
+int command_saved_get_int (struct command_saved *cs) {
     return get_int(&cs->ctx, &cs->res);
 }
 
-int
-command_saved_error (struct command_saved *cs) {
+int command_saved_error (struct command_saved *cs) {
     return cs->error;
 }
 
@@ -1606,8 +1553,7 @@ command_saved_error (struct command_saved *cs) {
  *
  * @param cs The command to evaluate
  */
-static void
-command_saved_evaluate_idle (struct command_saved *cs) {
+static void command_saved_evaluate_idle (struct command_saved *cs) {
     dbg(lvl_debug, "enter: cs=%p, cs->command=%s", cs, cs->command);
     // Only run once at a time
     if (cs->idle_ev) {
@@ -1639,8 +1585,7 @@ command_saved_evaluate_idle (struct command_saved *cs) {
  *
  * @param cs The command to evaluate
  */
-static void
-command_saved_evaluate(struct command_saved *cs) {
+static void command_saved_evaluate(struct command_saved *cs) {
     dbg(lvl_debug, "enter: cs=%p, cs->async=%d, cs->command=%s", cs, cs->async, cs->command);
     if (!cs->async) {
         command_saved_evaluate_idle(cs);
@@ -1663,8 +1608,7 @@ command_saved_evaluate(struct command_saved *cs) {
  *
  * @param cs The saved command
  */
-static void
-command_saved_callbacks_changed(struct command_saved *cs) {
+static void command_saved_callbacks_changed(struct command_saved *cs) {
     // For now, we delete each and every callback and then re-create them
     int i;
     struct object_func *func;
@@ -1719,8 +1663,7 @@ command_saved_callbacks_changed(struct command_saved *cs) {
  *
  * @return True if all callbacks were successfully registered, false if the function failed
  */
-static int
-command_register_callbacks(struct command_saved *cs) {
+static int command_register_callbacks(struct command_saved *cs) {
     struct attr prev;	/* The parent of the next object which will be retrieved. */
     struct attr cb_attr;
     int status;
@@ -1832,8 +1775,7 @@ command_saved_new(char *command, struct navit *navit, struct callback *cb, int a
     return command_saved_attr_new(command, &attr, cb, async);
 }
 
-void
-command_saved_destroy(struct command_saved *cs) {
+void command_saved_destroy(struct command_saved *cs) {
     g_free(cs->command);
     g_free(cs);
 }

--- a/navit/config_.c
+++ b/navit/config_.c
@@ -48,21 +48,18 @@ struct attr_iter {
     void *iter;
 };
 
-void
-config_destroy(struct config *this_) {
+void config_destroy(struct config *this_) {
     attr_list_free(this_->attrs);
     g_free(config);
     exit(0);
 }
 
-static void
-config_terminate(int sig) {
+static void config_terminate(int sig) {
     dbg(lvl_debug,"terminating");
     config_destroy(config);
 }
 
-static void
-config_new_int(void) {
+static void config_new_int(void) {
     config=g_new0(struct config, 1);
 #ifndef HAVE_API_WIN32_CE
     signal(SIGTERM, config_terminate);
@@ -76,13 +73,11 @@ config_new_int(void) {
 #endif
 }
 
-int
-config_get_attr(struct config *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int config_get_attr(struct config *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     return attr_generic_get_attr(this_->attrs, NULL, type, attr, iter);
 }
 
-static int
-config_set_attr_int(struct config *this_, struct attr *attr) {
+static int config_set_attr_int(struct config *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_language:
         setenv("LANG",attr->u.str,1);
@@ -94,16 +89,14 @@ config_set_attr_int(struct config *this_, struct attr *attr) {
     }
 }
 
-int
-config_set_attr(struct config *this_, struct attr *attr) {
+int config_set_attr(struct config *this_, struct attr *attr) {
     if (config_set_attr_int(this_, attr))
         return navit_object_set_attr((struct navit_object *)this_, attr);
     else
         return 0;
 }
 
-int
-config_add_attr(struct config *this_, struct attr *attr) {
+int config_add_attr(struct config *this_, struct attr *attr) {
     if (!config) {
         config_new_int();
         this_=config;
@@ -111,8 +104,7 @@ config_add_attr(struct config *this_, struct attr *attr) {
     return navit_object_add_attr((struct navit_object *)this_, attr);
 }
 
-int
-config_remove_attr(struct config *this_, struct attr *attr) {
+int config_remove_attr(struct config *this_, struct attr *attr) {
     return navit_object_remove_attr((struct navit_object *)this_, attr);
 }
 
@@ -121,8 +113,7 @@ config_attr_iter_new() {
     return navit_object_attr_iter_new();
 }
 
-void
-config_attr_iter_destroy(struct attr_iter *iter) {
+void config_attr_iter_destroy(struct attr_iter *iter) {
     navit_object_attr_iter_destroy(iter);
 }
 

--- a/navit/coord.c
+++ b/navit/coord.c
@@ -67,8 +67,7 @@ coord_new_from_attrs(struct attr *parent, struct attr **attrs) {
 }
 
 
-void
-coord_destroy(struct coord *c) {
+void coord_destroy(struct coord *c) {
     g_free(c);
 }
 
@@ -86,13 +85,11 @@ coord_rect_new(struct coord *lu, struct coord *rl) {
 
 }
 
-void
-coord_rect_destroy(struct coord_rect *r) {
+void coord_rect_destroy(struct coord_rect *r) {
     g_free(r);
 }
 
-int
-coord_rect_overlap(struct coord_rect *r1, struct coord_rect *r2) {
+int coord_rect_overlap(struct coord_rect *r1, struct coord_rect *r2) {
     dbg_assert(r1->lu.x <= r1->rl.x);
     dbg_assert(r1->lu.y >= r1->rl.y);
     dbg_assert(r2->lu.x <= r2->rl.x);
@@ -110,8 +107,7 @@ coord_rect_overlap(struct coord_rect *r1, struct coord_rect *r2) {
     return 1;
 }
 
-int
-coord_rect_contains(struct coord_rect *r, struct coord *c) {
+int coord_rect_contains(struct coord_rect *r, struct coord *c) {
     dbg_assert(r->lu.x <= r->rl.x);
     dbg_assert(r->lu.y >= r->rl.y);
     if (c->x < r->lu.x)
@@ -125,8 +121,7 @@ coord_rect_contains(struct coord_rect *r, struct coord *c) {
     return 1;
 }
 
-void
-coord_rect_extend(struct coord_rect *r, struct coord *c) {
+void coord_rect_extend(struct coord_rect *r, struct coord *c) {
     if (c->x < r->lu.x)
         r->lu.x=c->x;
     if (c->x > r->rl.x)
@@ -153,8 +148,7 @@ coord_rect_extend(struct coord_rect *r, struct coord *c) {
  * @returns The lenght of the parsed string
  */
 
-int
-coord_parse(const char *coord_input, enum projection output_projection, struct coord *result) {
+int coord_parse(const char *coord_input, enum projection output_projection, struct coord *result) {
     char *proj=NULL,*s,*co;
     const char *str=coord_input;
     int args,ret = 0;
@@ -265,8 +259,7 @@ out:
  * For parameters see coord_parse.
  */
 
-int
-pcoord_parse(const char *c_str, enum projection pro, struct pcoord *pc_ret) {
+int pcoord_parse(const char *c_str, enum projection pro, struct pcoord *pc_ret) {
     struct coord c;
     int ret;
     ret = coord_parse(c_str, pro, &c);
@@ -276,8 +269,7 @@ pcoord_parse(const char *c_str, enum projection pro, struct pcoord *pc_ret) {
     return ret;
 }
 
-void
-coord_print(enum projection pro, struct coord *c, FILE *out) {
+void coord_print(enum projection pro, struct coord *c, FILE *out) {
     unsigned int x;
     unsigned int y;
     char *sign_x = "";
@@ -372,14 +364,12 @@ void coord_format(float lat,float lng, enum coord_format fmt, char * buffer, int
 
 }
 
-unsigned int
-coord_hash(const void *key) {
+unsigned int coord_hash(const void *key) {
     const struct coord *c=key;
     return c->x^c->y;
 }
 
-int
-coord_equal(const void *a, const void *b) {
+int coord_equal(const void *a, const void *b) {
     const struct coord *c_a=a;
     const struct coord *c_b=b;
     if (c_a->x == c_b->x && c_a->y == c_b->y)

--- a/navit/country.c
+++ b/navit/country.c
@@ -303,8 +303,7 @@ struct country_search {
     enum attr_type attr_next;
 };
 
-static int
-country_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int country_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct country_search *this_=priv_data;
     struct country *country=this_->country;
 
@@ -377,8 +376,7 @@ country_search_new(struct attr *search, int partial) {
     return ret;
 }
 
-static int
-match(struct country_search *this_, enum attr_type type, const char *name) {
+static int match(struct country_search *this_, enum attr_type type, const char *name) {
     int ret;
     if (!name)
         return 0;
@@ -425,8 +423,7 @@ country_default(void) {
     return &country_default_attr;
 }
 
-void
-country_search_destroy(struct country_search *this_) {
+void country_search_destroy(struct country_search *this_) {
     g_free(this_->search.u.str);
     g_free(this_);
 }

--- a/navit/data_window.c
+++ b/navit/data_window.c
@@ -20,18 +20,15 @@
 #include <glib.h>
 #include "data_window.h"
 
-void
-datawindow_mode(struct datawindow *win, int start) {
+void datawindow_mode(struct datawindow *win, int start) {
     win->meth.mode(win->priv, start);
 }
 
-void
-datawindow_add(struct datawindow *win, struct param_list *param, int count) {
+void datawindow_add(struct datawindow *win, struct param_list *param, int count) {
     win->meth.add(win->priv, param, count);
 }
 
-void
-datawindow_destroy(struct datawindow *win) {
+void datawindow_destroy(struct datawindow *win) {
     win->meth.destroy(win->priv);
     g_free(win);
 }

--- a/navit/debug.c
+++ b/navit/debug.c
@@ -263,9 +263,7 @@ static android_LogPriority dbg_level_to_android(dbg_level level) {
 }
 #endif
 
-void debug_vprintf(dbg_level level, const char *module, const int mlen, const char *function, const int flen,
-                   int prefix,
-                   const char *fmt, va_list ap) {
+void debug_vprintf(dbg_level level, const char *module, const int mlen, const char *function, const int flen, int prefix, const char *fmt, va_list ap) {
 #if defined HAVE_API_WIN32_CE || defined _MSC_VER
     char message_origin[4096];
 #else
@@ -322,17 +320,14 @@ void debug_vprintf(dbg_level level, const char *module, const int mlen, const ch
     }
 }
 
-void debug_printf(dbg_level level, const char *module, const int mlen,const char *function, const int flen, int prefix,
-                  const char *fmt, ...) {
+void debug_printf(dbg_level level, const char *module, const int mlen,const char *function, const int flen, int prefix, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     debug_vprintf(level, module, mlen, function, flen, prefix, fmt, ap);
     va_end(ap);
 }
 
-void debug_assert_fail(const char *module, const int mlen,const char *function, const int flen, const char *file,
-                       int line,
-                       const char *expr) {
+void debug_assert_fail(const char *module, const int mlen,const char *function, const int flen, const char *file, int line, const char *expr) {
     debug_printf(lvl_error,module,mlen,function,flen,1,"%s:%d assertion failed:%s\n", file, line, expr);
     abort();
 }

--- a/navit/debug.c
+++ b/navit/debug.c
@@ -83,8 +83,7 @@ static void sigsegv(int sig) {
 }
 #endif
 
-void
-debug_init(const char *program_name) {
+void debug_init(const char *program_name) {
 #ifndef HAVE_API_ANDROID
     gdb_program=g_strdup(program_name);
     signal(SIGSEGV, sigsegv);
@@ -98,14 +97,12 @@ debug_init(const char *program_name) {
 }
 
 
-static void
-debug_update_level(gpointer key, gpointer value, gpointer user_data) {
+static void debug_update_level(gpointer key, gpointer value, gpointer user_data) {
     if (max_debug_level < GPOINTER_TO_INT(value))
         max_debug_level = GPOINTER_TO_INT(value);
 }
 
-void
-debug_set_global_level(dbg_level level, int override_old_value ) {
+void debug_set_global_level(dbg_level level, int override_old_value ) {
     if (global_debug_level == GLOBAL_DEBUG_LEVEL_UNSET || override_old_value) {
         global_debug_level=level;
         if (max_debug_level < global_debug_level) {
@@ -114,8 +111,7 @@ debug_set_global_level(dbg_level level, int override_old_value ) {
     }
 }
 
-void
-debug_level_set(const char *name, dbg_level level) {
+void debug_level_set(const char *name, dbg_level level) {
     if (!strcmp(name, "segv")) {
 #ifndef HAVE_API_ANDROID
         segv_level=level;
@@ -134,8 +130,7 @@ debug_level_set(const char *name, dbg_level level) {
     }
 }
 
-static dbg_level
-parse_dbg_level(struct attr *dbg_level_attr, struct attr *level_attr) {
+static dbg_level parse_dbg_level(struct attr *dbg_level_attr, struct attr *level_attr) {
     if (dbg_level_attr) {
         if(!strcmp(dbg_level_attr->u.str,"error")) {
             return lvl_error;
@@ -199,8 +194,7 @@ debug_new(struct attr *parent, struct attr **attrs) {
 }
 
 
-dbg_level
-debug_level_get(const char *message_category) {
+dbg_level debug_level_get(const char *message_category) {
     if (!debug_hash)
         return DEFAULT_DEBUG_LEVEL;
     gpointer level = g_hash_table_lookup(debug_hash, message_category);
@@ -252,8 +246,7 @@ static char* dbg_level_to_string(dbg_level level) {
 }
 
 #ifdef HAVE_API_ANDROID
-static android_LogPriority
-dbg_level_to_android(dbg_level level) {
+static android_LogPriority dbg_level_to_android(dbg_level level) {
     switch(level) {
     case lvl_unset:
         return ANDROID_LOG_UNKNOWN;
@@ -270,9 +263,9 @@ dbg_level_to_android(dbg_level level) {
 }
 #endif
 
-void
-debug_vprintf(dbg_level level, const char *module, const int mlen, const char *function, const int flen, int prefix,
-              const char *fmt, va_list ap) {
+void debug_vprintf(dbg_level level, const char *module, const int mlen, const char *function, const int flen,
+                   int prefix,
+                   const char *fmt, va_list ap) {
 #if defined HAVE_API_WIN32_CE || defined _MSC_VER
     char message_origin[4096];
 #else
@@ -329,24 +322,22 @@ debug_vprintf(dbg_level level, const char *module, const int mlen, const char *f
     }
 }
 
-void
-debug_printf(dbg_level level, const char *module, const int mlen,const char *function, const int flen, int prefix,
-             const char *fmt, ...) {
+void debug_printf(dbg_level level, const char *module, const int mlen,const char *function, const int flen, int prefix,
+                  const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     debug_vprintf(level, module, mlen, function, flen, prefix, fmt, ap);
     va_end(ap);
 }
 
-void
-debug_assert_fail(const char *module, const int mlen,const char *function, const int flen, const char *file, int line,
-                  const char *expr) {
+void debug_assert_fail(const char *module, const int mlen,const char *function, const int flen, const char *file,
+                       int line,
+                       const char *expr) {
     debug_printf(lvl_error,module,mlen,function,flen,1,"%s:%d assertion failed:%s\n", file, line, expr);
     abort();
 }
 
-void
-debug_destroy(void) {
+void debug_destroy(void) {
     if (!debug_fp)
         return;
     if (debug_fp == stderr || debug_fp == stdout)
@@ -381,8 +372,7 @@ struct malloc_tail {
 
 int mallocs,debug_malloc_size,debug_malloc_size_m;
 
-void
-debug_dump_mallocs(void) {
+void debug_dump_mallocs(void) {
     struct malloc_head *head=malloc_heads;
     int i;
     dbg(lvl_debug,"mallocs %d",mallocs);
@@ -394,8 +384,7 @@ debug_dump_mallocs(void) {
     }
 }
 
-void *
-debug_malloc(const char *where, int line, const char *func, int size) {
+void *debug_malloc(const char *where, int line, const char *func, int size) {
     struct malloc_head *head;
     struct malloc_tail *tail;
     if (!size)
@@ -433,16 +422,14 @@ debug_malloc(const char *where, int line, const char *func, int size) {
 }
 
 
-void *
-debug_malloc0(const char *where, int line, const char *func, int size) {
+void *debug_malloc0(const char *where, int line, const char *func, int size) {
     void *ret=debug_malloc(where, line, func, size);
     if (ret)
         memset(ret, 0, size);
     return ret;
 }
 
-void *
-debug_realloc(const char *where, int line, const char *func, void *ptr, int size) {
+void *debug_realloc(const char *where, int line, const char *func, void *ptr, int size) {
     void *ret=debug_malloc(where, line, func, size);
     if (ret && ptr)
         memcpy(ret, ptr, size);
@@ -450,8 +437,7 @@ debug_realloc(const char *where, int line, const char *func, void *ptr, int size
     return ret;
 }
 
-char *
-debug_strdup(const char *where, int line, const char *func, const char *ptr) {
+char *debug_strdup(const char *where, int line, const char *func, const char *ptr) {
     int size;
     char *ret;
 
@@ -463,15 +449,13 @@ debug_strdup(const char *where, int line, const char *func, const char *ptr) {
     return ret;
 }
 
-char *
-debug_guard(const char *where, int line, const char *func, char *str) {
+char *debug_guard(const char *where, int line, const char *func, char *str) {
     char *ret=debug_strdup(where, line, func, str);
     g_free(str);
     return ret;
 }
 
-void
-debug_free(const char *where, int line, const char *func, void *ptr) {
+void debug_free(const char *where, int line, const char *func, void *ptr) {
     struct malloc_head *head;
     struct malloc_tail *tail;
     if (!ptr)
@@ -495,8 +479,7 @@ debug_free(const char *where, int line, const char *func, void *ptr) {
     free(head);
 }
 
-void
-debug_free_func(void *ptr) {
+void debug_free_func(void *ptr) {
     debug_free("unknown",0,"unknown",ptr);
 }
 

--- a/navit/event.c
+++ b/navit/event.c
@@ -55,8 +55,7 @@ void event_main_loop_quit(void) {
     has_quit=1;
 }
 
-int
-event_main_loop_has_quit(void) {
+int event_main_loop_has_quit(void) {
     return has_quit;
 }
 
@@ -66,8 +65,7 @@ event_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     return event_methods.add_watch(fd, cond, cb);
 }
 
-void
-event_remove_watch(struct event_watch *ev) {
+void event_remove_watch(struct event_watch *ev) {
     require_method(remove_watch);
     event_methods.remove_watch(ev);
 }
@@ -87,8 +85,7 @@ event_add_timeout(int timeout, int multi, struct callback *cb) {
     return event_methods.add_timeout(timeout, multi, cb);
 }
 
-void
-event_remove_timeout(struct event_timeout *ev) {
+void event_remove_timeout(struct event_timeout *ev) {
     require_method(remove_timeout);
     event_methods.remove_timeout(ev);
 }
@@ -99,25 +96,21 @@ event_add_idle(int priority, struct callback *cb) {
     return event_methods.add_idle(priority,cb);
 }
 
-void
-event_remove_idle(struct event_idle *ev) {
+void event_remove_idle(struct event_idle *ev) {
     require_method(remove_idle);
     event_methods.remove_idle(ev);
 }
 
-void
-event_call_callback(struct callback_list *cb) {
+void event_call_callback(struct callback_list *cb) {
     require_method(call_callback);
     event_methods.call_callback(cb);
 }
 
-char const *
-event_system(void) {
+char const *event_system(void) {
     return e_system;
 }
 
-int
-event_request_system(const char *system, const char *requestor) {
+int event_request_system(const char *system, const char *requestor) {
     void (*event_type_new)(struct event_methods *meth);
     if (e_system) {
         if (strcmp(e_system, system)) {

--- a/navit/event_glib.c
+++ b/navit/event_glib.c
@@ -46,15 +46,13 @@ struct event_watch {
     guint source;
 };
 
-static gboolean
-event_glib_call_watch(GIOChannel * iochan, GIOCondition condition, gpointer t) {
+static gboolean event_glib_call_watch(GIOChannel * iochan, GIOCondition condition, gpointer t) {
     struct callback *cb=t;
     callback_call_0(cb);
     return TRUE;
 }
 
-static struct event_watch *
-event_glib_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_glib_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     struct event_watch *ret=g_new0(struct event_watch, 1);
     int flags=0;
     ret->iochan = g_io_channel_unix_new(fd);
@@ -73,8 +71,7 @@ event_glib_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     return ret;
 }
 
-static void
-event_glib_remove_watch(struct event_watch *ev) {
+static void event_glib_remove_watch(struct event_watch *ev) {
     if (! ev)
         return;
     g_source_remove(ev->source);
@@ -87,22 +84,19 @@ struct event_timeout {
     struct callback *cb;
 };
 
-static gboolean
-event_glib_call_timeout_single(struct event_timeout *ev) {
+static gboolean event_glib_call_timeout_single(struct event_timeout *ev) {
     callback_call_0(ev->cb);
     g_free(ev);
     return FALSE;
 }
 
-static gboolean
-event_glib_call_timeout_multi(struct event_timeout *ev) {
+static gboolean event_glib_call_timeout_multi(struct event_timeout *ev) {
     callback_call_0(ev->cb);
     return TRUE;
 }
 
 
-static struct event_timeout *
-event_glib_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_glib_add_timeout(int timeout, int multi, struct callback *cb) {
     struct event_timeout *ret=g_new0(struct event_timeout, 1);
     ret->cb=cb;
     ret->source = g_timeout_add(timeout,
@@ -111,8 +105,7 @@ event_glib_add_timeout(int timeout, int multi, struct callback *cb) {
     return ret;
 }
 
-static void
-event_glib_remove_timeout(struct event_timeout *ev) {
+static void event_glib_remove_timeout(struct event_timeout *ev) {
     if (! ev)
         return;
     g_source_remove(ev->source);
@@ -124,30 +117,26 @@ struct event_idle {
     struct callback *cb;
 };
 
-static gboolean
-event_glib_call_idle(struct event_idle *ev) {
+static gboolean event_glib_call_idle(struct event_idle *ev) {
     callback_call_0(ev->cb);
     return TRUE;
 }
 
-static struct event_idle *
-event_glib_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_glib_add_idle(int priority, struct callback *cb) {
     struct event_idle *ret=g_new0(struct event_idle, 1);
     ret->cb=cb;
     ret->source = g_idle_add_full(G_PRIORITY_HIGH_IDLE+priority, (GSourceFunc)event_glib_call_idle, (gpointer)ret, NULL);
     return ret;
 }
 
-static void
-event_glib_remove_idle(struct event_idle *ev) {
+static void event_glib_remove_idle(struct event_idle *ev) {
     if (! ev)
         return;
     g_source_remove(ev->source);
     g_free(ev);
 }
 
-static void
-event_glib_call_callback(struct callback_list *cb) {
+static void event_glib_call_callback(struct callback_list *cb) {
     /*
      Idea for implementation:
      Create a pipe then use add_watch
@@ -173,13 +162,11 @@ struct event_priv {
     int data;
 };
 
-static struct event_priv*
-event_glib_new(struct event_methods *meth) {
+static struct event_priv* event_glib_new(struct event_methods *meth) {
     *meth=event_glib_methods;
     return (struct event_priv *)event_glib_new;
 }
 
-void
-event_glib_init(void) {
+void event_glib_init(void) {
     plugin_register_category_event("glib", event_glib_new);
 }

--- a/navit/file.c
+++ b/navit/file.c
@@ -69,8 +69,7 @@ struct file_cache_id {
 #endif
 
 #ifdef HAVE_SOCKET
-static int
-file_socket_connect(char *host, char *service) {
+static int file_socket_connect(char *host, char *service) {
     struct addrinfo hints;
     struct addrinfo *result, *rp;
     int fd=-1,s;
@@ -98,8 +97,7 @@ file_socket_connect(char *host, char *service) {
     return fd;
 }
 
-static void
-file_http_request(struct file *file, char *method, char *host, char *path, char *header, int persistent) {
+static void file_http_request(struct file *file, char *method, char *host, char *path, char *header, int persistent) {
     char *request=g_strdup_printf("%s %s HTTP/1.0\r\nUser-Agent: navit %s\r\nHost: %s\r\n%s%s%s\r\n",method,path,version,
                                   host,persistent?"Connection: Keep-Alive\r\n":"",header?header:"",header?"\r\n":"");
     write(file->fd, request, strlen(request));
@@ -107,8 +105,7 @@ file_http_request(struct file *file, char *method, char *host, char *path, char 
     file->requests++;
 }
 
-static int
-file_request_do(struct file *file, struct attr **options, int connect) {
+static int file_request_do(struct file *file, struct attr **options, int connect) {
     struct attr *attr;
     char *name;
 
@@ -150,8 +147,7 @@ file_request_do(struct file *file, struct attr **options, int connect) {
 }
 #endif
 
-static unsigned char *
-file_http_header_end(unsigned char *str, int len) {
+static unsigned char *file_http_header_end(unsigned char *str, int len) {
     int i;
     for (i=0; i+1<len; i+=2) {
         if (str[i+1]=='\n') {
@@ -169,8 +165,7 @@ file_http_header_end(unsigned char *str, int len) {
     return NULL;
 }
 
-int
-file_request(struct file *f, struct attr **options) {
+int file_request(struct file *f, struct attr **options) {
 #ifdef HAVE_SOCKET
     return file_request_do(f, options, 0);
 #else
@@ -178,8 +173,7 @@ file_request(struct file *f, struct attr **options) {
 #endif
 }
 
-char *
-file_http_header(struct file *f, char *header) {
+char *file_http_header(struct file *f, char *header) {
     if (!f->headers)
         return NULL;
     return g_hash_table_lookup(f->headers, header);
@@ -254,8 +248,7 @@ int file_is_reg(char *name) {
     return 0;
 }
 
-long long
-file_size(struct file *file) {
+long long file_size(struct file *file) {
     return file->size;
 }
 
@@ -289,8 +282,7 @@ int file_mkdir(char *name, int pflag) {
     return file_mkdir(buffer, 0);
 }
 
-int
-file_mmap(struct file *file) {
+int file_mmap(struct file *file) {
 #if 0
     int mmap_size=file->size+1024*1024;
 #else
@@ -313,8 +305,7 @@ file_mmap(struct file *file) {
     return 1;
 }
 
-unsigned char *
-file_data_read(struct file *file, long long offset, int size) {
+unsigned char *file_data_read(struct file *file, long long offset, int size) {
     void *ret;
     if (file->special)
         return NULL;
@@ -337,8 +328,7 @@ file_data_read(struct file *file, long long offset, int size) {
 
 }
 
-static void
-file_process_headers(struct file *file, unsigned char *headers) {
+static void file_process_headers(struct file *file, unsigned char *headers) {
     char *tok;
     char *cl;
     if (file->headers)
@@ -371,14 +361,12 @@ file_process_headers(struct file *file, unsigned char *headers) {
 #endif
 }
 
-static void
-file_shift_buffer(struct file *file, int amount) {
+static void file_shift_buffer(struct file *file, int amount) {
     memmove(file->buffer, file->buffer+amount, file->buffer_len-amount);
     file->buffer_len-=amount;
 }
 
-unsigned char *
-file_data_read_special(struct file *file, int size, int *size_ret) {
+unsigned char *file_data_read_special(struct file *file, int size, int *size_ret) {
     unsigned char *ret,*hdr;
     int rets=0,rd;
     int buffer_size=8192;
@@ -425,13 +413,11 @@ file_data_read_special(struct file *file, int size, int *size_ret) {
     return ret;
 }
 
-unsigned char *
-file_data_read_all(struct file *file) {
+unsigned char *file_data_read_all(struct file *file) {
     return file_data_read(file, 0, file->size);
 }
 
-void
-file_data_flush(struct file *file, long long offset, int size) {
+void file_data_flush(struct file *file, long long offset, int size) {
     if (file->cache) {
         struct file_cache_id id= {offset,size,file->name_id,0};
         cache_flush(file_cache,&id);
@@ -439,8 +425,7 @@ file_data_flush(struct file *file, long long offset, int size) {
     }
 }
 
-int
-file_data_write(struct file *file, long long offset, int size, const void *data) {
+int file_data_write(struct file *file, long long offset, int size, const void *data) {
     file_data_flush(file, offset, size);
     lseek(file->fd, offset, SEEK_SET);
     if (write(file->fd, data, size) != size)
@@ -450,8 +435,7 @@ file_data_write(struct file *file, long long offset, int size, const void *data)
     return 1;
 }
 
-int
-file_get_contents(char *name, unsigned char **buffer, int *size) {
+int file_get_contents(char *name, unsigned char **buffer, int *size) {
     struct file *file;
     file=file_create(name, 0);
     if (!file)
@@ -464,8 +448,7 @@ file_get_contents(char *name, unsigned char **buffer, int *size) {
 }
 
 
-static int
-uncompress_int(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen) {
+static int uncompress_int(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen) {
     z_stream stream;
     int err;
 
@@ -493,8 +476,7 @@ uncompress_int(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLe
     return err;
 }
 
-unsigned char *
-file_data_read_compressed(struct file *file, long long offset, int size, int size_uncomp) {
+unsigned char *file_data_read_compressed(struct file *file, long long offset, int size, int size_uncomp) {
     void *ret;
     char *buffer = 0;
     uLongf destLen=size_uncomp;
@@ -525,8 +507,7 @@ file_data_read_compressed(struct file *file, long long offset, int size, int siz
     return ret;
 }
 
-void
-file_data_free(struct file *file, unsigned char *data) {
+void file_data_free(struct file *file, unsigned char *data) {
     if (file->begin) {
         if (data == file->begin)
             return;
@@ -539,8 +520,7 @@ file_data_free(struct file *file, unsigned char *data) {
         g_free(data);
 }
 
-void
-file_data_remove(struct file *file, unsigned char *data) {
+void file_data_remove(struct file *file, unsigned char *data) {
     if (file->begin) {
         if (data == file->begin)
             return;
@@ -553,16 +533,14 @@ file_data_remove(struct file *file, unsigned char *data) {
         g_free(data);
 }
 
-int
-file_exists(char const *name) {
+int file_exists(char const *name) {
     struct stat buf;
     if (! stat(name, &buf))
         return 1;
     return 0;
 }
 
-void
-file_remap_readonly(struct file *f) {
+void file_remap_readonly(struct file *f) {
 #if defined(_WIN32) || defined(__CEGCC__)
 #else
     void *begin;
@@ -573,8 +551,7 @@ file_remap_readonly(struct file *f) {
 #endif
 }
 
-void
-file_unmap(struct file *f) {
+void file_unmap(struct file *f) {
 #if defined(_WIN32) || defined(__CEGCC__)
     mmap_unmap_win32( f->begin, f->map_handle, f->map_file );
 #else
@@ -583,13 +560,11 @@ file_unmap(struct file *f) {
 }
 
 #ifndef _MSC_VER
-void *
-file_opendir(char *dir) {
+void *file_opendir(char *dir) {
     return opendir(dir);
 }
 #else
-void *
-file_opendir(char *dir) {
+void *file_opendir(char *dir) {
     WIN32_FIND_DATAA FindFileData;
     HANDLE hFind = INVALID_HANDLE_VALUE;
 #undef UNICODE         // we need FindFirstFileA() which takes an 8-bit c-string
@@ -601,8 +576,7 @@ file_opendir(char *dir) {
 #endif
 
 #ifndef _MSC_VER
-char *
-file_readdir(void *hnd) {
+char *file_readdir(void *hnd) {
     struct dirent *ent;
 
     ent=readdir(hnd);
@@ -611,8 +585,7 @@ file_readdir(void *hnd) {
     return ent->d_name;
 }
 #else
-char *
-file_readdir(void *hnd) {
+char *file_readdir(void *hnd) {
     WIN32_FIND_DATA FindFileData;
 
     if (FindNextFile(hnd, &FindFileData) ) {
@@ -624,13 +597,11 @@ file_readdir(void *hnd) {
 #endif /* _MSC_VER */
 
 #ifndef _MSC_VER
-void
-file_closedir(void *hnd) {
+void file_closedir(void *hnd) {
     closedir(hnd);
 }
 #else
-void
-file_closedir(void *hnd) {
+void file_closedir(void *hnd) {
     FindClose(hnd);
 }
 #endif /* _MSC_VER */
@@ -671,15 +642,13 @@ file_create_caseinsensitive(char *name, struct attr **options) {
     return ret;
 }
 
-void
-file_fsync(struct file *f) {
+void file_fsync(struct file *f) {
 #ifdef HAVE_FSYNC
     fsync(f->fd);
 #endif
 }
 
-void
-file_destroy(struct file *f) {
+void file_destroy(struct file *f) {
     if (f->headers)
         g_hash_table_destroy(f->headers);
     switch (f->special) {
@@ -715,22 +684,19 @@ file_wordexp_new(const char *pattern) {
     return ret;
 }
 
-int
-file_wordexp_get_count(struct file_wordexp *wexp) {
+int file_wordexp_get_count(struct file_wordexp *wexp) {
     if (wexp->err)
         return 1;
     return wexp->we.we_wordc;
 }
 
-char **
-file_wordexp_get_array(struct file_wordexp *wexp) {
+char ** file_wordexp_get_array(struct file_wordexp *wexp) {
     if (wexp->err)
         return &wexp->pattern;
     return wexp->we.we_wordv;
 }
 
-void
-file_wordexp_destroy(struct file_wordexp *wexp) {
+void file_wordexp_destroy(struct file_wordexp *wexp) {
     if (! wexp->err)
         wordfree(&wexp->we);
     g_free(wexp->pattern);
@@ -738,8 +704,7 @@ file_wordexp_destroy(struct file_wordexp *wexp) {
 }
 
 
-int
-file_version(struct file *file, int mode) {
+int file_version(struct file *file, int mode) {
 #ifndef HAVE_API_WIN32_BASE
     struct stat st;
     int error;
@@ -770,13 +735,11 @@ file_version(struct file *file, int mode) {
 #endif
 }
 
-void *
-file_get_os_handle(struct file *file) {
+void *file_get_os_handle(struct file *file) {
     return GINT_TO_POINTER(file->fd);
 }
 
-int
-file_set_cache_size(int cache_size) {
+int file_set_cache_size(int cache_size) {
 #ifdef CACHE_SIZE
     cache_resize(file_cache, cache_size);
     return 1;
@@ -785,8 +748,7 @@ file_set_cache_size(int cache_size) {
 #endif
 }
 
-void
-file_init(void) {
+void file_init(void) {
 #ifdef CACHE_SIZE
     file_name_hash=g_hash_table_new(g_str_hash, g_str_equal);
     file_cache=cache_new(sizeof(struct file_cache_id), CACHE_SIZE);

--- a/navit/font/freetype/font_freetype.c
+++ b/navit/font/freetype/font_freetype.c
@@ -86,11 +86,10 @@ static int library_init = 0;
 static int library_deinit = 0;
 
 
-static void
-font_freetype_get_text_bbox(struct graphics_priv *gr,
-                            struct font_freetype_font *font, char *text,
-                            int dx, int dy, struct point *ret,
-                            int estimate) {
+static void font_freetype_get_text_bbox(struct graphics_priv *gr,
+                                        struct font_freetype_font *font, char *text,
+                                        int dx, int dy, struct point *ret,
+                                        int estimate) {
     char *p = text;
     FT_BBox bbox;
     FT_UInt glyph_index;
@@ -191,9 +190,8 @@ font_freetype_get_text_bbox(struct graphics_priv *gr,
     }
 }
 
-static struct font_freetype_text *
-font_freetype_text_new(char *text, struct font_freetype_font *font, int dx,
-                       int dy) {
+static struct font_freetype_text *font_freetype_text_new(char *text, struct font_freetype_font *font, int dx,
+        int dy) {
     FT_Matrix matrix;
     FT_Vector pen;
     FT_UInt glyph_index;
@@ -319,8 +317,7 @@ static char *fontfamilies[] = {
     NULL,
 };
 
-static void
-font_destroy(struct graphics_font_priv *font) {
+static void font_destroy(struct graphics_font_priv *font) {
     g_free(font);
     /* TODO: free font->face */
 }
@@ -330,8 +327,7 @@ static struct graphics_font_methods font_methods = {
 };
 
 
-static void
-font_freetype_text_destroy(struct font_freetype_text *text) {
+static void font_freetype_text_destroy(struct font_freetype_text *text) {
     int i;
     struct font_freetype_glyph **gp;
 
@@ -370,10 +366,9 @@ static FT_Error face_requester( FTC_FaceID face_id, FT_Library library, FT_Point
 #endif
 
 /** Implementation of font_freetype_methods.font_new */
-static struct font_freetype_font *
-font_freetype_font_new(struct graphics_priv *gr,
-                       struct graphics_font_methods *meth,
-                       char *fontfamily, int size, int flags) {
+static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *gr,
+        struct graphics_font_methods *meth,
+        char *fontfamily, int size, int flags) {
     struct font_freetype_font *font =
         g_new(struct font_freetype_font, 1);
     int exact, found=0;
@@ -527,9 +522,8 @@ font_freetype_font_new(struct graphics_priv *gr,
 }
 
 /** Implementation of font_freetype_methods.get_shadow. */
-static int
-font_freetype_glyph_get_shadow(struct font_freetype_glyph *g,
-                               unsigned char *data, int stride, struct color *foreground, struct color *background) {
+static int font_freetype_glyph_get_shadow(struct font_freetype_glyph *g,
+        unsigned char *data, int stride, struct color *foreground, struct color *background) {
     int x, y, w = g->w, h = g->h;
     unsigned int bg, fg;
     unsigned char *pm, *psp,*ps,*psn;
@@ -581,9 +575,8 @@ font_freetype_glyph_get_shadow(struct font_freetype_glyph *g,
 }
 
 /** Implementation of font_freetype_methods.get_glyph. */
-static int
-font_freetype_glyph_get_glyph(struct font_freetype_glyph *g,
-                              unsigned char *data, int stride, struct color *fg, struct color *bg, struct color *transparent) {
+static int font_freetype_glyph_get_glyph(struct font_freetype_glyph *g,
+        unsigned char *data, int stride, struct color *fg, struct color *bg, struct color *transparent) {
     int x, y, w = g->w, h = g->h;
     unsigned int tr;
     unsigned char v,vi,*pm, *ps;
@@ -617,8 +610,7 @@ font_freetype_glyph_get_glyph(struct font_freetype_glyph *g,
     return 1;
 }
 
-static void
-font_freetype_destroy(void) {
+static void font_freetype_destroy(void) {
     // Do not call FcFini here: GdkPixbuf also (indirectly) uses fontconfig (for SVGs with
     // text), but does not properly deallocate all objects, so FcFini assert()s.
     if (!library_deinit) {
@@ -640,14 +632,12 @@ static struct font_freetype_methods methods = {
     font_freetype_glyph_get_glyph,
 };
 
-static struct font_priv *
-font_freetype_new(void *meth) {
+static struct font_priv *font_freetype_new(void *meth) {
     *((struct font_freetype_methods *) meth) = methods;
     return &dummy;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_font("freetype", font_freetype_new);
 #ifdef HAVE_FONTCONFIG
     FcInit();

--- a/navit/font/freetype/font_freetype.c
+++ b/navit/font/freetype/font_freetype.c
@@ -86,10 +86,7 @@ static int library_init = 0;
 static int library_deinit = 0;
 
 
-static void font_freetype_get_text_bbox(struct graphics_priv *gr,
-                                        struct font_freetype_font *font, char *text,
-                                        int dx, int dy, struct point *ret,
-                                        int estimate) {
+static void font_freetype_get_text_bbox(struct graphics_priv *gr, struct font_freetype_font *font, char *text, int dx, int dy, struct point *ret, int estimate) {
     char *p = text;
     FT_BBox bbox;
     FT_UInt glyph_index;
@@ -190,8 +187,7 @@ static void font_freetype_get_text_bbox(struct graphics_priv *gr,
     }
 }
 
-static struct font_freetype_text *font_freetype_text_new(char *text, struct font_freetype_font *font, int dx,
-        int dy) {
+static struct font_freetype_text *font_freetype_text_new(char *text, struct font_freetype_font *font, int dx, int dy) {
     FT_Matrix matrix;
     FT_Vector pen;
     FT_UInt glyph_index;
@@ -366,9 +362,7 @@ static FT_Error face_requester( FTC_FaceID face_id, FT_Library library, FT_Point
 #endif
 
 /** Implementation of font_freetype_methods.font_new */
-static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *gr,
-        struct graphics_font_methods *meth,
-        char *fontfamily, int size, int flags) {
+static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *gr, struct graphics_font_methods *meth, char *fontfamily, int size, int flags) {
     struct font_freetype_font *font =
         g_new(struct font_freetype_font, 1);
     int exact, found=0;
@@ -408,21 +402,15 @@ static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *g
 
 
         while (*family && !found) {
-            dbg(lvl_info, "Looking for font family %s. exact=%d",
-                *family, exact);
-            FcPattern *required =
-                FcPatternBuild(NULL, FC_FAMILY, FcTypeString,
-                               *family, NULL);
+            dbg(lvl_info, "Looking for font family %s. exact=%d", *family, exact);
+            FcPattern *required = FcPatternBuild(NULL, FC_FAMILY, FcTypeString, *family, NULL);
             if (flags)
-                FcPatternAddInteger(required, FC_WEIGHT,
-                                    FC_WEIGHT_BOLD);
-            FcConfigSubstitute(FcConfigGetCurrent(), required,
-                               FcMatchFont);
+                FcPatternAddInteger(required, FC_WEIGHT, FC_WEIGHT_BOLD);
+            FcConfigSubstitute(FcConfigGetCurrent(), required, FcMatchFont);
             FcDefaultSubstitute(required);
             FcResult result;
             FcPattern *matched =
-                FcFontMatch(FcConfigGetCurrent(), required,
-                            &result);
+                FcFontMatch(FcConfigGetCurrent(), required, &result);
             if (matched) {
                 FcValue v1, v2;
                 FcChar8 *fontfile;
@@ -430,17 +418,13 @@ static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *g
                 FcPatternGet(required, FC_FAMILY, 0, &v1);
                 FcPatternGet(matched, FC_FAMILY, 0, &v2);
                 FcResult r1 =
-                    FcPatternGetString(matched, FC_FILE, 0,
-                                       &fontfile);
+                    FcPatternGetString(matched, FC_FILE, 0, &fontfile);
                 FcResult r2 =
-                    FcPatternGetInteger(matched, FC_INDEX,
-                                        0, &fontindex);
+                    FcPatternGetInteger(matched, FC_INDEX, 0, &fontindex);
                 if ((r1 == FcResultMatch)
                         && (r2 == FcResultMatch)
                         && (FcValueEqual(v1, v2) || !exact)) {
-                    dbg(lvl_info,
-                        "About to load font from file %s index %d",
-                        fontfile, fontindex);
+                    dbg(lvl_info, "About to load font from file %s index %d", fontfile, fontindex);
 #if USE_CACHING
                     idstr=g_strdup_printf("%s/%d", fontfile, fontindex);
                     font->scaler.face_id=(FTC_FaceID)atom(idstr);
@@ -459,10 +443,7 @@ static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *g
                     FTC_Manager_LookupFace(manager, font->scaler.face_id, &face);
                     font->charmap_index=face->charmap ? FT_Get_Charmap_Index(face->charmap) : 0;
 #else /* USE_CACHING */
-                    FT_New_Face(library,
-                                (char *) fontfile,
-                                fontindex,
-                                &font->face);
+                    FT_New_Face(library, (char *) fontfile, fontindex, &font->face);
 #endif /* USE_CACHING */
                     found = 1;
                 }
@@ -522,8 +503,7 @@ static struct font_freetype_font *font_freetype_font_new(struct graphics_priv *g
 }
 
 /** Implementation of font_freetype_methods.get_shadow. */
-static int font_freetype_glyph_get_shadow(struct font_freetype_glyph *g,
-        unsigned char *data, int stride, struct color *foreground, struct color *background) {
+static int font_freetype_glyph_get_shadow(struct font_freetype_glyph *g, unsigned char *data, int stride, struct color *foreground, struct color *background) {
     int x, y, w = g->w, h = g->h;
     unsigned int bg, fg;
     unsigned char *pm, *psp,*ps,*psn;
@@ -575,8 +555,7 @@ static int font_freetype_glyph_get_shadow(struct font_freetype_glyph *g,
 }
 
 /** Implementation of font_freetype_methods.get_glyph. */
-static int font_freetype_glyph_get_glyph(struct font_freetype_glyph *g,
-        unsigned char *data, int stride, struct color *fg, struct color *bg, struct color *transparent) {
+static int font_freetype_glyph_get_glyph(struct font_freetype_glyph *g, unsigned char *data, int stride, struct color *fg, struct color *bg, struct color *transparent) {
     int x, y, w = g->w, h = g->h;
     unsigned int tr;
     unsigned char v,vi,*pm, *ps;

--- a/navit/geom.c
+++ b/navit/geom.c
@@ -20,8 +20,7 @@
 #include <math.h>
 #include "geom.h"
 
-void
-geom_coord_copy(struct coord *from, struct coord *to, int count, int reverse) {
+void geom_coord_copy(struct coord *from, struct coord *to, int count, int reverse) {
     int i;
     if (!reverse) {
         memcpy(to, from, count*sizeof(struct coord));
@@ -39,8 +38,7 @@ geom_coord_copy(struct coord *from, struct coord *to, int count, int reverse) {
   * @param out *c coordinates of middle point
   * @returns number of first vertex of segment containing middle point
   */
-int
-geom_line_middle(struct coord *p, int count, struct coord *c) {
+int geom_line_middle(struct coord *p, int count, struct coord *c) {
     double length=0,half=0,len=0;
     int i;
 
@@ -72,8 +70,7 @@ geom_line_middle(struct coord *p, int count, struct coord *c) {
 }
 
 
-void
-geom_coord_revert(struct coord *c, int count) {
+void geom_coord_revert(struct coord *c, int count) {
     struct coord tmp;
     int i;
 
@@ -85,8 +82,7 @@ geom_coord_revert(struct coord *c, int count) {
 }
 
 
-long long
-geom_poly_area(struct coord *c, int count) {
+long long geom_poly_area(struct coord *c, int count) {
     long long area=0;
     int i,j=0;
     for (i=0; i<count; i++) {
@@ -104,8 +100,7 @@ geom_poly_area(struct coord *c, int count) {
   * @param out *c coordinates of poly centroid
   * @returns 1 on success, 0 if poly area is 0
   */
-int
-geom_poly_centroid(struct coord *p, int count, struct coord *c) {
+int geom_poly_centroid(struct coord *p, int count, struct coord *c) {
     long long area=0;
     long long sx=0,sy=0,tmp;
     int i,j;
@@ -140,8 +135,7 @@ geom_poly_centroid(struct coord *p, int count, struct coord *c) {
   * @param out *c coordinates of polyline point most close to given point.
   * @returns first vertex number of polyline segment to which c belongs
   */
-int
-geom_poly_closest_point(struct coord *pl, int count, struct coord *p, struct coord *c) {
+int geom_poly_closest_point(struct coord *pl, int count, struct coord *p, struct coord *c) {
     int i,vertex=0;
     long long x, y, xi, xj, yi, yj, u, d, dmin=0;
     if(count<2) {
@@ -182,8 +176,7 @@ geom_poly_closest_point(struct coord *pl, int count, struct coord *p, struct coo
   * @param in *c point coordinates
   * @returns 1 - inside, 0 - outside
   */
-int
-geom_poly_point_inside(struct coord *cp, int count, struct coord *c) {
+int geom_poly_point_inside(struct coord *cp, int count, struct coord *c) {
     int ret=0;
     struct coord *last=cp+count-1;
     while (cp < last) {
@@ -198,9 +191,8 @@ geom_poly_point_inside(struct coord *cp, int count, struct coord *c) {
 
 
 
-GList *
-geom_poly_segments_insert(GList *list, struct geom_poly_segment *first, struct geom_poly_segment *second,
-                          struct geom_poly_segment *third) {
+GList *geom_poly_segments_insert(GList *list, struct geom_poly_segment *first, struct geom_poly_segment *second,
+                                 struct geom_poly_segment *third) {
     int count;
     struct geom_poly_segment *ret;
     struct coord *pos;
@@ -235,14 +227,12 @@ geom_poly_segments_insert(GList *list, struct geom_poly_segment *first, struct g
     return list;
 }
 
-void
-geom_poly_segment_destroy(struct geom_poly_segment *seg) {
+void geom_poly_segment_destroy(struct geom_poly_segment *seg) {
     g_free(seg->first);
     g_free(seg);
 }
 
-GList *
-geom_poly_segments_remove(GList *list, struct geom_poly_segment *seg) {
+GList *geom_poly_segments_remove(GList *list, struct geom_poly_segment *seg) {
     if (seg) {
         list=g_list_remove(list, seg);
         geom_poly_segment_destroy(seg);
@@ -250,8 +240,7 @@ geom_poly_segments_remove(GList *list, struct geom_poly_segment *seg) {
     return list;
 }
 
-int
-geom_poly_segment_compatible(struct geom_poly_segment *s1, struct geom_poly_segment *s2, int dir) {
+int geom_poly_segment_compatible(struct geom_poly_segment *s1, struct geom_poly_segment *s2, int dir) {
     int same=0,opposite=0;
     if (s1->type == geom_poly_segment_type_none || s2->type == geom_poly_segment_type_none)
         return 0;
@@ -280,8 +269,7 @@ geom_poly_segment_compatible(struct geom_poly_segment *s1, struct geom_poly_segm
 }
 
 
-GList *
-geom_poly_segments_sort(GList *in, enum geom_poly_segment_type type) {
+GList *geom_poly_segments_sort(GList *in, enum geom_poly_segment_type type) {
     GList *ret=NULL;
     while (in) {
         struct geom_poly_segment *seg=in->data;
@@ -316,8 +304,7 @@ geom_poly_segments_sort(GList *in, enum geom_poly_segment_type type) {
     return ret;
 }
 
-int
-geom_poly_segments_point_inside(GList *in, struct coord *c) {
+int geom_poly_segments_point_inside(GList *in, struct coord *c) {
     int open_matches=0,closed_matches=0;
     while (in) {
         struct geom_poly_segment *seg=in->data;
@@ -345,8 +332,7 @@ geom_poly_segments_point_inside(GList *in, struct coord *c) {
     return 0;
 }
 
-static int
-clipcode(struct coord *p, struct rect *r) {
+static int clipcode(struct coord *p, struct rect *r) {
     int code=0;
     if (p->x < r->l.x)
         code=1;
@@ -360,8 +346,7 @@ clipcode(struct coord *p, struct rect *r) {
 }
 
 
-int
-geom_clip_line_code(struct coord *p1, struct coord *p2, struct rect *r) {
+int geom_clip_line_code(struct coord *p1, struct coord *p2, struct rect *r) {
     int code1,code2,ret=1;
     long long dx,dy;
     code1=clipcode(p1, r);
@@ -411,8 +396,7 @@ geom_clip_line_code(struct coord *p1, struct coord *p2, struct rect *r) {
     return ret;
 }
 
-int
-geom_is_inside(struct coord *p, struct rect *r, int edge) {
+int geom_is_inside(struct coord *p, struct rect *r, int edge) {
     switch(edge) {
     case 0:
         return p->x >= r->l.x;
@@ -427,8 +411,7 @@ geom_is_inside(struct coord *p, struct rect *r, int edge) {
     }
 }
 
-void
-geom_poly_intersection(struct coord *p1, struct coord *p2, struct rect *r, int edge, struct coord *ret) {
+void geom_poly_intersection(struct coord *p1, struct coord *p2, struct rect *r, int edge, struct coord *ret) {
     int dx=p2->x-p1->x;
     int dy=p2->y-p1->y;
     switch(edge) {

--- a/navit/geom.c
+++ b/navit/geom.c
@@ -191,8 +191,7 @@ int geom_poly_point_inside(struct coord *cp, int count, struct coord *c) {
 
 
 
-GList *geom_poly_segments_insert(GList *list, struct geom_poly_segment *first, struct geom_poly_segment *second,
-                                 struct geom_poly_segment *third) {
+GList *geom_poly_segments_insert(GList *list, struct geom_poly_segment *first, struct geom_poly_segment *second, struct geom_poly_segment *third) {
     int count;
     struct geom_poly_segment *ret;
     struct coord *pos;

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -135,8 +135,7 @@ struct displaylist_icon_cache {
 
 };
 
-static void draw_circle(struct point *pnt, int diameter, int scale, int start, int len, struct point *res, int *pos,
-                        int dir);
+static void draw_circle(struct point *pnt, int diameter, int scale, int start, int len, struct point *res, int *pos, int dir);
 static void graphics_process_selection(struct graphics *gra, struct displaylist *dl);
 static void graphics_gc_init(struct graphics *this_);
 
@@ -252,8 +251,7 @@ void graphics_set_rect(struct graphics *gra, struct point_rect *pr) {
 struct graphics * graphics_new(struct attr *parent, struct attr **attrs) {
     struct graphics *this_;
     struct attr *type_attr, cbl_attr;
-    struct graphics_priv * (*graphicstype_new)(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
-            struct callback_list *cbl);
+    struct graphics_priv * (*graphicstype_new)(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl);
 
     if (! (type_attr=attr_search(attrs, NULL, attr_type))) {
         dbg(lvl_error,"Graphics plugin type is not set.");
@@ -631,9 +629,7 @@ struct graphics_image * graphics_image_new_scaled(struct graphics *gra, char *pa
     return graphics_image_new_scaled_rotated(gra, path, w, h, 0);
 }
 
-static void image_new_helper(struct graphics *gra, struct graphics_image *this_, char *path, char *name, int width,
-                             int height,
-                             int rotate, int zip) {
+static void image_new_helper(struct graphics *gra, struct graphics_image *this_, char *path, char *name, int width, int height, int rotate, int zip) {
     int i=0;
     int stdsizes[]= {8,12,16,22,24,32,36,48,64,72,96,128,192,256};
     const int numstdsizes=sizeof(stdsizes)/sizeof(int);
@@ -729,8 +725,7 @@ static void image_new_helper(struct graphics *gra, struct graphics_image *this_,
                 struct graphics_image_buffer buffer= {"buffer:",graphics_image_type_unknown};
                 buffer.start=start;
                 buffer.len=len;
-                this_->priv=gra->meth.image_new(gra->priv, &this_->meth, (char *)&buffer, &this_->width, &this_->height, &this_->hot,
-                                                rotate);
+                this_->priv=gra->meth.image_new(gra->priv, &this_->meth, (char *)&buffer, &this_->width, &this_->height, &this_->hot, rotate);
                 g_free(start);
             }
         } else {
@@ -931,8 +926,7 @@ void graphics_draw_rectangle(struct graphics *this_, struct graphics_gc *gc, str
     this_->meth.draw_rectangle(this_->priv, gc->priv, p, w, h);
 }
 
-void graphics_draw_rectangle_rounded(struct graphics *this_, struct graphics_gc *gc, struct point *plu, int w, int h,
-                                     int r, int fill) {
+void graphics_draw_rectangle_rounded(struct graphics *this_, struct graphics_gc *gc, struct point *plu, int w, int h, int r, int fill) {
     struct point *p=g_alloca(sizeof(struct point)*(r*4+32));
     struct point pi0= {plu->x+r,plu->y+r};
     struct point pi1= {plu->x+w-r,plu->y+r};
@@ -959,8 +953,7 @@ void graphics_draw_rectangle_rounded(struct graphics *this_, struct graphics_gc 
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-void graphics_draw_text(struct graphics *this_, struct graphics_gc *gc1, struct graphics_gc *gc2,
-                        struct graphics_font *font, char *text, struct point *p, int dx, int dy) {
+void graphics_draw_text(struct graphics *this_, struct graphics_gc *gc1, struct graphics_gc *gc2, struct graphics_font *font, char *text, struct point *p, int dx, int dy) {
     this_->meth.draw_text(this_->priv, gc1->priv, gc2 ? gc2->priv : NULL, font->priv, text, p, dx, dy);
 }
 
@@ -971,8 +964,7 @@ void graphics_draw_text(struct graphics *this_, struct graphics_gc *gc1, struct 
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-void graphics_get_text_bbox(struct graphics *this_, struct graphics_font *font, char *text, int dx, int dy,
-                            struct point *ret, int estimate) {
+void graphics_get_text_bbox(struct graphics *this_, struct graphics_font *font, char *text, int dx, int dy, struct point *ret, int estimate) {
     this_->meth.get_text_bbox(this_->priv, font->priv, text, dx, dy, ret, estimate);
 }
 
@@ -1148,8 +1140,7 @@ static void xdisplay_free(struct displaylist *dl) {
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-static void display_add(struct hash_entry *entry, struct item *item, int count, struct coord *c, char **label,
-                        int label_count) {
+static void display_add(struct hash_entry *entry, struct item *item, int count, struct coord *c, char **label, int label_count) {
     struct displayitem *di;
     int len,i;
     char *p;
@@ -1193,8 +1184,7 @@ static void display_add(struct hash_entry *entry, struct item *item, int count, 
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-static void label_line(struct graphics *gra, struct graphics_gc *fg, struct graphics_gc *bg, struct graphics_font *font,
-                       struct point *p, int count, char *label) {
+static void label_line(struct graphics *gra, struct graphics_gc *fg, struct graphics_gc *bg, struct graphics_font *font, struct point *p, int count, char *label) {
     int i,x,y,tl,tlm,th,thm,tlsq,l;
     float lsq;
     double dx,dy;
@@ -1272,8 +1262,7 @@ static void display_draw_arrows(struct graphics *gra, struct graphics_gc *gc, st
     }
 }
 
-static int intersection(struct point * a1, int adx, int ady, struct point * b1, int bdx, int bdy,
-                        struct point * res) {
+static int intersection(struct point * a1, int adx, int ady, struct point * b1, int bdx, int bdy, struct point * res) {
     int n, a, b;
     dbg(lvl_debug,"%d,%d - %d,%d x %d,%d-%d,%d",a1->x,a1->y,a1->x+adx,a1->y+ady,b1->x,b1->y,b1->x+bdx,b1->y+bdy);
     n = bdy * adx - bdx * ady;
@@ -1362,8 +1351,7 @@ struct circle {
     {-13,127,1011},
 };
 
-static void draw_circle(struct point *pnt, int diameter, int scale, int start, int len, struct point *res, int *pos,
-                        int dir) {
+static void draw_circle(struct point *pnt, int diameter, int scale, int start, int len, struct point *res, int *pos, int dir) {
     struct circle *c;
     int count=64;
     int end=start+len;
@@ -1582,8 +1570,7 @@ static int draw_middle(struct draw_polyline_context *ctx, struct point *p) {
         draw_point(&ctx->prev_shape, p, &poso, 1);
         if (delta >= 256)
             return 0;
-        if (intersection(&pos, ctx->shape.dx, ctx->shape.dy, &poso, ctx->prev_shape.dx, ctx->prev_shape.dy,
-                         &ctx->res[ctx->ppos])) {
+        if (intersection(&pos, ctx->shape.dx, ctx->shape.dy, &poso, ctx->prev_shape.dx, ctx->prev_shape.dy, &ctx->res[ctx->ppos])) {
             ctx->ppos++;
             draw_point(&ctx->prev_shape, p, &ctx->res[ctx->npos--], 0);
             draw_point(&ctx->shape, p, &ctx->res[ctx->npos--], 0);
@@ -1595,8 +1582,7 @@ static int draw_middle(struct draw_polyline_context *ctx, struct point *p) {
         draw_point(&ctx->prev_shape, p, &nego, 0);
         if (delta <= -256)
             return 0;
-        if (intersection(&neg, ctx->shape.dx, ctx->shape.dy, &nego, ctx->prev_shape.dx, ctx->prev_shape.dy,
-                         &ctx->res[ctx->npos])) {
+        if (intersection(&neg, ctx->shape.dx, ctx->shape.dy, &nego, ctx->prev_shape.dx, ctx->prev_shape.dy, &ctx->res[ctx->npos])) {
             ctx->npos--;
             draw_point(&ctx->prev_shape, p, &ctx->res[ctx->ppos++], 1);
             draw_point(&ctx->shape, p, &ctx->res[ctx->ppos++], 1);
@@ -1623,10 +1609,7 @@ static void draw_init_ctx(struct draw_polyline_context *ctx, int maxpoints) {
 }
 
 
-static void graphics_draw_polyline_as_polygon(struct graphics_priv *gra_priv, struct graphics_gc_priv *gc_priv,
-        struct point *pnt,
-        int count, int *width,  void (*draw)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p,
-                int count)) {
+static void graphics_draw_polyline_as_polygon(struct graphics_priv *gra_priv, struct graphics_gc_priv *gc_priv, struct point *pnt, int count, int *width,  void (*draw)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count)) {
     int maxpoints=200;
     struct draw_polyline_context ctx;
     int i=0;
@@ -1683,8 +1666,7 @@ static int relative_pos(struct wpoint *p, struct point_rect *r) {
     return relative_pos;
 }
 
-static void clip_line_endoint_to_rect_edge(struct wpoint *p, int rel_pos, int dx, int dy, int dw,
-        struct point_rect *clip_rect) {
+static void clip_line_endoint_to_rect_edge(struct wpoint *p, int rel_pos, int dx, int dy, int dw, struct point_rect *clip_rect) {
     // We must cast to float to avoid integer
     // overflow (i.e. undefined behaviour) at high
     // zoom levels.
@@ -1752,9 +1734,7 @@ static int clip_line(struct wpoint *p1, struct wpoint *p2, struct point_rect *cl
  * @param[in] width An array of width matching the line starting from the corresponding @p pa (if all equal, all lines will have the same width)
  * @param poly A boolean indicating whether the polyline should be closed to form a polygon (only the contour of this polygon will be drawn)
  */
-void graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pa, int count,
-                                    int *width,
-                                    int poly) {
+void graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pa, int count, int *width, int poly) {
     struct point *points_to_draw=g_alloca(sizeof(struct point)*(count+1));
     int *w=g_alloca(sizeof(int)*(count+1));
     struct wpoint segment_start,segment_end;
@@ -2032,10 +2012,7 @@ static void displayitem_draw(struct displayitem *di, void *dummy, struct display
         case element_polyline: {
             gc->meth.gc_set_linewidth(gc->priv, 1);
             if (e->u.polyline.width > 0 && e->u.polyline.dash_num > 0)
-                graphics_gc_set_dashes(gc, e->u.polyline.width,
-                                       e->u.polyline.offset,
-                                       e->u.polyline.dash_table,
-                                       e->u.polyline.dash_num);
+                graphics_gc_set_dashes(gc, e->u.polyline.width, e->u.polyline.offset, e->u.polyline.dash_table, e->u.polyline.dash_num);
             for (i = 0 ; i < count ; i++) {
                 if (width[i] < 2)
                     width[i]=2;
@@ -2457,8 +2434,7 @@ static void do_draw(struct displaylist *displaylist, int cancel, int flags) {
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-void graphics_displaylist_draw(struct graphics *gra, struct displaylist *displaylist, struct transformation *trans,
-                               struct layout *l, int flags) {
+void graphics_displaylist_draw(struct graphics *gra, struct displaylist *displaylist, struct transformation *trans, struct layout *l, int flags) {
     int order=transform_get_order(trans);
     if(displaylist->dc.trans && displaylist->dc.trans!=trans)
         transform_destroy(displaylist->dc.trans);
@@ -2489,8 +2465,7 @@ void graphics_displaylist_draw(struct graphics *gra, struct displaylist *display
         gra->meth.draw_mode(gra->priv, draw_mode_end);
 }
 
-static void graphics_load_mapset(struct graphics *gra, struct displaylist *displaylist, struct mapset *mapset,
-                                 struct transformation *trans, struct layout *l, int async, struct callback *cb, int flags) {
+static void graphics_load_mapset(struct graphics *gra, struct displaylist *displaylist, struct mapset *mapset, struct transformation *trans, struct layout *l, int async, struct callback *cb, int flags) {
     int order=transform_get_order(trans);
 
     dbg(lvl_debug,"enter");
@@ -2529,8 +2504,7 @@ static void graphics_load_mapset(struct graphics *gra, struct displaylist *displ
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-void graphics_draw(struct graphics *gra, struct displaylist *displaylist, struct mapset *mapset,
-                   struct transformation *trans, struct layout *l, int async, struct callback *cb, int flags) {
+void graphics_draw(struct graphics *gra, struct displaylist *displaylist, struct mapset *mapset, struct transformation *trans, struct layout *l, int async, struct callback *cb, int flags) {
     graphics_load_mapset(gra, displaylist, mapset, trans, l, async, cb, flags);
 }
 
@@ -2779,8 +2753,7 @@ static int within_dist_polygon(struct point *p, struct point *poly_pnt, int coun
  * @returns <>
  * @author Martin Schaller (04/2008)
 */
-int graphics_displayitem_within_dist(struct displaylist *displaylist, struct displayitem *di, struct point *p,
-                                     int dist) {
+int graphics_displayitem_within_dist(struct displaylist *displaylist, struct displayitem *di, struct point *p, int dist) {
     struct point *pa=g_alloca(sizeof(struct point)*displaylist->dc.maxlen);
     int count;
 

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -140,15 +140,13 @@ static void draw_circle(struct point *pnt, int diameter, int scale, int start, i
 static void graphics_process_selection(struct graphics *gra, struct displaylist *dl);
 static void graphics_gc_init(struct graphics *this_);
 
-static void
-clear_hash(struct displaylist *dl) {
+static void clear_hash(struct displaylist *dl) {
     int i;
     for (i = 0 ; i < HASH_SIZE ; i++)
         dl->hash_entries[i].type=type_none;
 }
 
-static struct hash_entry *
-get_hash_entry(struct displaylist *dl, enum item_type type) {
+static struct hash_entry *get_hash_entry(struct displaylist *dl, enum item_type type) {
     int hashidx=(type*2654435761UL) & (HASH_SIZE-1);
     int offset=dl->max_offset;
     do {
@@ -161,8 +159,7 @@ get_hash_entry(struct displaylist *dl, enum item_type type) {
     return NULL;
 }
 
-static struct hash_entry *
-set_hash_entry(struct displaylist *dl, enum item_type type) {
+static struct hash_entry *set_hash_entry(struct displaylist *dl, enum item_type type) {
     int hashidx=(type*2654435761UL) & (HASH_SIZE-1);
     int offset=0;
     for (;;) {
@@ -194,8 +191,7 @@ set_hash_entry(struct displaylist *dl, enum item_type type) {
  *
  * @return True if the attribute was set, false if not
  */
-static int
-graphics_set_attr_do(struct graphics *gra, struct attr *attr) {
+static int graphics_set_attr_do(struct graphics *gra, struct attr *attr) {
     switch (attr->type) {
     case attr_gamma:
         gra->gamma=attr->u.num;
@@ -231,8 +227,7 @@ graphics_set_attr_do(struct graphics *gra, struct attr *attr) {
  *
  * @return True if the attribute was successfully set, false otherwise.
  */
-int
-graphics_set_attr(struct graphics *gra, struct attr *attr) {
+int graphics_set_attr(struct graphics *gra, struct attr *attr) {
     int ret=1;
     /* FIXME if gra->meth doesn't have a setter, we don't even try the generic attrs - is that what we want? */
     dbg(lvl_debug,"enter");
@@ -243,8 +238,7 @@ graphics_set_attr(struct graphics *gra, struct attr *attr) {
     return ret != 0;
 }
 
-void
-graphics_set_rect(struct graphics *gra, struct point_rect *pr) {
+void graphics_set_rect(struct graphics *gra, struct point_rect *pr) {
     gra->r=*pr;
 }
 
@@ -369,8 +363,7 @@ struct graphics * graphics_overlay_new(struct graphics *parent, struct point *p,
  * @param h The new height of the overlay
  * @param wraparound The new wraparound of the overlay
  */
-void
-graphics_overlay_resize(struct graphics *this_, struct point *p, int w, int h, int wraparound) {
+void graphics_overlay_resize(struct graphics *this_, struct point *p, int w, int h, int wraparound) {
     if (! this_->meth.overlay_resize) {
         return;
     }
@@ -378,8 +371,7 @@ graphics_overlay_resize(struct graphics *this_, struct point *p, int w, int h, i
     this_->meth.overlay_resize(this_->priv, p, w, h, wraparound);
 }
 
-static void
-graphics_gc_init(struct graphics *this_) {
+static void graphics_gc_init(struct graphics *this_) {
     struct color background= { COLOR_BACKGROUND_ };
     struct color black= { COLOR_BLACK_ };
     struct color white= { COLOR_WHITE_ };
@@ -542,8 +534,7 @@ void graphics_gc_destroy(struct graphics_gc *gc) {
     g_free(gc);
 }
 
-static void
-graphics_convert_color(struct graphics *gra, struct color *in, struct color *out) {
+static void graphics_convert_color(struct graphics *gra, struct color *in, struct color *out) {
     *out=*in;
     if (gra->brightness) {
         out->r+=gra->brightness;
@@ -640,9 +631,9 @@ struct graphics_image * graphics_image_new_scaled(struct graphics *gra, char *pa
     return graphics_image_new_scaled_rotated(gra, path, w, h, 0);
 }
 
-static void
-image_new_helper(struct graphics *gra, struct graphics_image *this_, char *path, char *name, int width, int height,
-                 int rotate, int zip) {
+static void image_new_helper(struct graphics *gra, struct graphics_image *this_, char *path, char *name, int width,
+                             int height,
+                             int rotate, int zip) {
     int i=0;
     int stdsizes[]= {8,12,16,22,24,32,36,48,64,72,96,128,192,256};
     const int numstdsizes=sizeof(stdsizes)/sizeof(int);
@@ -1017,16 +1008,14 @@ void graphics_draw_image(struct graphics *this_, struct graphics_gc *gc, struct 
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-int
-graphics_draw_drag(struct graphics *this_, struct point *p) {
+int graphics_draw_drag(struct graphics *this_, struct point *p) {
     if (!this_->meth.draw_drag)
         return 0;
     this_->meth.draw_drag(this_->priv, p);
     return 1;
 }
 
-void
-graphics_background_gc(struct graphics *this_, struct graphics_gc *gc) {
+void graphics_background_gc(struct graphics *this_, struct graphics_gc *gc) {
     this_->meth.background_gc(this_->priv, gc ? gc->priv : NULL);
 }
 
@@ -1283,9 +1272,8 @@ static void display_draw_arrows(struct graphics *gra, struct graphics_gc *gc, st
     }
 }
 
-static int
-intersection(struct point * a1, int adx, int ady, struct point * b1, int bdx, int bdy,
-             struct point * res) {
+static int intersection(struct point * a1, int adx, int ady, struct point * b1, int bdx, int bdy,
+                        struct point * res) {
     int n, a, b;
     dbg(lvl_debug,"%d,%d - %d,%d x %d,%d-%d,%d",a1->x,a1->y,a1->x+adx,a1->y+ady,b1->x,b1->y,b1->x+bdx,b1->y+bdy);
     n = bdy * adx - bdx * ady;
@@ -1374,8 +1362,8 @@ struct circle {
     {-13,127,1011},
 };
 
-static void
-draw_circle(struct point *pnt, int diameter, int scale, int start, int len, struct point *res, int *pos, int dir) {
+static void draw_circle(struct point *pnt, int diameter, int scale, int start, int len, struct point *res, int *pos,
+                        int dir) {
     struct circle *c;
     int count=64;
     int end=start+len;
@@ -1435,8 +1423,7 @@ draw_circle(struct point *pnt, int diameter, int scale, int start, int len, stru
 }
 
 
-static int
-fowler(int dy, int dx) {
+static int fowler(int dy, int dx) {
     int adx, ady;		/* Absolute Values of Dx and Dy */
     int code;		/* Angular Region Classification Code */
 
@@ -1469,8 +1456,7 @@ fowler(int dy, int dx) {
     }
     return 0;
 }
-static int
-int_sqrt(unsigned int n) {
+static int int_sqrt(unsigned int n) {
     unsigned int h, p= 0, q= 1, r= n;
 
     /* avoid q rollover */
@@ -1511,14 +1497,12 @@ struct draw_polyline_context {
     struct draw_polyline_shape prev_shape;
 };
 
-static void
-draw_shape_update(struct draw_polyline_shape *shape) {
+static void draw_shape_update(struct draw_polyline_shape *shape) {
     shape->dxw = -(shape->dx * shape->wi * shape->lscale) / shape->l;
     shape->dyw = (shape->dy * shape->wi * shape->lscale) / shape->l;
 }
 
-static void
-draw_shape(struct draw_polyline_context *ctx, struct point *pnt, int wi) {
+static void draw_shape(struct draw_polyline_context *ctx, struct point *pnt, int wi) {
     int dxs,dys,lscales;
     int lscale=16;
     int l;
@@ -1560,8 +1544,7 @@ draw_shape(struct draw_polyline_context *ctx, struct point *pnt, int wi) {
     draw_shape_update(shape);
 }
 
-static void
-draw_point(struct draw_polyline_shape *shape, struct point *src, struct point *dst, int pos) {
+static void draw_point(struct draw_polyline_shape *shape, struct point *src, struct point *dst, int pos) {
     if (pos) {
         dst->x=(src->x*2-shape->dyw)/2;
         dst->y=(src->y*2-shape->dxw)/2;
@@ -1571,8 +1554,7 @@ draw_point(struct draw_polyline_shape *shape, struct point *src, struct point *d
     }
 }
 
-static void
-draw_begin(struct draw_polyline_context *ctx, struct point *p) {
+static void draw_begin(struct draw_polyline_context *ctx, struct point *p) {
     struct draw_polyline_shape *shape=&ctx->shape;
     int i;
     for (i = 0 ; i <= 32 ; i+=shape->step) {
@@ -1582,8 +1564,7 @@ draw_begin(struct draw_polyline_context *ctx, struct point *p) {
     }
 }
 
-static int
-draw_middle(struct draw_polyline_context *ctx, struct point *p) {
+static int draw_middle(struct draw_polyline_context *ctx, struct point *p) {
     int delta=ctx->prev_shape.fow-ctx->shape.fow;
     if (delta > 512)
         delta-=1024;
@@ -1625,8 +1606,7 @@ draw_middle(struct draw_polyline_context *ctx, struct point *p) {
     return 0;
 }
 
-static void
-draw_end(struct draw_polyline_context *ctx, struct point *p) {
+static void draw_end(struct draw_polyline_context *ctx, struct point *p) {
     int i;
     struct draw_polyline_shape *shape=&ctx->prev_shape;
     for (i = 0 ; i <= 32 ; i+=shape->step) {
@@ -1636,18 +1616,17 @@ draw_end(struct draw_polyline_context *ctx, struct point *p) {
     }
 }
 
-static void
-draw_init_ctx(struct draw_polyline_context *ctx, int maxpoints) {
+static void draw_init_ctx(struct draw_polyline_context *ctx, int maxpoints) {
     ctx->prec=1;
     ctx->ppos=maxpoints/2;
     ctx->npos=maxpoints/2-1;
 }
 
 
-static void
-graphics_draw_polyline_as_polygon(struct graphics_priv *gra_priv, struct graphics_gc_priv *gc_priv, struct point *pnt,
-                                  int count, int *width,  void (*draw)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p,
-                                          int count)) {
+static void graphics_draw_polyline_as_polygon(struct graphics_priv *gra_priv, struct graphics_gc_priv *gc_priv,
+        struct point *pnt,
+        int count, int *width,  void (*draw)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p,
+                int count)) {
     int maxpoints=200;
     struct draw_polyline_context ctx;
     int i=0;
@@ -1691,8 +1670,7 @@ enum relative_pos {
     BELOW    = 8
 };
 
-static int
-relative_pos(struct wpoint *p, struct point_rect *r) {
+static int relative_pos(struct wpoint *p, struct point_rect *r) {
     int relative_pos=INSIDE;
     if (p->x < r->lu.x)
         relative_pos=LEFT_OF;
@@ -1705,8 +1683,8 @@ relative_pos(struct wpoint *p, struct point_rect *r) {
     return relative_pos;
 }
 
-static void
-clip_line_endoint_to_rect_edge(struct wpoint *p, int rel_pos, int dx, int dy, int dw, struct point_rect *clip_rect) {
+static void clip_line_endoint_to_rect_edge(struct wpoint *p, int rel_pos, int dx, int dy, int dw,
+        struct point_rect *clip_rect) {
     // We must cast to float to avoid integer
     // overflow (i.e. undefined behaviour) at high
     // zoom levels.
@@ -1736,8 +1714,7 @@ enum clip_result {
     CLIPRES_END_CLIPPED   = 4,
 };
 
-static int
-clip_line(struct wpoint *p1, struct wpoint *p2, struct point_rect *clip_rect) {
+static int clip_line(struct wpoint *p1, struct wpoint *p2, struct point_rect *clip_rect) {
     int rel_pos1,rel_pos2;
     int ret = CLIPRES_VISIBLE;
     int dx,dy,dw;
@@ -1775,9 +1752,9 @@ clip_line(struct wpoint *p1, struct wpoint *p2, struct point_rect *clip_rect) {
  * @param[in] width An array of width matching the line starting from the corresponding @p pa (if all equal, all lines will have the same width)
  * @param poly A boolean indicating whether the polyline should be closed to form a polygon (only the contour of this polygon will be drawn)
  */
-void
-graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pa, int count, int *width,
-                               int poly) {
+void graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pa, int count,
+                                    int *width,
+                                    int poly) {
     struct point *points_to_draw=g_alloca(sizeof(struct point)*(count+1));
     int *w=g_alloca(sizeof(int)*(count+1));
     struct wpoint segment_start,segment_end;
@@ -1838,8 +1815,7 @@ graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, str
     }
 }
 
-static int
-is_inside(struct point *p, struct point_rect *r, int edge) {
+static int is_inside(struct point *p, struct point_rect *r, int edge) {
     switch(edge) {
     case 0:
         return p->x >= r->lu.x;
@@ -1854,8 +1830,7 @@ is_inside(struct point *p, struct point_rect *r, int edge) {
     }
 }
 
-static void
-poly_intersection(struct point *p1, struct point *p2, struct point_rect *r, int edge, struct point *ret) {
+static void poly_intersection(struct point *p1, struct point *p2, struct point_rect *r, int edge, struct point *ret) {
     int dx=p2->x-p1->x;
     int dy=p2->y-p1->y;
     switch(edge) {
@@ -1886,8 +1861,7 @@ poly_intersection(struct point *p1, struct point *p2, struct point_rect *r, int 
  * @param[in] pin An array of points forming the polygon
  * @param count_in The number of elements inside @p pin
  */
-void
-graphics_draw_polygon_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pin, int count_in) {
+void graphics_draw_polygon_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pin, int count_in) {
     struct point_rect r=gra->r;
     struct point *pout,*p,*s,pi,*p1,*p2;
     int limit=10000;
@@ -1941,8 +1915,7 @@ graphics_draw_polygon_clipped(struct graphics *gra, struct graphics_gc *gc, stru
 }
 
 
-static void
-display_context_free(struct display_context *dc) {
+static void display_context_free(struct display_context *dc) {
     if (dc->gc)
         graphics_gc_destroy(dc->gc);
     if (dc->gc_background)
@@ -1954,8 +1927,7 @@ display_context_free(struct display_context *dc) {
     dc->img=NULL;
 }
 
-static struct graphics_font *
-get_font(struct graphics *gra, int size) {
+static struct graphics_font *get_font(struct graphics *gra, int size) {
     if (size > 64)
         size=64;
     if (size >= gra->font_len) {
@@ -1982,8 +1954,7 @@ void graphics_draw_text_std(struct graphics *this_, int text_size, char *text, s
     graphics_draw_text(this_, this_->gc[1], this_->gc[2], font, text, p, 0x10000, 0);
 }
 
-char *
-graphics_icon_path(const char *icon) {
+char *graphics_icon_path(const char *icon) {
     static char *navit_sharedir;
     char *ret=NULL;
     struct file_wordexp *wordexp=NULL;
@@ -2016,8 +1987,7 @@ graphics_icon_path(const char *icon) {
     return ret;
 }
 
-static int
-limit_count(struct coord *c, int count) {
+static int limit_count(struct coord *c, int count) {
     int i;
     for (i = 1 ; i < count ; i++) {
         if (c[i].x == c[0].x && c[i].y == c[0].y)
@@ -2027,8 +1997,7 @@ limit_count(struct coord *c, int count) {
 }
 
 
-static void
-displayitem_draw(struct displayitem *di, void *dummy, struct display_context *dc) {
+static void displayitem_draw(struct displayitem *di, void *dummy, struct display_context *dc) {
     int *width=g_alloca(sizeof(int)*dc->maxlen);
     struct point *pa=g_alloca(sizeof(struct point)*dc->maxlen);
     struct graphics *gra=dc->gra;
@@ -2195,8 +2164,7 @@ static void xdisplay_draw_elements(struct graphics *gra, struct displaylist *dis
     }
 }
 
-void
-graphics_draw_itemgra(struct graphics *gra, struct itemgra *itm, struct transformation *t, char *label) {
+void graphics_draw_itemgra(struct graphics *gra, struct itemgra *itm, struct transformation *t, char *label) {
     GList *es;
     struct display_context dc;
     int max_coord=32;
@@ -2291,8 +2259,7 @@ static void xdisplay_draw(struct displaylist *display_list, struct graphics *gra
 */
 extern void *route_selection;
 
-static void
-displaylist_update_layers(struct displaylist *displaylist, GList *layers, int order) {
+static void displaylist_update_layers(struct displaylist *displaylist, GList *layers, int order) {
     while (layers) {
         struct layer *layer=layers->data;
         GList *itemgras;
@@ -2315,8 +2282,7 @@ displaylist_update_layers(struct displaylist *displaylist, GList *layers, int or
     }
 }
 
-static void
-displaylist_update_hash(struct displaylist *displaylist) {
+static void displaylist_update_hash(struct displaylist *displaylist) {
     displaylist->max_offset=0;
     clear_hash(displaylist);
     displaylist_update_layers(displaylist, displaylist->layout->layers, displaylist->order);
@@ -2370,8 +2336,7 @@ GList *displaylist_get_clicked_list(struct displaylist *displaylist, struct poin
 
 
 
-static void
-do_draw(struct displaylist *displaylist, int cancel, int flags) {
+static void do_draw(struct displaylist *displaylist, int cancel, int flags) {
     struct item *item;
     int count,max=displaylist->dc.maxlen,workload=0;
     struct coord *ca=g_alloca(sizeof(struct coord)*max);
@@ -2569,8 +2534,7 @@ void graphics_draw(struct graphics *gra, struct displaylist *displaylist, struct
     graphics_load_mapset(gra, displaylist, mapset, trans, l, async, cb, flags);
 }
 
-int
-graphics_draw_cancel(struct graphics *gra, struct displaylist *displaylist) {
+int graphics_draw_cancel(struct graphics *gra, struct displaylist *displaylist) {
     if (!displaylist->busy)
         return 0;
     do_draw(displaylist, 1, 0);
@@ -2686,8 +2650,7 @@ int graphics_displayitem_get_z_order(struct displayitem *di) {
 }
 
 
-int
-graphics_displayitem_get_coord_count(struct displayitem *di) {
+int graphics_displayitem_get_coord_count(struct displayitem *di) {
     return di->count;
 }
 
@@ -2701,8 +2664,7 @@ char * graphics_displayitem_get_label(struct displayitem *di) {
     return di->label;
 }
 
-int
-graphics_displayitem_get_displayed(struct displayitem *di) {
+int graphics_displayitem_get_displayed(struct displayitem *di) {
     return 1;
 }
 
@@ -2834,8 +2796,7 @@ int graphics_displayitem_within_dist(struct displaylist *displaylist, struct dis
 }
 
 
-static void
-graphics_process_selection_item(struct displaylist *dl, struct item *item) {
+static void graphics_process_selection_item(struct displaylist *dl, struct item *item) {
 #if 0 /* FIXME */
     struct displayitem di,*di_res;
     GHashTable *h;
@@ -2871,8 +2832,7 @@ graphics_process_selection_item(struct displaylist *dl, struct item *item) {
 #endif
 }
 
-void
-graphics_add_selection(struct graphics *gra, struct item *item, enum item_type type, struct displaylist *dl) {
+void graphics_add_selection(struct graphics *gra, struct item *item, enum item_type type, struct displaylist *dl) {
     struct item *item_dup=g_new(struct item, 1);
     *item_dup=*item;
     item_dup->priv_data=(void *)type;
@@ -2881,8 +2841,7 @@ graphics_add_selection(struct graphics *gra, struct item *item, enum item_type t
         graphics_process_selection_item(dl, item_dup);
 }
 
-void
-graphics_remove_selection(struct graphics *gra, struct item *item, enum item_type type, struct displaylist *dl) {
+void graphics_remove_selection(struct graphics *gra, struct item *item, enum item_type type, struct displaylist *dl) {
     GList *curr;
     int found;
 
@@ -2916,16 +2875,14 @@ graphics_remove_selection(struct graphics *gra, struct item *item, enum item_typ
     }
 }
 
-void
-graphics_clear_selection(struct graphics *gra, struct displaylist *dl) {
+void graphics_clear_selection(struct graphics *gra, struct displaylist *dl) {
     while (gra->selection) {
         struct item *item=(struct item *)gra->selection->data;
         graphics_remove_selection(gra, item, (enum item_type)item->priv_data,dl);
     }
 }
 
-static void
-graphics_process_selection(struct graphics *gra, struct displaylist *dl) {
+static void graphics_process_selection(struct graphics *gra, struct displaylist *dl) {
     GList *curr;
 
     curr=gra->selection;

--- a/navit/graphics/android/graphics_android.c
+++ b/navit/graphics/android/graphics_android.c
@@ -91,8 +91,7 @@ struct graphics_image_priv {
 
 static GHashTable *image_cache_hash = NULL;
 
-static int
-find_class_global(char *name, jclass *ret) {
+static int find_class_global(char *name, jclass *ret) {
     *ret=(*jnienv)->FindClass(jnienv, name);
     if (! *ret) {
         dbg(lvl_error,"Failed to get Class %s",name);
@@ -102,8 +101,7 @@ find_class_global(char *name, jclass *ret) {
     return 1;
 }
 
-static int
-find_method(jclass class, char *name, char *args, jmethodID *ret) {
+static int find_method(jclass class, char *name, char *args, jmethodID *ret) {
     *ret = (*jnienv)->GetMethodID(jnienv, class, name, args);
     if (*ret == NULL) {
         dbg(lvl_error,"Failed to get Method %s with signature %s",name,args);
@@ -112,8 +110,7 @@ find_method(jclass class, char *name, char *args, jmethodID *ret) {
     return 1;
 }
 
-static int
-find_static_method(jclass class, char *name, char *args, jmethodID *ret) {
+static int find_static_method(jclass class, char *name, char *args, jmethodID *ret) {
     *ret = (*jnienv)->GetStaticMethodID(jnienv, class, name, args);
     if (*ret == NULL) {
         dbg(lvl_error,"Failed to get static Method %s with signature %s",name,args);
@@ -122,8 +119,7 @@ find_static_method(jclass class, char *name, char *args, jmethodID *ret) {
     return 1;
 }
 
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
 }
 
 static void font_destroy(struct graphics_font_priv *font) {
@@ -143,19 +139,16 @@ static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct grap
     return ret;
 }
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
     g_free(gc->dashes);
     g_free(gc);
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->linewidth = w;
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
     g_free(gc->dashes);
     gc->ndashes=n;
     if(n) {
@@ -166,16 +159,14 @@ gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *das
     }
 }
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     gc->r = c->r >> 8;
     gc->g = c->g >> 8;
     gc->b = c->b >> 8;
     gc->a = c->a >> 8;
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
 }
 
 static struct graphics_gc_methods gc_methods = {
@@ -205,9 +196,9 @@ static struct graphics_image_methods image_methods = {
 };
 
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gra, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot,
-          int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gra, struct graphics_image_methods *meth, char *path,
+        int *w, int *h, struct point *hot,
+        int rotation) {
     struct graphics_image_priv* ret = NULL;
 
     ret=g_new0(struct graphics_image_priv, 1);
@@ -279,8 +270,7 @@ static void initPaint(struct graphics_priv *gra, struct graphics_gc_priv *gc) {
     (*jnienv)->CallVoidMethod(jnienv, gc->gra->Paint, gra->Paint_setARGB, gc->a, gc->r, gc->g, gc->b);
 }
 
-static void
-draw_lines(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int count) {
     int arrsize=1+4+1+gc->ndashes+count*2;
     jint pc[arrsize];
     int i;
@@ -306,8 +296,7 @@ draw_lines(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point 
     (*jnienv)->DeleteLocalRef(jnienv, points);
 }
 
-static void
-draw_polygon(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int count) {
     int arrsize=1+4+count*2;
     jint pc[arrsize];
     int i;
@@ -329,23 +318,20 @@ draw_polygon(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct poin
     (*jnienv)->DeleteLocalRef(jnienv, points);
 }
 
-static void
-draw_rectangle(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     initPaint(gra, gc);
     (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_rectangle, gc->gra->Paint, p->x, p->y, w,
                               h);
 }
 
-static void
-draw_circle(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int r) {
+static void draw_circle(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int r) {
     initPaint(gra, gc);
     (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_circle, gc->gra->Paint, p->x, p->y, r);
 }
 
 
-static void
-draw_text(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-          struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
+                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     int bgcolor=0;
     dbg(lvl_debug,"enter %s", text);
     initPaint(gra, fg);
@@ -357,8 +343,8 @@ draw_text(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct graphic
     (*jnienv)->DeleteLocalRef(jnienv, string);
 }
 
-static void
-draw_image(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct point *p,
+                       struct graphics_image_priv *img) {
     dbg(lvl_debug,"enter %p",img);
     initPaint(gra, fg);
     (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_image, fg->gra->Paint, p->x, p->y,
@@ -366,9 +352,8 @@ draw_image(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct point 
 
 }
 
-static void
-draw_image_warp (struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
-                 struct graphics_image_priv *img) {
+static void draw_image_warp (struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
+                             struct graphics_image_priv *img) {
 
     /*
      *
@@ -391,20 +376,17 @@ static void draw_drag(struct graphics_priv *gra, struct point *p) {
     (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_drag, p ? p->x : 0, p ? p->y : 0);
 }
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
 }
 
-static void
-draw_mode(struct graphics_priv *gra, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gra, enum draw_mode_num mode) {
     (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_mode, (int)mode);
 }
 
 static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
         int w, int h, int wraparound);
 
-static void *
-get_data(struct graphics_priv *this, const char *type) {
+static void *get_data(struct graphics_priv *this, const char *type) {
     if (!strcmp(type,"padding"))
         return this->padding;
     if (!strcmp(type,"window"))
@@ -442,8 +424,7 @@ static void overlay_resize(struct graphics_priv *gra, struct point *pnt, int w, 
                               w, h, wraparound);
 }
 
-static int
-set_attr(struct graphics_priv *gra, struct attr *attr) {
+static int set_attr(struct graphics_priv *gra, struct attr *attr) {
     switch (attr->type) {
     case attr_use_camera:
         (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_SetCamera, attr->u.num);
@@ -497,15 +478,13 @@ static struct graphics_methods graphics_methods = {
     hide_native_keyboard,
 };
 
-static void
-resize_callback(struct graphics_priv *gra, int w, int h) {
+static void resize_callback(struct graphics_priv *gra, int w, int h) {
     dbg(lvl_debug,"w=%d h=%d ok",w,h);
     dbg(lvl_debug,"gra=%p, %d callbacks in list", gra, g_list_length(gra->cbl));
     callback_list_call_attr_2(gra->cbl, attr_resize, (void *)w, (void *)h);
 }
 
-static void
-padding_callback(struct graphics_priv *gra, int left, int top, int right, int bottom) {
+static void padding_callback(struct graphics_priv *gra, int left, int top, int right, int bottom) {
     dbg(lvl_debug, "win.padding left=%d top=%d right=%d bottom=%d ok", left, top, right, bottom);
     gra->padding->left = left;
     gra->padding->top = top;
@@ -513,22 +492,19 @@ padding_callback(struct graphics_priv *gra, int left, int top, int right, int bo
     gra->padding->bottom = bottom;
 }
 
-static void
-motion_callback(struct graphics_priv *gra, int x, int y) {
+static void motion_callback(struct graphics_priv *gra, int x, int y) {
     struct point p;
     p.x=x;
     p.y=y;
     callback_list_call_attr_1(gra->cbl, attr_motion, (void *)&p);
 }
 
-static void
-keypress_callback(struct graphics_priv *gra, char *s) {
+static void keypress_callback(struct graphics_priv *gra, char *s) {
     dbg(lvl_debug,"enter %s",s);
     callback_list_call_attr_1(gra->cbl, attr_keypress, s);
 }
 
-static void
-button_callback(struct graphics_priv *gra, int pressed, int button, int x, int y) {
+static void button_callback(struct graphics_priv *gra, int pressed, int button, int x, int y) {
     struct point p;
     p.x=x;
     p.y=y;
@@ -536,8 +512,7 @@ button_callback(struct graphics_priv *gra, int pressed, int button, int x, int y
 }
 
 
-static int
-set_activity(jobject graphics) {
+static int set_activity(jobject graphics) {
     jclass ActivityClass;
     jmethodID cid;
 
@@ -572,9 +547,9 @@ set_activity(jobject graphics) {
  * @param wraparound (0 for the main view)
  * @param use_camera Whether to use the camera (0 for overlays)
  */
-static int
-graphics_android_init(struct graphics_priv *ret, struct graphics_priv *parent, struct point *pnt, int w, int h,
-                      int wraparound, int use_camera) {
+static int graphics_android_init(struct graphics_priv *ret, struct graphics_priv *parent, struct point *pnt, int w,
+                                 int h,
+                                 int wraparound, int use_camera) {
     struct callback *cb;
     jmethodID cid, Context_getPackageName;
 
@@ -735,14 +710,12 @@ static jclass NavitClass;
 static jmethodID Navit_disableSuspend, Navit_exit, Navit_fullscreen, Navit_runOptionsItem, Navit_showMenu,
        Navit_showNativeKeyboard, Navit_hideNativeKeyboard;
 
-static int
-graphics_android_fullscreen(struct window *win, int on) {
+static int graphics_android_fullscreen(struct window *win, int on) {
     (*jnienv)->CallVoidMethod(jnienv, android_activity, Navit_fullscreen, on);
     return 1;
 }
 
-static void
-graphics_android_disable_suspend(struct window *win) {
+static void graphics_android_disable_suspend(struct window *win) {
     dbg(lvl_debug,"enter");
     (*jnienv)->CallVoidMethod(jnienv, android_activity, Navit_disableSuspend);
 }
@@ -758,9 +731,9 @@ graphics_android_disable_suspend(struct window *win) {
  * @param out Points to a buffer which will receive a pointer to the output of the command
  * @param valid
  */
-static void
-graphics_android_cmd_runMenuItem(struct graphics_priv *this, char *function, struct attr **in, struct attr ***out,
-                                 int *valid) {
+static void graphics_android_cmd_runMenuItem(struct graphics_priv *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     int ncmd=0;
     dbg(0,"Running %s",function);
     if(!strcmp(function,"map_download_dialog")) {
@@ -784,9 +757,8 @@ graphics_android_cmd_runMenuItem(struct graphics_priv *this, char *function, str
  * @param out Points to a buffer which will receive a pointer to the output of the command
  * @param valid
  */
-static void
-graphics_android_cmd_menu(struct graphics_priv *this, char *function, struct attr **in, struct attr ***out,
-                          int *valid) {
+static void graphics_android_cmd_menu(struct graphics_priv *this, char *function, struct attr **in, struct attr ***out,
+                                      int *valid) {
     dbg(lvl_debug, "enter");
     (*jnienv)->CallVoidMethod(jnienv, android_activity, Navit_showMenu);
 }
@@ -815,8 +787,8 @@ static struct command_table commands[] = {
  *
  * @return The new graphics instance
  */
-static struct graphics_priv *
-graphics_android_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_android_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
+        struct callback_list *cbl) {
     struct graphics_priv *ret;
     struct attr *attr;
     int use_camera=0;
@@ -902,8 +874,8 @@ graphics_android_new(struct navit *nav, struct graphics_methods *meth, struct at
  *
  * @return The graphics instance for the new overlay
  */
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h, int wraparound) {
     struct graphics_priv *ret=g_new0(struct graphics_priv, 1);
     *meth=graphics_methods;
     if (graphics_android_init(ret, gr, p, w, h, wraparound, 0)) {
@@ -916,8 +888,7 @@ overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct poin
 }
 
 
-static void
-event_android_main_loop_run(void) {
+static void event_android_main_loop_run(void) {
     dbg(lvl_debug,"enter");
 }
 
@@ -961,8 +932,7 @@ static void do_poll(JNIEnv *env, int fd, int cond) {
     poll(&pfd, 1, -1);
 }
 
-static struct event_watch *
-event_android_add_watch(int h, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_android_add_watch(int h, enum event_watch_cond cond, struct callback *cb) {
     jobject ret;
     ret=(*jnienv)->NewObject(jnienv, NavitWatchClass, NavitWatch_init, (int)do_poll, h, (int) cond, (int)cb);
     dbg(lvl_debug,"result for %d,%d,%p=%p",h,cond,cb,ret);
@@ -971,8 +941,7 @@ event_android_add_watch(int h, enum event_watch_cond cond, struct callback *cb) 
     return (struct event_watch *)ret;
 }
 
-static void
-event_android_remove_watch(struct event_watch *ev) {
+static void event_android_remove_watch(struct event_watch *ev) {
     dbg(lvl_debug,"enter %p",ev);
     if (ev) {
         jobject obj=(jobject )ev;
@@ -988,8 +957,7 @@ struct event_timeout {
     struct callback *cb;
 };
 
-static void
-event_android_remove_timeout(struct event_timeout *priv) {
+static void event_android_remove_timeout(struct event_timeout *priv) {
     if (priv && priv->jni_timeout) {
         (*jnienv)->CallVoidMethod(jnienv, priv->jni_timeout, NavitTimeout_remove);
         (*jnienv)->DeleteGlobalRef(jnienv, priv->jni_timeout);
@@ -1003,8 +971,7 @@ static void event_android_handle_timeout(struct event_timeout *priv) {
         event_android_remove_timeout(priv);
 }
 
-static struct event_timeout *
-event_android_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_android_add_timeout(int timeout, int multi, struct callback *cb) {
     struct event_timeout *ret = g_new0(struct event_timeout, 1);
     ret->cb = cb;
     ret->multi = multi;
@@ -1016,8 +983,7 @@ event_android_add_timeout(int timeout, int multi, struct callback *cb) {
 }
 
 
-static struct event_idle *
-event_android_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_android_add_idle(int priority, struct callback *cb) {
 #if 0
     jobject ret;
     dbg(lvl_debug,"enter");
@@ -1030,8 +996,7 @@ event_android_add_idle(int priority, struct callback *cb) {
     return (struct event_idle *)event_android_add_timeout(1, 1, cb);
 }
 
-static void
-event_android_remove_idle(struct event_idle *ev) {
+static void event_android_remove_idle(struct event_idle *ev) {
 #if 0
     dbg(lvl_debug,"enter %p",ev);
     if (ev) {
@@ -1043,8 +1008,7 @@ event_android_remove_idle(struct event_idle *ev) {
     event_android_remove_timeout((struct event_timeout *)ev);
 }
 
-static void
-event_android_call_callback(struct callback_list *cb) {
+static void event_android_call_callback(struct callback_list *cb) {
     dbg(lvl_debug,"enter");
 }
 
@@ -1060,8 +1024,7 @@ static struct event_methods event_android_methods = {
     event_android_call_callback,
 };
 
-static struct event_priv *
-event_android_new(struct event_methods *meth) {
+static struct event_priv *event_android_new(struct event_methods *meth) {
     dbg(lvl_debug,"enter");
     if (!find_class_global("org/navitproject/navit/NavitTimeout", &NavitTimeoutClass))
         return NULL;
@@ -1166,8 +1129,7 @@ void hide_native_keyboard (struct graphics_keyboard *kbd) {
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug,"enter");
     plugin_register_category_graphics("android", graphics_android_new);
     plugin_register_category_event("android", event_android_new);

--- a/navit/graphics/android/graphics_android.c
+++ b/navit/graphics/android/graphics_android.c
@@ -130,8 +130,7 @@ static struct graphics_font_methods font_methods = {
     font_destroy
 };
 
-static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct graphics_font_methods *meth, char *font,
-        int size, int flags) {
+static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct graphics_font_methods *meth, char *font, int size, int flags) {
     struct graphics_font_priv *ret=g_new0(struct graphics_font_priv, 1);
     *meth=font_methods;
 
@@ -196,9 +195,7 @@ static struct graphics_image_methods image_methods = {
 };
 
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gra, struct graphics_image_methods *meth, char *path,
-        int *w, int *h, struct point *hot,
-        int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gra, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot, int rotation) {
     struct graphics_image_priv* ret = NULL;
 
     ret=g_new0(struct graphics_image_priv, 1);
@@ -219,8 +216,7 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gra, struct g
         id=(*jnienv)->CallIntMethod(jnienv, gra->Resources, gra->Resources_getIdentifier, string, a, gra->packageName);
         dbg(lvl_debug,"id=%d",id);
         if (id)
-            localBitmap=(*jnienv)->CallStaticObjectMethod(jnienv, gra->BitmapFactoryClass, gra->BitmapFactory_decodeResource,
-                        gra->Resources, id);
+            localBitmap=(*jnienv)->CallStaticObjectMethod(jnienv, gra->BitmapFactoryClass, gra->BitmapFactory_decodeResource, gra->Resources, id);
         (*jnienv)->DeleteLocalRef(jnienv, a);
     } else {
         string = (*jnienv)->NewStringUTF(jnienv, path);
@@ -320,8 +316,7 @@ static void draw_polygon(struct graphics_priv *gra, struct graphics_gc_priv *gc,
 
 static void draw_rectangle(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     initPaint(gra, gc);
-    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_rectangle, gc->gra->Paint, p->x, p->y, w,
-                              h);
+    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_rectangle, gc->gra->Paint, p->x, p->y, w, h);
 }
 
 static void draw_circle(struct graphics_priv *gra, struct graphics_gc_priv *gc, struct point *p, int r) {
@@ -330,30 +325,25 @@ static void draw_circle(struct graphics_priv *gra, struct graphics_gc_priv *gc, 
 }
 
 
-static void draw_text(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     int bgcolor=0;
     dbg(lvl_debug,"enter %s", text);
     initPaint(gra, fg);
     if(bg)
         bgcolor=(bg->a<<24)| (bg->r<<16) | (bg->g<<8) | bg->b;
     jstring string = (*jnienv)->NewStringUTF(jnienv, text);
-    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_text, fg->gra->Paint, p->x, p->y, string,
-                              font->size, dx, dy, bgcolor);
+    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_text, fg->gra->Paint, p->x, p->y, string, font->size, dx, dy, bgcolor);
     (*jnienv)->DeleteLocalRef(jnienv, string);
 }
 
-static void draw_image(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct point *p,
-                       struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gra, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
     dbg(lvl_debug,"enter %p",img);
     initPaint(gra, fg);
-    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_image, fg->gra->Paint, p->x, p->y,
-                              img->Bitmap);
+    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_image, fg->gra->Paint, p->x, p->y, img->Bitmap);
 
 }
 
-static void draw_image_warp (struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
-                             struct graphics_image_priv *img) {
+static void draw_image_warp (struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count, struct graphics_image_priv *img) {
 
     /*
      *
@@ -364,8 +354,7 @@ static void draw_image_warp (struct graphics_priv *gr, struct graphics_gc_priv *
 
     if (count==3) {
         initPaint(gr, fg);
-        (*jnienv)->CallVoidMethod(jnienv, gr->NavitGraphics, gr->NavitGraphics_draw_image_warp, fg->gra->Paint,
-                                  count,  p[0].x, p[0].y,p[1].x, p[1].y, p[2].x, p[2].y, img->Bitmap);
+        (*jnienv)->CallVoidMethod(jnienv, gr->NavitGraphics, gr->NavitGraphics_draw_image_warp, fg->gra->Paint, count,  p[0].x, p[0].y,p[1].x, p[1].y, p[2].x, p[2].y, img->Bitmap);
     } else
         dbg(lvl_debug,"draw_image_warp is called with unsupported count parameter value %d", count);
 }
@@ -383,8 +372,7 @@ static void draw_mode(struct graphics_priv *gra, enum draw_mode_num mode) {
     (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_draw_mode, (int)mode);
 }
 
-static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound);
+static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound);
 
 static void *get_data(struct graphics_priv *this, const char *type) {
     if (!strcmp(type,"padding"))
@@ -397,8 +385,7 @@ static void *get_data(struct graphics_priv *this, const char *type) {
 static void image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
 }
 
-static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy,
-                          struct point *ret, int estimate) {
+static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy, struct point *ret, int estimate) {
     int len = g_utf8_strlen(text, -1);
     int xMin = 0;
     int yMin = 0;
@@ -420,8 +407,7 @@ static void overlay_disable(struct graphics_priv *gra, int disable) {
 }
 
 static void overlay_resize(struct graphics_priv *gra, struct point *pnt, int w, int h, int wraparound) {
-    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_overlay_resize, pnt ? pnt->x:0, pnt ? pnt->y:0,
-                              w, h, wraparound);
+    (*jnienv)->CallVoidMethod(jnienv, gra->NavitGraphics, gra->NavitGraphics_overlay_resize, pnt ? pnt->x:0, pnt ? pnt->y:0, w, h, wraparound);
 }
 
 static int set_attr(struct graphics_priv *gra, struct attr *attr) {
@@ -547,9 +533,7 @@ static int set_activity(jobject graphics) {
  * @param wraparound (0 for the main view)
  * @param use_camera Whether to use the camera (0 for overlays)
  */
-static int graphics_android_init(struct graphics_priv *ret, struct graphics_priv *parent, struct point *pnt, int w,
-                                 int h,
-                                 int wraparound, int use_camera) {
+static int graphics_android_init(struct graphics_priv *ret, struct graphics_priv *parent, struct point *pnt, int w, int h, int wraparound, int use_camera) {
     struct callback *cb;
     jmethodID cid, Context_getPackageName;
 
@@ -707,8 +691,7 @@ static int graphics_android_init(struct graphics_priv *ret, struct graphics_priv
 }
 
 static jclass NavitClass;
-static jmethodID Navit_disableSuspend, Navit_exit, Navit_fullscreen, Navit_runOptionsItem, Navit_showMenu,
-       Navit_showNativeKeyboard, Navit_hideNativeKeyboard;
+static jmethodID Navit_disableSuspend, Navit_exit, Navit_fullscreen, Navit_runOptionsItem, Navit_showMenu, Navit_showNativeKeyboard, Navit_hideNativeKeyboard;
 
 static int graphics_android_fullscreen(struct window *win, int on) {
     (*jnienv)->CallVoidMethod(jnienv, android_activity, Navit_fullscreen, on);
@@ -731,9 +714,7 @@ static void graphics_android_disable_suspend(struct window *win) {
  * @param out Points to a buffer which will receive a pointer to the output of the command
  * @param valid
  */
-static void graphics_android_cmd_runMenuItem(struct graphics_priv *this, char *function, struct attr **in,
-        struct attr ***out,
-        int *valid) {
+static void graphics_android_cmd_runMenuItem(struct graphics_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     int ncmd=0;
     dbg(0,"Running %s",function);
     if(!strcmp(function,"map_download_dialog")) {
@@ -757,8 +738,7 @@ static void graphics_android_cmd_runMenuItem(struct graphics_priv *this, char *f
  * @param out Points to a buffer which will receive a pointer to the output of the command
  * @param valid
  */
-static void graphics_android_cmd_menu(struct graphics_priv *this, char *function, struct attr **in, struct attr ***out,
-                                      int *valid) {
+static void graphics_android_cmd_menu(struct graphics_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     dbg(lvl_debug, "enter");
     (*jnienv)->CallVoidMethod(jnienv, android_activity, Navit_showMenu);
 }
@@ -787,8 +767,7 @@ static struct command_table commands[] = {
  *
  * @return The new graphics instance
  */
-static struct graphics_priv *graphics_android_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
-        struct callback_list *cbl) {
+static struct graphics_priv *graphics_android_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct graphics_priv *ret;
     struct attr *attr;
     int use_camera=0;
@@ -874,8 +853,7 @@ static struct graphics_priv *graphics_android_new(struct navit *nav, struct grap
  *
  * @return The graphics instance for the new overlay
  */
-static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
     struct graphics_priv *ret=g_new0(struct graphics_priv, 1);
     *meth=graphics_methods;
     if (graphics_android_init(ret, gr, p, w, h, wraparound, 0)) {

--- a/navit/graphics/egl/graphics_egl.c
+++ b/navit/graphics/egl/graphics_egl.c
@@ -177,11 +177,10 @@ float area(const struct contour* contour) {
     return A * .5f;
 }
 
-int
-inside_triangle(float Ax, float Ay,
-                float Bx, float By,
-                float Cx, float Cy,
-                float Px, float Py) {
+int inside_triangle(float Ax, float Ay,
+                    float Bx, float By,
+                    float Cx, float Cy,
+                    float Px, float Py) {
     float ax, ay, bx, by, cx, cy, apx, apy, bpx, bpy, cpx, cpy;
     float cCROSSap, bCROSScp, aCROSSbp;
 
@@ -205,8 +204,7 @@ inside_triangle(float Ax, float Ay,
     return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f));
 }
 
-int
-snip(const struct point* pnt,int u,int v,int w,int n,int *V) {
+int snip(const struct point* pnt,int u,int v,int w,int n,int *V) {
     int p;
     float Ax, Ay, Bx, By, Cx, Cy, Px, Py;
 
@@ -234,8 +232,7 @@ snip(const struct point* pnt,int u,int v,int w,int n,int *V) {
     return 1;
 }
 
-int
-process_triangles(const struct contour* contour, struct contour* result) {
+int process_triangles(const struct contour* contour, struct contour* result) {
     int v;
     int contour_size = contour->count - 1;
     int polygon_temp_size = contour_size * 80;
@@ -309,8 +306,7 @@ process_triangles(const struct contour* contour, struct contour* result) {
 /*
  * Destroys SDL/EGL context
  */
-static void
-sdl_egl_destroy(struct graphics_opengl_platform *egl) {
+static void sdl_egl_destroy(struct graphics_opengl_platform *egl) {
     if (egl->eglwindow) {
         SDL_GL_DeleteContext(egl->eglcontext);
         SDL_DestroyWindow(egl->eglwindow);
@@ -322,16 +318,14 @@ sdl_egl_destroy(struct graphics_opengl_platform *egl) {
 /*
  * Swap EGL buffer
  */
-static void
-sdl_egl_swap_buffers(struct graphics_opengl_platform *egl) {
+static void sdl_egl_swap_buffers(struct graphics_opengl_platform *egl) {
     SDL_GL_SwapWindow(egl->eglwindow);
 }
 
 /*
  * Main graphic destroy
  */
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
     /*FIXME graphics_destroy is never called */
     gr->freetype_methods.destroy();
     g_free(gr);
@@ -340,20 +334,17 @@ graphics_destroy(struct graphics_priv *gr) {
     SDL_Quit();
 }
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
     g_free(gc);
     gc = NULL;
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->linewidth = w;
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
-              unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
+                          unsigned char *dash_list, int n) {
     int i;
     const int cOpenglMaskBits = 16;
     gc->dash_count = n;
@@ -408,16 +399,14 @@ gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
 }
 
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     gc->fr = c->r / 65535.0;
     gc->fg = c->g / 65535.0;
     gc->fb = c->b / 65535.0;
     gc->fa = c->a / 65535.0;
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
     gc->br = c->r / 65535.0;
     gc->bg = c->g / 65535.0;
     gc->bb = c->b / 65535.0;
@@ -432,8 +421,7 @@ static struct graphics_gc_methods gc_methods = {
     gc_set_background
 };
 
-static struct graphics_gc_priv *
-gc_new(struct graphics_priv *gr, struct graphics_gc_methods *meth) {
+static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics_gc_methods *meth) {
     struct graphics_gc_priv *gc = g_new0(struct graphics_gc_priv, 1);
 
     *meth = gc_methods;
@@ -444,9 +432,9 @@ gc_new(struct graphics_priv *gr, struct graphics_gc_methods *meth) {
 
 static struct graphics_image_priv image_error;
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h,
-          struct point *hot, int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
+        int *w, int *h,
+        struct point *hot, int rotation) {
     struct graphics_image_priv *gi;
 
     /* FIXME: meth is not used yet.. so gi leaks. at least xpm is small */
@@ -494,14 +482,12 @@ image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *n
     return gi;
 }
 
-static void
-image_free(struct graphics_priv *gr, struct graphics_image_priv * gi) {
+static void image_free(struct graphics_priv *gr, struct graphics_image_priv * gi) {
 //    SDL_FreeSurface(gi->img);
 //    g_free(gi);
 }
 
-static void
-set_color(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void set_color(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     GLfloat col[4];
     col[0]=gc->fr;
     col[1]=gc->fg;
@@ -510,8 +496,7 @@ set_color(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     glUniform4fv(gr->color_location, 1, col);
 }
 
-static void
-draw_array(struct graphics_priv *gr, struct point *p, int count, GLenum mode) {
+static void draw_array(struct graphics_priv *gr, struct point *p, int count, GLenum mode) {
     int i;
     GLf *x;//[count*2];
     x = alloca(sizeof(GLf)*count*2);
@@ -524,8 +509,7 @@ draw_array(struct graphics_priv *gr, struct point *p, int count, GLenum mode) {
     glDrawArrays(mode, 0, count);
 }
 
-static void
-draw_rectangle_do(struct graphics_priv *gr, struct point *p, int w, int h) {
+static void draw_rectangle_do(struct graphics_priv *gr, struct point *p, int w, int h) {
     struct point pa[4];
     pa[0]=pa[1]=pa[2]=pa[3]=*p;
     pa[0].x+=w;
@@ -536,8 +520,7 @@ draw_rectangle_do(struct graphics_priv *gr, struct point *p, int w, int h) {
 }
 
 
-static void
-draw_image_es(struct graphics_priv *gr, struct point *p, int w, int h, unsigned char *data) {
+static void draw_image_es(struct graphics_priv *gr, struct point *p, int w, int h, unsigned char *data) {
     GLf x[8];
     GLuint texture;
     memset(x, 0, sizeof(x));
@@ -571,8 +554,7 @@ draw_image_es(struct graphics_priv *gr, struct point *p, int w, int h, unsigned 
     glDeleteTextures(1, &texture);
 }
 
-inline void
-get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
+inline void get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
     if (gr->parent == NULL) {
         point_out->x = 0;
         point_out->y = 0;
@@ -589,8 +571,7 @@ get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
     }
 }
 
-inline void
-draw_overlay(struct graphics_priv *gr) {
+inline void draw_overlay(struct graphics_priv *gr) {
     struct point p_eff;
     GLf x[8];
 
@@ -618,9 +599,8 @@ draw_overlay(struct graphics_priv *gr) {
     glDisable(GL_BLEND);
 }
 
-static void
-draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-           struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
+                       struct point *p, int count) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -636,9 +616,8 @@ draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
 }
 
 
-static void
-draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-             struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
+                         struct point *p, int count) {
     int ok;
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
@@ -659,9 +638,8 @@ draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
     }
 }
 
-static void
-draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-               struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
+                           struct point *p, int w, int h) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -672,10 +650,9 @@ draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
     graphics_priv_root->dirty = 1;
 }
 
-static void
-display_text_draw(struct font_freetype_text *text,
-                  struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                  struct graphics_gc_priv *bg, int color, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text,
+                              struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                              struct graphics_gc_priv *bg, int color, struct point *p) {
     int i, x, y, stride;
     struct font_freetype_glyph *g, **gp;
     unsigned char *shadow, *glyph;
@@ -793,10 +770,9 @@ display_text_draw(struct font_freetype_text *text,
     }
 }
 
-static void
-draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-          struct graphics_gc_priv *bg, struct graphics_font_priv *font,
-          char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                      struct graphics_gc_priv *bg, struct graphics_font_priv *font,
+                      char *text, struct point *p, int dx, int dy) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -825,30 +801,26 @@ draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
 }
 
 
-static void
-draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-           struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                       struct point *p, struct graphics_image_priv *img) {
     draw_image_es(gr, p, img->img->w, img->img->h, img->img->pixels);
 }
 
-static void
-draw_drag(struct graphics_priv *gr, struct point *p) {
+static void draw_drag(struct graphics_priv *gr, struct point *p) {
     if (p) {
         gr->p.x = p->x;
         gr->p.y = p->y;
     }
 }
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     gr->background_gc = gc;
 }
 
 /*
  * Draws map in background
  */
-static void
-draw_background(struct graphics_priv *gr) {
+static void draw_background(struct graphics_priv *gr) {
     struct point p_eff;
     GLf x[8];
 
@@ -882,8 +854,7 @@ draw_background(struct graphics_priv *gr) {
     Map and overlays are rendered in an offscreen buffer (See render to texture)
     and are recomposed altogether at draw_mode_end request for root
 */
-static void
-draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     GLfloat matrix[16];
     struct graphics_priv *overlay = NULL;
     int i;
@@ -932,19 +903,16 @@ draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     gr->mode = mode;
 }
 
-static int
-graphics_opengl_fullscreen(struct window *w, int on) {
+static int graphics_opengl_fullscreen(struct window *w, int on) {
     return 1;
 }
 
-static void
-graphics_opengl_disable_suspend(struct window *w) {
+static void graphics_opengl_disable_suspend(struct window *w) {
     // No op
 }
 
 
-static GLuint
-load_shader(const char *shader_source, GLenum type) {
+static GLuint load_shader(const char *shader_source, GLenum type) {
     GLuint shader = glCreateShader(type);
 
     glShaderSource(shader, 1, &shader_source, NULL);
@@ -953,8 +921,7 @@ load_shader(const char *shader_source, GLenum type) {
     return shader;
 }
 
-static void *
-get_data(struct graphics_priv *this, const char *type) {
+static void *get_data(struct graphics_priv *this, const char *type) {
     GLuint vertexShader;
     GLuint fragmentShader;
     struct window* win;
@@ -1007,17 +974,15 @@ get_data(struct graphics_priv *this, const char *type) {
 
 }
 
-static void
-overlay_disable(struct graphics_priv *gr, int disable) {
+static void overlay_disable(struct graphics_priv *gr, int disable) {
     gr->overlay_enabled = !disable;
     gr->force_redraw = 1;
     draw_mode(gr, draw_mode_end);
 }
 
 // Need more testing
-static void
-overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h,
-               int wraparound) {
+static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h,
+                           int wraparound) {
     int changed = 0;
     int w2, h2;
 
@@ -1099,8 +1064,7 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *
-graphics_opengl_new_helper(struct graphics_methods *meth) {
+static struct graphics_priv *graphics_opengl_new_helper(struct graphics_methods *meth) {
     struct font_priv *(*font_freetype_new) (void *meth);
     font_freetype_new = plugin_get_category_font("freetype");
 
@@ -1123,8 +1087,7 @@ graphics_opengl_new_helper(struct graphics_methods *meth) {
     return this;
 }
 
-static void
-create_framebuffer_texture(struct graphics_priv *gr) {
+static void create_framebuffer_texture(struct graphics_priv *gr) {
     GLenum status;
     // Prepare a new framebuffer object
     glGenFramebuffers(1, &gr->framebuffer_name);
@@ -1145,9 +1108,8 @@ create_framebuffer_texture(struct graphics_priv *gr) {
     }
 }
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth,
-            struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth,
+        struct point *p, int w, int h, int wraparound) {
     struct graphics_priv *this = graphics_opengl_new_helper(meth);
 
     this->p.x = p->x;
@@ -1302,9 +1264,8 @@ static gboolean graphics_sdl_idle(void *data) {
 }
 
 
-static struct graphics_priv *
-graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
-                    struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
+        struct attr **attrs, struct callback_list *cbl) {
     struct attr *attr;
     if (!event_request_system("glib", "graphics_opengl_new"))
         return NULL;
@@ -1392,8 +1353,7 @@ error:
     return NULL;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_graphics("egl", graphics_opengl_new);
 }
 

--- a/navit/graphics/egl/graphics_egl.c
+++ b/navit/graphics/egl/graphics_egl.c
@@ -88,8 +88,7 @@ struct graphics_priv {
     struct graphics_gc_priv *background_gc;
     enum draw_mode_num mode;
     GLuint program;
-    GLint mvp_location, position_location, color_location, texture_position_location, use_texture_location,
-          texture_location;
+    GLint mvp_location, position_location, color_location, texture_position_location, use_texture_location, texture_location;
     struct callback_list *cbl;
     struct font_freetype_methods freetype_methods;
     struct navit *nav;
@@ -343,8 +342,7 @@ static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->linewidth = w;
 }
 
-static void gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
-                          unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset, unsigned char *dash_list, int n) {
     int i;
     const int cOpenglMaskBits = 16;
     gc->dash_count = n;
@@ -432,9 +430,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 
 static struct graphics_image_priv image_error;
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
-        int *w, int *h,
-        struct point *hot, int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h, struct point *hot, int rotation) {
     struct graphics_image_priv *gi;
 
     /* FIXME: meth is not used yet.. so gi leaks. at least xpm is small */
@@ -455,8 +451,7 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct gr
     }
 
     if (strlen(name) < 4) {
-        g_hash_table_insert(hImageData, g_strdup(name),
-                            &image_error);
+        g_hash_table_insert(hImageData, g_strdup(name), &image_error);
         return NULL;
     }
 
@@ -472,9 +467,7 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct gr
         dbg(lvl_error,"image_new on '%s' failed: %s", name, IMG_GetError());
         g_free(gi);
         gi = NULL;
-        g_hash_table_insert(hImageData,
-                            g_strdup(name),
-                            &image_error);
+        g_hash_table_insert(hImageData, g_strdup(name), &image_error);
         return gi;
     }
 
@@ -599,8 +592,7 @@ inline void draw_overlay(struct graphics_priv *gr) {
     glDisable(GL_BLEND);
 }
 
-static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-                       struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -616,8 +608,7 @@ static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
 }
 
 
-static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-                         struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     int ok;
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
@@ -638,8 +629,7 @@ static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
     }
 }
 
-static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-                           struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -650,9 +640,7 @@ static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc
     graphics_priv_root->dirty = 1;
 }
 
-static void display_text_draw(struct font_freetype_text *text,
-                              struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                              struct graphics_gc_priv *bg, int color, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, int color, struct point *p) {
     int i, x, y, stride;
     struct font_freetype_glyph *g, **gp;
     unsigned char *shadow, *glyph;
@@ -707,10 +695,7 @@ static void display_text_draw(struct font_freetype_text *text,
             stride = (g->w + 2) * 4;
             if (color) {
                 shadow = g_malloc(stride * (g->h + 2));
-                gr->freetype_methods.get_shadow(g, shadow,
-                                                stride,
-                                                &white,
-                                                &transparent);
+                gr->freetype_methods.get_shadow(g, shadow, stride, &white, &transparent);
 
                 struct point p;
                 p.x=((x + g->x) >> 6)-1;
@@ -736,13 +721,7 @@ static void display_text_draw(struct font_freetype_text *text,
                 if (bg) {
                     glyph =
                         g_malloc(stride * g->h * 4);
-                    gr->freetype_methods.get_glyph(g,
-                                                   glyph,
-                                                   stride
-                                                   * 4,
-                                                   &black,
-                                                   &white,
-                                                   &transparent);
+                    gr->freetype_methods.get_glyph(g, glyph, stride * 4, &black, &white, &transparent);
                     struct point p;
                     p.x=(x + g->x) >> 6;
                     p.y=(y + g->y) >> 6;
@@ -752,11 +731,7 @@ static void display_text_draw(struct font_freetype_text *text,
                 }
                 stride *= 4;
                 glyph = g_malloc(stride * g->h);
-                gr->freetype_methods.get_glyph(g, glyph,
-                                               stride,
-                                               &black,
-                                               &white,
-                                               &transparent);
+                gr->freetype_methods.get_glyph(g, glyph, stride, &black, &white, &transparent);
                 struct point p;
                 p.x=(x + g->x) >> 6;
                 p.y=(y + g->y) >> 6;
@@ -770,9 +745,7 @@ static void display_text_draw(struct font_freetype_text *text,
     }
 }
 
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                      struct graphics_gc_priv *bg, struct graphics_font_priv *font,
-                      char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -788,9 +761,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
     }
     graphics_priv_root->dirty = 1;
 
-    t = gr->freetype_methods.text_new(text,
-                                      (struct font_freetype_font *)
-                                      font, dx, dy);
+    t = gr->freetype_methods.text_new(text, (struct font_freetype_font *) font, dx, dy);
 
     struct point p_eff;
     p_eff.x = p->x;
@@ -801,8 +772,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
 }
 
 
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                       struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
     draw_image_es(gr, p, img->img->w, img->img->h, img->img->pixels);
 }
 
@@ -928,8 +898,7 @@ static void *get_data(struct graphics_priv *this, const char *type) {
     int i;
 
     if (!strcmp(type, "gtk_widget")) {
-        fprintf(stderr,
-                "Currently GTK gui is not yet supported with EGL graphics driver\n");
+        fprintf(stderr, "Currently GTK gui is not yet supported with EGL graphics driver\n");
         return NULL;
     }
 
@@ -939,8 +908,7 @@ static void *get_data(struct graphics_priv *this, const char *type) {
         glClearColor ( 0, 0, 0, 1);
         glClear ( GL_COLOR_BUFFER_BIT );
 
-        callback_list_call_attr_2(graphics_priv_root->cbl, attr_resize,
-                                  GINT_TO_POINTER(this->width), GINT_TO_POINTER(this->height));
+        callback_list_call_attr_2(graphics_priv_root->cbl, attr_resize, GINT_TO_POINTER(this->width), GINT_TO_POINTER(this->height));
 
         this->program  = glCreateProgram();
         vertexShader   = load_shader(vertex_src, GL_VERTEX_SHADER);
@@ -981,8 +949,7 @@ static void overlay_disable(struct graphics_priv *gr, int disable) {
 }
 
 // Need more testing
-static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h,
-                           int wraparound) {
+static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound) {
     int changed = 0;
     int w2, h2;
 
@@ -1026,9 +993,7 @@ static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, gr->overlay_texture, 0);
         }
 
-        callback_list_call_attr_2(gr->cbl, attr_resize,
-                                  GINT_TO_POINTER(gr->width),
-                                  GINT_TO_POINTER(gr->height));
+        callback_list_call_attr_2(gr->cbl, attr_resize, GINT_TO_POINTER(gr->width), GINT_TO_POINTER(gr->height));
     }
 }
 
@@ -1108,8 +1073,7 @@ static void create_framebuffer_texture(struct graphics_priv *gr) {
     }
 }
 
-static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth,
-        struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
     struct graphics_priv *this = graphics_opengl_new_helper(meth);
 
     this->p.x = p->x;
@@ -1264,8 +1228,7 @@ static gboolean graphics_sdl_idle(void *data) {
 }
 
 
-static struct graphics_priv *graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
-        struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_opengl_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct attr *attr;
     if (!event_request_system("glib", "graphics_opengl_new"))
         return NULL;

--- a/navit/graphics/gd/graphics_gd.c
+++ b/navit/graphics/gd/graphics_gd.c
@@ -279,9 +279,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 }
 
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
-        int *w, int *h, struct point *hot,
-        int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h, struct point *hot, int rotation) {
     FILE *file;
     struct graphics_image_priv *ret=NULL;
     gdImagePtr im=NULL;
@@ -378,8 +376,7 @@ static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, s
 }
 
 
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     struct font_freetype_text *t;
     struct font_freetype_glyph *g, **gp;
     gdImagePtr im;
@@ -431,8 +428,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, str
     gr->freetype_methods.text_destroy(t);
 }
 
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
-                       struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
     gdImageCopy(gr->im, img->im, p->x, p->y, 0, 0, img->im->sx, img->im->sy);
 }
 
@@ -511,8 +507,7 @@ static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     }
 }
 
-static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound);
+static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound);
 
 static void add_overlays(struct graphics_priv *overlay, gdImagePtr im) {
     while (overlay) {
@@ -761,8 +756,7 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
     struct font_priv * (*font_freetype_new)(void *meth);
     struct graphics_priv *ret;
 
@@ -790,8 +784,7 @@ static void emit_callback(struct graphics_priv *priv) {
 }
 
 
-static struct graphics_priv *graphics_gd_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
-        struct callback_list *cbl) {
+static struct graphics_priv *graphics_gd_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct font_priv * (*font_freetype_new)(void *meth);
     struct graphics_priv *ret;
     event_request_system("glib","graphics_gd_new");
@@ -801,8 +794,7 @@ static struct graphics_priv *graphics_gd_new(struct navit *nav, struct graphics_
     *meth=graphics_methods;
     ret=g_new0(struct graphics_priv, 1);
     font_freetype_new(&ret->freetype_methods);
-    meth->font_new=(struct graphics_font_priv *(*)(struct graphics_priv *, struct graphics_font_methods *, char *,  int,
-                    int))ret->freetype_methods.font_new;
+    meth->font_new=(struct graphics_font_priv *(*)(struct graphics_priv *, struct graphics_font_methods *, char *,  int, int))ret->freetype_methods.font_new;
     meth->get_text_bbox=ret->freetype_methods.get_text_bbox;
     ret->cb=callback_new_attr_1(callback_cast(emit_callback), attr_navit, ret);
     navit_add_callback(nav, ret->cb);

--- a/navit/graphics/gd/graphics_gd.c
+++ b/navit/graphics/gd/graphics_gd.c
@@ -221,14 +221,12 @@ struct graphics_image_priv {
 };
 
 
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
     gr->freetype_methods.destroy();
     g_free(gr);
 }
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
     if (gc->color != -1)
         gdImageColorDeallocate(gc->gr->im, gc->color);
     if (gc->bgcolor != -1)
@@ -237,13 +235,11 @@ gc_destroy(struct graphics_gc_priv *gc) {
     g_free(gc);
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->width=w;
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
     int i,count=0;
     g_free(gc->dash_list);
     gc->dash_list=g_new(unsigned char, n);
@@ -255,14 +251,12 @@ gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *das
     gc->dash_count=count;
 }
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     gc->color2=*c;
     gc->color=gdImageColorAllocate(gc->gr->im, c->r>>8, c->g>>8, c->b>>8);
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
     gc->bgcolor=gdImageColorAllocate(gc->gr->im, c->r>>8, c->g>>8, c->b>>8);
 }
 
@@ -285,9 +279,9 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 }
 
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h, struct point *hot,
-          int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
+        int *w, int *h, struct point *hot,
+        int rotation) {
     FILE *file;
     struct graphics_image_priv *ret=NULL;
     gdImagePtr im=NULL;
@@ -324,8 +318,7 @@ image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *n
     return ret;
 }
 
-static void
-draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     int color[gc->dash_count],cc;
     int i,j,k=0;
 
@@ -356,8 +349,7 @@ draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *
 #endif
 }
 
-static void
-draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     int cc=gc->color;
     if (gr->flags & 8) {
         gdImageSetAntiAliased(gr->im, cc);
@@ -366,8 +358,7 @@ draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point
     gdImageFilledPolygon(gr->im, (gdPointPtr) p, count, cc);
 }
 
-static void
-draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     int cc=gc->color;
     if (gr->flags & 8) {
         gdImageSetAntiAliased(gr->im, cc);
@@ -376,8 +367,7 @@ draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct poi
     gdImageFilledRectangle(gr->im, p->x, p->y, p->x+w, p->y+h, cc);
 }
 
-static void
-draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
+static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
     int cc=gc->color;
     if (gr->flags & 8) {
         gdImageSetAntiAliased(gr->im, cc);
@@ -388,9 +378,8 @@ draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point 
 }
 
 
-static void
-draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-          struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
+                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     struct font_freetype_text *t;
     struct font_freetype_glyph *g, **gp;
     gdImagePtr im;
@@ -442,13 +431,12 @@ draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics
     gr->freetype_methods.text_destroy(t);
 }
 
-static void
-draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
+                       struct graphics_image_priv *img) {
     gdImageCopy(gr->im, img->im, p->x, p->y, 0, 0, img->im->sx, img->im->sy);
 }
 
-static void
-draw_drag(struct graphics_priv *gr, struct point *p) {
+static void draw_drag(struct graphics_priv *gr, struct point *p) {
     if (p)
         gr->p=*p;
     else {
@@ -458,13 +446,11 @@ draw_drag(struct graphics_priv *gr, struct point *p) {
 }
 
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     gr->background=gc;
 }
 
-static void
-draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     FILE *pngout;
 #if 0
     if (mode == draw_mode_begin && gr->background) {
@@ -528,8 +514,7 @@ draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
 static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
         int w, int h, int wraparound);
 
-static void
-add_overlays(struct graphics_priv *overlay, gdImagePtr im) {
+static void add_overlays(struct graphics_priv *overlay, gdImagePtr im) {
     while (overlay) {
         if (overlay->background) {
             gdImagePtr res,src;
@@ -558,8 +543,7 @@ add_overlays(struct graphics_priv *overlay, gdImagePtr im) {
     }
 }
 
-static void *
-get_data(struct graphics_priv *this, char *type) {
+static void *get_data(struct graphics_priv *this, char *type) {
     int b;
     struct point p;
     gdImagePtr im = this->im;
@@ -596,19 +580,16 @@ get_data(struct graphics_priv *this, char *type) {
 }
 
 
-static void
-image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
+static void image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
     gdImageDestroy(priv->im);
     g_free(priv);
 }
 
-static void
-overlay_disable(struct graphics_priv *gr, int disable) {
+static void overlay_disable(struct graphics_priv *gr, int disable) {
     dbg(lvl_debug,"enter");
 }
 
-static void
-overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound) {
+static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound) {
     dbg(lvl_debug,"enter");
 }
 
@@ -623,8 +604,7 @@ shm_next(struct graphics_priv *gr) {
     return (struct shmem_header *)next;
 
 }
-static void
-image_setup(struct graphics_priv *gr) {
+static void image_setup(struct graphics_priv *gr) {
     int i,*shm=(int *)(gr->shm_header+1);
     if (!gr->shmkey)
         return;
@@ -636,8 +616,7 @@ image_setup(struct graphics_priv *gr) {
     gr->shm_header->flag=0;
 }
 
-static void
-image_create(struct graphics_priv *gr) {
+static void image_create(struct graphics_priv *gr) {
     dbg(lvl_debug,"shmkey %d",gr->shmkey);
 #ifdef HAVE_SHMEM
     if (gr->shmkey) {
@@ -666,8 +645,7 @@ image_create(struct graphics_priv *gr) {
         gr->im=gdImageCreateTrueColor(gr->w,gr->h);
 }
 
-static void
-image_destroy(struct graphics_priv *gr) {
+static void image_destroy(struct graphics_priv *gr) {
 #ifdef HAVE_SHMEM
     if (gr->shmkey) {
         shmdt(gr->shm);
@@ -679,8 +657,7 @@ image_destroy(struct graphics_priv *gr) {
     gr->im=NULL;
 }
 
-static int
-set_attr_do(struct graphics_priv *gr, struct attr *attr, int init) {
+static int set_attr_do(struct graphics_priv *gr, struct attr *attr, int init) {
     char *s,*c,*n,*p;
     switch (attr->type) {
     case attr_w:
@@ -754,8 +731,7 @@ set_attr_do(struct graphics_priv *gr, struct attr *attr, int init) {
 }
 
 
-static int
-set_attr(struct graphics_priv *gr, struct attr *attr) {
+static int set_attr(struct graphics_priv *gr, struct attr *attr) {
     return set_attr_do(gr, attr, 0);
 }
 
@@ -785,8 +761,8 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h, int wraparound) {
     struct font_priv * (*font_freetype_new)(void *meth);
     struct graphics_priv *ret;
 
@@ -809,14 +785,13 @@ overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct poin
     return ret;
 }
 
-static void
-emit_callback(struct graphics_priv *priv) {
+static void emit_callback(struct graphics_priv *priv) {
     callback_list_call_attr_2(priv->cbl, attr_resize, (void *)priv->w, (void *)priv->h);
 }
 
 
-static struct graphics_priv *
-graphics_gd_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_gd_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
+        struct callback_list *cbl) {
     struct font_priv * (*font_freetype_new)(void *meth);
     struct graphics_priv *ret;
     event_request_system("glib","graphics_gd_new");
@@ -844,7 +819,6 @@ graphics_gd_new(struct navit *nav, struct graphics_methods *meth, struct attr **
     return ret;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_graphics("gd", graphics_gd_new);
 }

--- a/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
+++ b/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
@@ -109,8 +109,7 @@ struct graphics_image_priv {
 #endif
 };
 
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
     dbg(lvl_debug,"enter parent %p",gr->parent);
     gr->freetype_methods.destroy();
     if (!gr->parent) {
@@ -125,18 +124,15 @@ graphics_destroy(struct graphics_priv *gr) {
     g_free(gr);
 }
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
     g_free(gc);
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->linewidth = w;
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
     int i;
     g_free(gc->dashes);
     gc->ndashes=n;
@@ -151,13 +147,11 @@ gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *das
     }
 }
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     gc->c=*c;
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
 }
 
 static struct graphics_gc_methods gc_methods = {
@@ -187,9 +181,9 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 }
 
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h, struct point *hot,
-          int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
+        int *w, int *h, struct point *hot,
+        int rotation) {
     GdkPixbuf *pixbuf;
     struct graphics_image_priv *ret;
     const char *option;
@@ -263,27 +257,23 @@ image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *n
     return ret;
 }
 
-static void
-image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
+static void image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
     g_object_unref(priv->pixbuf);
     g_free(priv);
 }
 
-static void
-set_drawing_color(cairo_t *cairo, struct color c) {
+static void set_drawing_color(cairo_t *cairo, struct color c) {
     double col_max = 1<<COLOR_BITDEPTH;
     cairo_set_source_rgba(cairo, c.r/col_max, c.g/col_max, c.b/col_max, c.a/col_max);
 }
 
-static void
-set_stroke_params_from_gc(cairo_t *cairo, struct graphics_gc_priv *gc) {
+static void set_stroke_params_from_gc(cairo_t *cairo, struct graphics_gc_priv *gc) {
     set_drawing_color(cairo, gc->c);
     cairo_set_dash(cairo, gc->dashes, gc->ndashes, gc->offset);
     cairo_set_line_width(cairo, gc->linewidth);
 }
 
-static void
-draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     int i;
     if (!count)
         return;
@@ -295,8 +285,7 @@ draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *
     cairo_stroke(gr->cairo);
 }
 
-static void
-draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     int i;
     set_drawing_color(gr->cairo, gc->c);
     cairo_move_to(gr->cairo, p[0].x, p[0].y);
@@ -306,8 +295,7 @@ draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point
     cairo_fill(gr->cairo);
 }
 
-static void
-draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     cairo_save(gr->cairo);
     // Use OPERATOR_SOURCE to overwrite old contents even when drawing with transparency.
     // Necessary for OSD drawing.
@@ -318,16 +306,15 @@ draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct poi
     cairo_restore(gr->cairo);
 }
 
-static void
-draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
+static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
     cairo_arc (gr->cairo,  p->x, p->y, r/2, 0.0, 2*M_PI);
     set_stroke_params_from_gc(gr->cairo, gc);
     cairo_stroke(gr->cairo);
 }
 
-static void
-draw_rgb_image_buffer(cairo_t *cairo, int buffer_width, int buffer_height, int draw_pos_x, int draw_pos_y, int stride,
-                      unsigned char *buffer) {
+static void draw_rgb_image_buffer(cairo_t *cairo, int buffer_width, int buffer_height, int draw_pos_x, int draw_pos_y,
+                                  int stride,
+                                  unsigned char *buffer) {
     cairo_surface_t *buffer_surface = cairo_image_surface_create_for_data(
                                           buffer, CAIRO_FORMAT_ARGB32, buffer_width, buffer_height, stride);
     cairo_set_source_surface(cairo, buffer_surface, draw_pos_x, draw_pos_y);
@@ -335,9 +322,8 @@ draw_rgb_image_buffer(cairo_t *cairo, int buffer_width, int buffer_height, int d
     cairo_surface_destroy(buffer_surface);
 }
 
-static void
-display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                  struct graphics_gc_priv *bg, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                              struct graphics_gc_priv *bg, struct point *p) {
     int i,x,y,stride;
     struct font_freetype_glyph *g, **gp;
     struct color transparent= {0x0,0x0,0x0,0x0};
@@ -378,9 +364,8 @@ display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, str
     }
 }
 
-static void
-draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-          struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
+                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     struct font_freetype_text *t;
 
     if (! font) {
@@ -405,16 +390,16 @@ draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics
     gr->freetype_methods.text_destroy(t);
 }
 
-static void
-draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
+                       struct graphics_image_priv *img) {
     gdk_cairo_set_source_pixbuf(gr->cairo, img->pixbuf, p->x, p->y);
     cairo_paint(gr->cairo);
 }
 
 #ifdef HAVE_IMLIB2
-static unsigned char*
-create_buffer_with_stride_if_required(unsigned char *input_buffer, int w, int h, size_t bytes_per_pixel,
-                                      size_t output_stride) {
+static unsigned char* create_buffer_with_stride_if_required(unsigned char *input_buffer, int w, int h,
+        size_t bytes_per_pixel,
+        size_t output_stride) {
     int line;
     size_t input_offset, output_offset;
     unsigned char *out_buf;
@@ -432,9 +417,8 @@ create_buffer_with_stride_if_required(unsigned char *input_buffer, int w, int h,
     return out_buf;
 }
 
-static void
-draw_image_warp(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
-                struct graphics_image_priv *img) {
+static void draw_image_warp(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
+                            struct graphics_image_priv *img) {
     int w,h;
     DATA32 *intermediate_buffer;
     unsigned char* intermediate_buffer_aligned;
@@ -512,8 +496,7 @@ draw_image_warp(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct po
 }
 #endif
 
-static void
-overlay_rect(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRectangle *r) {
+static void overlay_rect(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRectangle *r) {
     r->x=overlay->p.x;
     r->y=overlay->p.y;
     r->width=overlay->width;
@@ -530,8 +513,8 @@ overlay_rect(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRec
         r->height += parent->height;
 }
 
-static void
-overlay_draw(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRectangle *re, cairo_t *cairo) {
+static void overlay_draw(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRectangle *re,
+                         cairo_t *cairo) {
     GdkRectangle or, ir;
     if (parent->overlay_disabled || overlay->overlay_disabled || overlay->overlay_autodisabled)
         return;
@@ -545,8 +528,7 @@ overlay_draw(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRec
     cairo_paint(cairo);
 }
 
-static void
-draw_drag(struct graphics_priv *gr, struct point *p) {
+static void draw_drag(struct graphics_priv *gr, struct point *p) {
     if (p)
         gr->p=*p;
     else {
@@ -556,13 +538,11 @@ draw_drag(struct graphics_priv *gr, struct point *p) {
 }
 
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     gr->background_gc=gc;
 }
 
-static void
-draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     if (mode == draw_mode_end) {
         // Just invalidate the whole window. We could only the invalidate the area of
         // graphics_priv, but that is probably not significantly faster.
@@ -572,8 +552,7 @@ draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
 
 /* Events */
 
-static gint
-configure(GtkWidget * widget, GdkEventConfigure * event, gpointer user_data) {
+static gint configure(GtkWidget * widget, GdkEventConfigure * event, gpointer user_data) {
     struct graphics_priv *gra=user_data;
     if (! gra->visible)
         return TRUE;
@@ -592,8 +571,7 @@ configure(GtkWidget * widget, GdkEventConfigure * event, gpointer user_data) {
     return TRUE;
 }
 
-static gint
-expose(GtkWidget * widget, GdkEventExpose * event, gpointer user_data) {
+static gint expose(GtkWidget * widget, GdkEventExpose * event, gpointer user_data) {
     struct graphics_priv *gra=user_data;
     struct graphics_gc_priv *background_gc=gra->background_gc;
     struct graphics_priv *overlay;
@@ -620,15 +598,13 @@ expose(GtkWidget * widget, GdkEventExpose * event, gpointer user_data) {
     return FALSE;
 }
 
-static int
-tv_delta(struct timeval *old, struct timeval *new) {
+static int tv_delta(struct timeval *old, struct timeval *new) {
     if (new->tv_sec-old->tv_sec >= INT_MAX/1000)
         return INT_MAX;
     return (new->tv_sec-old->tv_sec)*1000+(new->tv_usec-old->tv_usec)/1000;
 }
 
-static gint
-button_press(GtkWidget * widget, GdkEventButton * event, gpointer user_data) {
+static gint button_press(GtkWidget * widget, GdkEventButton * event, gpointer user_data) {
     struct graphics_priv *this=user_data;
     struct point p;
     struct timeval tv;
@@ -649,8 +625,7 @@ button_press(GtkWidget * widget, GdkEventButton * event, gpointer user_data) {
     return FALSE;
 }
 
-static gint
-button_release(GtkWidget * widget, GdkEventButton * event, gpointer user_data) {
+static gint button_release(GtkWidget * widget, GdkEventButton * event, gpointer user_data) {
     struct graphics_priv *this=user_data;
     struct point p;
     struct timeval tv;
@@ -673,8 +648,7 @@ button_release(GtkWidget * widget, GdkEventButton * event, gpointer user_data) {
 
 
 
-static gint
-scroll(GtkWidget * widget, GdkEventScroll * event, gpointer user_data) {
+static gint scroll(GtkWidget * widget, GdkEventScroll * event, gpointer user_data) {
     struct graphics_priv *this=user_data;
     struct point p;
     int button;
@@ -699,8 +673,7 @@ scroll(GtkWidget * widget, GdkEventScroll * event, gpointer user_data) {
     return FALSE;
 }
 
-static gint
-motion_notify(GtkWidget * widget, GdkEventMotion * event, gpointer user_data) {
+static gint motion_notify(GtkWidget * widget, GdkEventMotion * event, gpointer user_data) {
     struct graphics_priv *this=user_data;
     struct point p;
 
@@ -717,8 +690,7 @@ motion_notify(GtkWidget * widget, GdkEventMotion * event, gpointer user_data) {
  * * @param user_data Pointer to private data structure
  * * @returns TRUE
  * */
-static gint
-delete(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
+static gint delete(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
     struct graphics_priv *this=user_data;
     dbg(lvl_debug,"enter this->win=%p",this->win);
     if (this->delay & 2) {
@@ -730,8 +702,7 @@ delete(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
     return TRUE;
 }
 
-static gint
-keypress(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
+static gint keypress(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
     struct graphics_priv *this=user_data;
     int len,ucode;
     char key[8];
@@ -810,8 +781,7 @@ keypress(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
 
 static struct graphics_priv *graphics_gtk_drawing_area_new_helper(struct graphics_methods *meth);
 
-static void
-overlay_disable(struct graphics_priv *gr, int disabled) {
+static void overlay_disable(struct graphics_priv *gr, int disabled) {
     if (!gr->overlay_disabled != !disabled) {
         gr->overlay_disabled=disabled;
         if (gr->parent) {
@@ -822,8 +792,7 @@ overlay_disable(struct graphics_priv *gr, int disabled) {
     }
 }
 
-static void
-overlay_resize(struct graphics_priv *this, struct point *p, int w, int h, int wraparound) {
+static void overlay_resize(struct graphics_priv *this, struct point *p, int w, int h, int wraparound) {
     //do not dereference parent for non overlay osds
     if(!this->parent) {
         return;
@@ -873,8 +842,7 @@ overlay_resize(struct graphics_priv *this, struct point *p, int w, int h, int wr
     }
 }
 
-static void
-get_data_window(struct graphics_priv *this, unsigned int xid) {
+static void get_data_window(struct graphics_priv *this, unsigned int xid) {
     if (!xid)
         this->win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     else
@@ -898,8 +866,7 @@ get_data_window(struct graphics_priv *this, unsigned int xid) {
     g_signal_connect(G_OBJECT(this->win), "delete_event", G_CALLBACK(delete), this);
 }
 
-static int
-set_attr(struct graphics_priv *gr, struct attr *attr) {
+static int set_attr(struct graphics_priv *gr, struct attr *attr) {
     dbg(lvl_debug,"enter");
     switch (attr->type) {
     case attr_windowid:
@@ -910,8 +877,8 @@ set_attr(struct graphics_priv *gr, struct attr *attr) {
     }
 }
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h, int wraparound) {
     int w2,h2;
     struct graphics_priv *this=graphics_gtk_drawing_area_new_helper(meth);
     this->widget=gr->widget;
@@ -954,8 +921,7 @@ static int gtk_argc;
 static char **gtk_argv= {NULL};
 
 
-static int
-graphics_gtk_drawing_area_fullscreen(struct window *w, int on) {
+static int graphics_gtk_drawing_area_fullscreen(struct window *w, int on) {
     struct graphics_priv *gr=w->priv;
     if (on)
         gtk_window_fullscreen(GTK_WINDOW(gr->win));
@@ -964,8 +930,7 @@ graphics_gtk_drawing_area_fullscreen(struct window *w, int on) {
     return 1;
 }
 
-static void
-graphics_gtk_drawing_area_disable_suspend(struct window *w) {
+static void graphics_gtk_drawing_area_disable_suspend(struct window *w) {
     struct graphics_priv *gr=w->priv;
 
 #ifndef _WIN32
@@ -977,8 +942,7 @@ graphics_gtk_drawing_area_disable_suspend(struct window *w) {
 }
 
 
-static void *
-get_data(struct graphics_priv *this, char const *type) {
+static void *get_data(struct graphics_priv *this, char const *type) {
     FILE *f;
     if (!strcmp(type,"gtk_widget"))
         return this->widget;
@@ -1043,8 +1007,7 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *
-graphics_gtk_drawing_area_new_helper(struct graphics_methods *meth) {
+static struct graphics_priv *graphics_gtk_drawing_area_new_helper(struct graphics_methods *meth) {
     struct font_priv * (*font_freetype_new)(void *meth);
     font_freetype_new=plugin_get_category_font("freetype");
     if (!font_freetype_new)
@@ -1059,9 +1022,9 @@ graphics_gtk_drawing_area_new_helper(struct graphics_methods *meth) {
     return this;
 }
 
-static struct graphics_priv *
-graphics_gtk_drawing_area_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
-                              struct callback_list *cbl) {
+static struct graphics_priv *graphics_gtk_drawing_area_new(struct navit *nav, struct graphics_methods *meth,
+        struct attr **attrs,
+        struct callback_list *cbl) {
     int i;
     GtkWidget *draw;
     struct attr *attr;
@@ -1109,8 +1072,7 @@ graphics_gtk_drawing_area_new(struct navit *nav, struct graphics_methods *meth, 
     return this;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     gtk_init(&gtk_argc, &gtk_argv);
     gtk_set_locale();
 #ifdef HAVE_API_WIN32

--- a/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
+++ b/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
@@ -181,9 +181,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 }
 
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
-        int *w, int *h, struct point *hot,
-        int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h, struct point *hot, int rotation) {
     GdkPixbuf *pixbuf;
     struct graphics_image_priv *ret;
     const char *option;
@@ -312,9 +310,7 @@ static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, s
     cairo_stroke(gr->cairo);
 }
 
-static void draw_rgb_image_buffer(cairo_t *cairo, int buffer_width, int buffer_height, int draw_pos_x, int draw_pos_y,
-                                  int stride,
-                                  unsigned char *buffer) {
+static void draw_rgb_image_buffer(cairo_t *cairo, int buffer_width, int buffer_height, int draw_pos_x, int draw_pos_y, int stride, unsigned char *buffer) {
     cairo_surface_t *buffer_surface = cairo_image_surface_create_for_data(
                                           buffer, CAIRO_FORMAT_ARGB32, buffer_width, buffer_height, stride);
     cairo_set_source_surface(cairo, buffer_surface, draw_pos_x, draw_pos_y);
@@ -322,8 +318,7 @@ static void draw_rgb_image_buffer(cairo_t *cairo, int buffer_width, int buffer_h
     cairo_surface_destroy(buffer_surface);
 }
 
-static void display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                              struct graphics_gc_priv *bg, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct point *p) {
     int i,x,y,stride;
     struct font_freetype_glyph *g, **gp;
     struct color transparent= {0x0,0x0,0x0,0x0};
@@ -364,8 +359,7 @@ static void display_text_draw(struct font_freetype_text *text, struct graphics_p
     }
 }
 
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     struct font_freetype_text *t;
 
     if (! font) {
@@ -390,16 +384,13 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, str
     gr->freetype_methods.text_destroy(t);
 }
 
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
-                       struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
     gdk_cairo_set_source_pixbuf(gr->cairo, img->pixbuf, p->x, p->y);
     cairo_paint(gr->cairo);
 }
 
 #ifdef HAVE_IMLIB2
-static unsigned char* create_buffer_with_stride_if_required(unsigned char *input_buffer, int w, int h,
-        size_t bytes_per_pixel,
-        size_t output_stride) {
+static unsigned char* create_buffer_with_stride_if_required(unsigned char *input_buffer, int w, int h, size_t bytes_per_pixel, size_t output_stride) {
     int line;
     size_t input_offset, output_offset;
     unsigned char *out_buf;
@@ -417,8 +408,7 @@ static unsigned char* create_buffer_with_stride_if_required(unsigned char *input
     return out_buf;
 }
 
-static void draw_image_warp(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
-                            struct graphics_image_priv *img) {
+static void draw_image_warp(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count, struct graphics_image_priv *img) {
     int w,h;
     DATA32 *intermediate_buffer;
     unsigned char* intermediate_buffer_aligned;
@@ -513,8 +503,7 @@ static void overlay_rect(struct graphics_priv *parent, struct graphics_priv *ove
         r->height += parent->height;
 }
 
-static void overlay_draw(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRectangle *re,
-                         cairo_t *cairo) {
+static void overlay_draw(struct graphics_priv *parent, struct graphics_priv *overlay, GdkRectangle *re, cairo_t *cairo) {
     GdkRectangle or, ir;
     if (parent->overlay_disabled || overlay->overlay_disabled || overlay->overlay_autodisabled)
         return;
@@ -877,8 +866,7 @@ static int set_attr(struct graphics_priv *gr, struct attr *attr) {
     }
 }
 
-static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
     int w2,h2;
     struct graphics_priv *this=graphics_gtk_drawing_area_new_helper(meth);
     this->widget=gr->widget;
@@ -1022,9 +1010,7 @@ static struct graphics_priv *graphics_gtk_drawing_area_new_helper(struct graphic
     return this;
 }
 
-static struct graphics_priv *graphics_gtk_drawing_area_new(struct navit *nav, struct graphics_methods *meth,
-        struct attr **attrs,
-        struct callback_list *cbl) {
+static struct graphics_priv *graphics_gtk_drawing_area_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     int i;
     GtkWidget *draw;
     struct attr *attr;

--- a/navit/graphics/null/graphics_null.c
+++ b/navit/graphics/null/graphics_null.c
@@ -65,8 +65,7 @@ static struct graphics_font_methods font_methods = {
     font_destroy
 };
 
-static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct graphics_font_methods *meth, char *font,
-        int size, int flags) {
+static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct graphics_font_methods *meth, char *font, int size, int flags) {
     *meth=font_methods;
     return &graphics_font_priv;
 }
@@ -99,9 +98,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
     return &graphics_gc_priv;
 }
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path,
-        int *w, int *h, struct point *hot,
-        int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot, int rotation) {
     return &graphics_image_priv;
 }
 
@@ -118,12 +115,10 @@ static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, s
 }
 
 
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
 }
 
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
-                       struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
 }
 
 static void draw_drag(struct graphics_priv *gr, struct point *p) {
@@ -135,12 +130,10 @@ static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc)
 static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
 }
 
-static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound);
+static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound);
 
 static void resize_callback(int w, int h) {
-    callback_list_call_attr_2(callbacks, attr_resize,
-                              GINT_TO_POINTER(1), GINT_TO_POINTER(1));
+    callback_list_call_attr_2(callbacks, attr_resize, GINT_TO_POINTER(1), GINT_TO_POINTER(1));
 }
 
 static int graphics_null_fullscreen(struct window *w, int on) {
@@ -166,8 +159,7 @@ static void *get_data(struct graphics_priv *this, char const *type) {
 static void image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
 }
 
-static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy,
-                          struct point *ret, int estimate) {
+static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy, struct point *ret, int estimate) {
 }
 
 static void overlay_disable(struct graphics_priv *gr, int disable) {
@@ -201,15 +193,13 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
     *meth=graphics_methods;
     return &graphics_priv;
 }
 
 
-static struct graphics_priv *graphics_null_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
-        struct callback_list *cbl) {
+static struct graphics_priv *graphics_null_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct attr *event_loop_system = NULL;
     *meth=graphics_methods;
 

--- a/navit/graphics/null/graphics_null.c
+++ b/navit/graphics/null/graphics_null.c
@@ -54,8 +54,7 @@ static struct graphics_image_priv {
     int dummy;
 } graphics_image_priv;
 
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
 }
 
 static void font_destroy(struct graphics_font_priv *font) {
@@ -72,24 +71,19 @@ static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct grap
     return &graphics_font_priv;
 }
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
 }
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
 }
 
 static struct graphics_gc_methods gc_methods = {
@@ -105,69 +99,58 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
     return &graphics_gc_priv;
 }
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot,
-          int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path,
+        int *w, int *h, struct point *hot,
+        int rotation) {
     return &graphics_image_priv;
 }
 
-static void
-draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
 }
 
-static void
-draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
 }
 
-static void
-draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
 }
 
-static void
-draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
+static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
 }
 
 
-static void
-draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-          struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
+                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
 }
 
-static void
-draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
+                       struct graphics_image_priv *img) {
 }
 
 static void draw_drag(struct graphics_priv *gr, struct point *p) {
 }
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
 }
 
-static void
-draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
 }
 
 static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
         int w, int h, int wraparound);
 
-static void
-resize_callback(int w, int h) {
+static void resize_callback(int w, int h) {
     callback_list_call_attr_2(callbacks, attr_resize,
                               GINT_TO_POINTER(1), GINT_TO_POINTER(1));
 }
 
-static int
-graphics_null_fullscreen(struct window *w, int on) {
+static int graphics_null_fullscreen(struct window *w, int on) {
     return 1;
 }
 
-static void
-graphics_null_disable_suspend(struct window *w) {
+static void graphics_null_disable_suspend(struct window *w) {
 }
 
-static void *
-get_data(struct graphics_priv *this, char const *type) {
+static void *get_data(struct graphics_priv *this, char const *type) {
     if (strcmp(type, "window") == 0) {
         struct window *win;
         win = g_new0(struct window, 1);
@@ -218,15 +201,15 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h, int wraparound) {
     *meth=graphics_methods;
     return &graphics_priv;
 }
 
 
-static struct graphics_priv *
-graphics_null_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_null_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
+        struct callback_list *cbl) {
     struct attr *event_loop_system = NULL;
     *meth=graphics_methods;
 
@@ -245,8 +228,7 @@ graphics_null_new(struct navit *nav, struct graphics_methods *meth, struct attr 
     return &graphics_priv;
 }
 
-static void
-event_null_main_loop_run(void) {
+static void event_null_main_loop_run(void) {
 
     dbg(lvl_debug,"enter");
     for (;;)
@@ -258,43 +240,36 @@ static void event_null_main_loop_quit(void) {
     dbg(lvl_debug,"enter");
 }
 
-static struct event_watch *
-event_null_add_watch(int h, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_null_add_watch(int h, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug,"enter");
     return NULL;
 }
 
-static void
-event_null_remove_watch(struct event_watch *ev) {
+static void event_null_remove_watch(struct event_watch *ev) {
     dbg(lvl_debug,"enter");
 }
 
 
-static struct event_timeout *
-event_null_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_null_add_timeout(int timeout, int multi, struct callback *cb) {
     dbg(lvl_debug,"enter");
     return NULL;
 }
 
-static void
-event_null_remove_timeout(struct event_timeout *to) {
+static void event_null_remove_timeout(struct event_timeout *to) {
     dbg(lvl_debug,"enter");
 }
 
 
-static struct event_idle *
-event_null_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_null_add_idle(int priority, struct callback *cb) {
     dbg(lvl_debug,"enter");
     return NULL;
 }
 
-static void
-event_null_remove_idle(struct event_idle *ev) {
+static void event_null_remove_idle(struct event_idle *ev) {
     dbg(lvl_debug,"enter");
 }
 
-static void
-event_null_call_callback(struct callback_list *cb) {
+static void event_null_call_callback(struct callback_list *cb) {
     dbg(lvl_debug,"enter");
 }
 
@@ -310,15 +285,13 @@ static struct event_methods event_null_methods = {
     event_null_call_callback,
 };
 
-static struct event_priv *
-event_null_new(struct event_methods *meth) {
+static struct event_priv *event_null_new(struct event_methods *meth) {
     *meth=event_null_methods;
     return NULL;
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_graphics("null", graphics_null_new);
     plugin_register_category_event("null", event_null_new);
 }

--- a/navit/graphics/opengl/graphics_opengl.c
+++ b/navit/graphics/opengl/graphics_opengl.c
@@ -142,8 +142,7 @@ struct graphics_priv {
     void *resize_callback_data;
     void (*motion_callback) (void *data, struct point * p);
     void *motion_callback_data;
-    void (*button_callback) (void *data, int press, int button,
-                             struct point * p);
+    void (*button_callback) (void *data, int press, int button, struct point * p);
     void *button_callback_data;
 #ifdef USE_OPENGLES
     GLuint program;
@@ -265,8 +264,7 @@ static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->linewidth = w;
 }
 
-static void gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
-                          unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset, unsigned char *dash_list, int n) {
     int i;
     const int cOpenglMaskBits = 16;
     gc->dash_count = n;
@@ -354,8 +352,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 
 static struct graphics_image_priv image_error;
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth,
-        char *path, int *w, int *h, struct point *hot, int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot, int rotation) {
 #ifdef HAVE_FREEIMAGE
     FIBITMAP *image;
     RGBQUAD aPixel;
@@ -377,25 +374,20 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct gr
         return curr_elem;
     } else {
         if (strlen(path) < 4) {
-            g_hash_table_insert(hImageData, g_strdup(path),
-                                &image_error);
+            g_hash_table_insert(hImageData, g_strdup(path), &image_error);
             return NULL;
         }
         char *ext_str = path + strlen(path) - 3;
         if (strstr(ext_str, "png") || strstr(path, "PNG")) {
             if ((image =
                         FreeImage_Load(FIF_PNG, path, 0)) == NULL) {
-                g_hash_table_insert(hImageData,
-                                    g_strdup(path),
-                                    &image_error);
+                g_hash_table_insert(hImageData, g_strdup(path), &image_error);
                 return NULL;
             }
         } else if (strstr(ext_str, "xpm") || strstr(path, "XPM")) {
             if ((image =
                         FreeImage_Load(FIF_XPM, path, 0)) == NULL) {
-                g_hash_table_insert(hImageData,
-                                    g_strdup(path),
-                                    &image_error);
+                g_hash_table_insert(hImageData, g_strdup(path), &image_error);
                 return NULL;
             }
         } else if (strstr(ext_str, "svg") || strstr(path, "SVG")) {
@@ -403,17 +395,12 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct gr
             snprintf(path_new, strlen(path) - 3, "%s", path);
             strcat(path_new, "_48_48.png");
 
-            if ((image =
-                        FreeImage_Load(FIF_PNG, path_new,
-                                       0)) == NULL) {
-                g_hash_table_insert(hImageData,
-                                    g_strdup(path),
-                                    &image_error);
+            if ((image = FreeImage_Load(FIF_PNG, path_new, 0)) == NULL) {
+                g_hash_table_insert(hImageData, g_strdup(path), &image_error);
                 return NULL;
             }
         } else {
-            g_hash_table_insert(hImageData, g_strdup(path),
-                                &image_error);
+            g_hash_table_insert(hImageData, g_strdup(path), &image_error);
             return NULL;
         }
 
@@ -456,10 +443,7 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct gr
             for (j = 0; j < width; j++) {
                 unsigned char idx;
                 if (FreeImage_GetBPP(image) == 8) {
-                    FreeImage_GetPixelIndex(image, j,
-                                            height -
-                                            i - 1,
-                                            &idx);
+                    FreeImage_GetPixelIndex(image, j, height - i - 1, &idx);
                     data[4 * width * i + 4 * j + 0] =
                         palette[idx].rgbRed;
                     data[4 * width * i + 4 * j + 1] =
@@ -470,12 +454,8 @@ static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct gr
                         255;
                 } else if (FreeImage_GetBPP(image) == 16
                            || FreeImage_GetBPP(image) == 24
-                           || FreeImage_GetBPP(image) ==
-                           32) {
-                    FreeImage_GetPixelColor(image, j,
-                                            height -
-                                            i - 1,
-                                            &aPixel);
+                           || FreeImage_GetBPP(image) == 32) {
+                    FreeImage_GetPixelColor(image, j, height - i - 1, &aPixel);
                     int transparent =
                         (aPixel.rgbRed == 0
                          && aPixel.rgbBlue == 0
@@ -645,8 +625,7 @@ static void get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
     }
 }
 
-static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-                       struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -754,8 +733,7 @@ void APIENTRY tessCombineCB(GLdouble c[3], void *d[4], GLfloat w[4], void **out)
 #endif
 
 
-static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-                         struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -808,8 +786,7 @@ static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
 #endif
 }
 
-static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-                           struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -820,16 +797,13 @@ static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc
     graphics_priv_root->dirty = 1;
 }
 
-static void display_text_draw(struct font_freetype_text *text,
-                              struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                              struct graphics_gc_priv *bg, int color, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, int color, struct point *p) {
     int i, x, y, stride;
     struct font_freetype_glyph *g, **gp;
     unsigned char *shadow, *glyph;
     struct color transparent = { 0x0000, 0x0000, 0x0000, 0x0000 };
     struct color black = {
-        fg->fr * 65535, fg->fg * 65535, fg->fb * 65535,
-        fg->fa * 65535
+        fg->fr * 65535, fg->fg * 65535, fg->fb * 65535, fg->fa * 65535
     };
     struct color white = { 0xffff, 0xffff, 0xffff, 0xffff };
 
@@ -877,10 +851,7 @@ static void display_text_draw(struct font_freetype_text *text,
             stride = (g->w + 2) * 4;
             if (color) {
                 shadow = g_malloc(stride * (g->h + 2));
-                gr->freetype_methods.get_shadow(g, shadow,
-                                                stride,
-                                                &white,
-                                                &transparent);
+                gr->freetype_methods.get_shadow(g, shadow, stride, &white, &transparent);
 #ifdef USE_OPENGLES
                 struct point p;
                 p.x=((x + g->x) >> 6)-1;
@@ -892,10 +863,8 @@ static void display_text_draw(struct font_freetype_text *text,
 #else
                 glPixelZoom(1.0, -1.0);
 #endif
-                glRasterPos2d((x + g->x) >> 6,
-                              (y + g->y) >> 6);
-                glDrawPixels(g->w + 2, g->h + 2, PIXEL_FORMAT,
-                             GL_UNSIGNED_BYTE, shadow);
+                glRasterPos2d((x + g->x) >> 6, (y + g->y) >> 6);
+                glDrawPixels(g->w + 2, g->h + 2, PIXEL_FORMAT, GL_UNSIGNED_BYTE, shadow);
 #endif
                 g_free(shadow);
             }
@@ -916,13 +885,7 @@ static void display_text_draw(struct font_freetype_text *text,
                 if (bg) {
                     glyph =
                         g_malloc(stride * g->h * 4);
-                    gr->freetype_methods.get_glyph(g,
-                                                   glyph,
-                                                   stride
-                                                   * 4,
-                                                   &black,
-                                                   &white,
-                                                   &transparent);
+                    gr->freetype_methods.get_glyph(g, glyph, stride * 4, &black, &white, &transparent);
 #ifdef USE_OPENGLES
                     struct point p;
                     p.x=(x + g->x) >> 6;
@@ -934,21 +897,14 @@ static void display_text_draw(struct font_freetype_text *text,
 #else
                     glPixelZoom(1.0, -1.0);
 #endif
-                    glRasterPos2d((x + g->x) >> 6,
-                                  (y + g->y) >> 6);
-                    glDrawPixels(g->w, g->h, PIXEL_FORMAT,
-                                 GL_UNSIGNED_BYTE,
-                                 glyph);
+                    glRasterPos2d((x + g->x) >> 6, (y + g->y) >> 6);
+                    glDrawPixels(g->w, g->h, PIXEL_FORMAT, GL_UNSIGNED_BYTE, glyph);
 #endif
                     g_free(glyph);
                 }
                 stride *= 4;
                 glyph = g_malloc(stride * g->h);
-                gr->freetype_methods.get_glyph(g, glyph,
-                                               stride,
-                                               &black,
-                                               &white,
-                                               &transparent);
+                gr->freetype_methods.get_glyph(g, glyph, stride, &black, &white, &transparent);
 #ifdef USE_OPENGLES
                 struct point p;
                 p.x=(x + g->x) >> 6;
@@ -960,10 +916,8 @@ static void display_text_draw(struct font_freetype_text *text,
 #else
                 glPixelZoom(1.0, -1.0);
 #endif
-                glRasterPos2d((x + g->x) >> 6,
-                              (y + g->y) >> 6);
-                glDrawPixels(g->w, g->h, PIXEL_FORMAT,
-                             GL_UNSIGNED_BYTE, glyph);
+                glRasterPos2d((x + g->x) >> 6, (y + g->y) >> 6);
+                glDrawPixels(g->w, g->h, PIXEL_FORMAT, GL_UNSIGNED_BYTE, glyph);
 #endif
                 g_free(glyph);
             }
@@ -973,9 +927,7 @@ static void display_text_draw(struct font_freetype_text *text,
     }
 }
 
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                      struct graphics_gc_priv *bg, struct graphics_font_priv *font,
-                      char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -992,9 +944,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
 
     graphics_priv_root->dirty = 1;
 
-    t = gr->freetype_methods.text_new(text,
-                                      (struct font_freetype_font *)
-                                      font, dx, dy);
+    t = gr->freetype_methods.text_new(text, (struct font_freetype_font *) font, dx, dy);
 
     struct point p_eff;
     p_eff.x = p->x;
@@ -1005,8 +955,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
 }
 
 
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                       struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
 #ifdef USE_OPENGLES
     draw_image_es(gr, p, img->w, img->h, img->data);
 #else
@@ -1070,9 +1019,7 @@ static void handle_mouse_queue(void) {
                 mouse_queue[mouse_event_queue_begin_idx %
                                                         mouse_event_queue_size].y;
             graphics_priv_root->force_redraw = 1;
-            callback_list_call_attr_3(graphics_priv_root->cbl,
-                                      attr_button, (void *) 0,
-                                      1, (void *) &p);
+            callback_list_call_attr_3(graphics_priv_root->cbl, attr_button, (void *) 0, 1, (void *) &p);
         } else if (mouse_queue[mouse_event_queue_begin_idx].
                    button == GLUT_LEFT_BUTTON
                    && mouse_queue[mouse_event_queue_begin_idx].
@@ -1085,9 +1032,7 @@ static void handle_mouse_queue(void) {
                 mouse_queue[mouse_event_queue_begin_idx %
                                                         mouse_event_queue_size].y;
             graphics_priv_root->force_redraw = 1;
-            callback_list_call_attr_3(graphics_priv_root->cbl,
-                                      attr_button, (void *) 1,
-                                      1, (void *) &p);
+            callback_list_call_attr_3(graphics_priv_root->cbl, attr_button, (void *) 1, 1, (void *) &p);
         }
         ++mouse_event_queue_begin_idx;
     }
@@ -1198,8 +1143,7 @@ static GLuint load_shader(const char *shader_source, GLenum type) {
 static void *get_data(struct graphics_priv *this, const char *type) {
     /*TODO initialize gtkglext context when type=="gtk_widget" */
     if (!strcmp(type, "gtk_widget")) {
-        fprintf(stderr,
-                "Currently GTK gui is not yet supported with opengl graphics driver\n");
+        fprintf(stderr, "Currently GTK gui is not yet supported with opengl graphics driver\n");
         return NULL;
     }
     if (strcmp(type, "window") == 0) {
@@ -1215,8 +1159,7 @@ static void *get_data(struct graphics_priv *this, const char *type) {
         this->platform=graphics_opengl_egl_new(this->window_system_methods->get_display(this->window_system),
                                                this->window_system_methods->get_window(this->window_system),
                                                &this->platform_methods);
-        this->window_system_methods->set_callbacks(this->window_system, this, resize_callback_do, click_notify_do,
-                motion_notify_do, NULL);
+        this->window_system_methods->set_callbacks(this->window_system, this, resize_callback_do, click_notify_do, motion_notify_do, NULL);
         resize_callback(this->width,this->height);
 #if 0
         glClearColor ( 0.4, 0.4, 0.4, 1);
@@ -1296,8 +1239,7 @@ static void overlay_disable(struct graphics_priv *gr, int disable) {
     draw_mode(gr, draw_mode_end);
 }
 
-static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h,
-                           int wraparound) {
+static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound) {
     int changed = 0;
     int w2, h2;
 
@@ -1333,9 +1275,7 @@ static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int
             gr->overlay_autodisabled = 0;
         }
 
-        callback_list_call_attr_2(gr->cbl, attr_resize,
-                                  GINT_TO_POINTER(gr->width),
-                                  GINT_TO_POINTER(gr->height));
+        callback_list_call_attr_2(gr->cbl, attr_resize, GINT_TO_POINTER(gr->width), GINT_TO_POINTER(gr->height));
     }
 }
 
@@ -1446,8 +1386,7 @@ static void motion_notify_do(struct graphics_priv *priv, int x, int y) {
     p.x = x;
 #endif
     p.y = y;
-    callback_list_call_attr_1(priv->cbl, attr_motion,
-                              (void *) &p);
+    callback_list_call_attr_1(priv->cbl, attr_motion, (void *) &p);
     return;
 }
 
@@ -1459,12 +1398,7 @@ static void motion_notify(int x, int y) {
 static gboolean graphics_opengl_idle(void *data) {
     static int opengl_init_ok = 0;
     if (!opengl_init_ok) {
-        callback_list_call_attr_2(graphics_priv_root->cbl,
-                                  attr_resize,
-                                  GINT_TO_POINTER
-                                  (graphics_priv_root->width),
-                                  GINT_TO_POINTER
-                                  (graphics_priv_root->height));
+        callback_list_call_attr_2(graphics_priv_root->cbl, attr_resize, GINT_TO_POINTER (graphics_priv_root->width), GINT_TO_POINTER (graphics_priv_root->height));
         opengl_init_ok = 1;
     } else {
 
@@ -1492,8 +1426,7 @@ static void ProcessNormalKeys(unsigned char key_in, int x, int y) {
     keybuf[0] = key;
     keybuf[1] = '\0';
     graphics_priv_root->force_redraw = 1;
-    callback_list_call_attr_1(graphics_priv_root->cbl, attr_keypress,
-                              (void *) keybuf);
+    callback_list_call_attr_1(graphics_priv_root->cbl, attr_keypress, (void *) keybuf);
 }
 
 static void ProcessSpecialKeys(int key_in, int x, int y) {
@@ -1526,8 +1459,7 @@ static void ProcessSpecialKeys(int key_in, int x, int y) {
     graphics_priv_root->force_redraw = 1;
     keybuf[0] = key;
     keybuf[1] = '\0';
-    callback_list_call_attr_1(graphics_priv_root->cbl, attr_keypress,
-                              (void *) keybuf);
+    callback_list_call_attr_1(graphics_priv_root->cbl, attr_keypress, (void *) keybuf);
 }
 
 static void resize_callback_do(struct graphics_priv *priv, int w, int h) {
@@ -1544,8 +1476,7 @@ static void resize_callback_do(struct graphics_priv *priv, int w, int h) {
     priv->width = w;
     priv->height = h;
 
-    callback_list_call_attr_2(priv->cbl, attr_resize,
-                              GINT_TO_POINTER(w), GINT_TO_POINTER(h));
+    callback_list_call_attr_2(priv->cbl, attr_resize, GINT_TO_POINTER(w), GINT_TO_POINTER(h));
 }
 
 static void resize_callback(int w, int h) {
@@ -1555,18 +1486,15 @@ static void resize_callback(int w, int h) {
 static void display(void) {
     graphics_priv_root->force_redraw = 1;
     redraw_screen(graphics_priv_root);
-    resize_callback(graphics_priv_root->width,
-                    graphics_priv_root->height);
+    resize_callback(graphics_priv_root->width, graphics_priv_root->height);
 }
 
 static void glut_close(void) {
-    callback_list_call_attr_0(graphics_priv_root->cbl,
-                              attr_window_closed);
+    callback_list_call_attr_0(graphics_priv_root->cbl, attr_window_closed);
 }
 
 
-static struct graphics_priv *graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
-        struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_opengl_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct attr *attr;
 
     if (!event_request_system("glib", "graphics_opengl_new"))
@@ -1643,8 +1571,7 @@ static void event_opengl_main_loop_quit(void) {
     dbg(lvl_debug, "enter");
 }
 
-static struct event_watch *event_opengl_add_watch(int fd, enum event_watch_cond cond,
-        struct callback *cb) {
+static struct event_watch *event_opengl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug, "enter");
     return NULL;
 }

--- a/navit/graphics/opengl/graphics_opengl.c
+++ b/navit/graphics/opengl/graphics_opengl.c
@@ -248,8 +248,7 @@ const char fragment_src [] =
 ";
 #endif
 
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
     /*FIXME graphics_destroy is never called */
     /*TODO add destroy code for image cache(delete entries in hImageData) */
     gr->freetype_methods.destroy();
@@ -257,20 +256,17 @@ graphics_destroy(struct graphics_priv *gr) {
     gr = NULL;
 }
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
     g_free(gc);
     gc = NULL;
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     gc->linewidth = w;
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
-              unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
+                          unsigned char *dash_list, int n) {
     int i;
     const int cOpenglMaskBits = 16;
     gc->dash_count = n;
@@ -325,16 +321,14 @@ gc_set_dashes(struct graphics_gc_priv *gc, int width, int offset,
 }
 
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     gc->fr = c->r / 65535.0;
     gc->fg = c->g / 65535.0;
     gc->fb = c->b / 65535.0;
     gc->fa = c->a / 65535.0;
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
     gc->br = c->r / 65535.0;
     gc->bg = c->g / 65535.0;
     gc->bb = c->b / 65535.0;
@@ -349,8 +343,7 @@ static struct graphics_gc_methods gc_methods = {
     gc_set_background
 };
 
-static struct graphics_gc_priv *
-gc_new(struct graphics_priv *gr, struct graphics_gc_methods *meth) {
+static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics_gc_methods *meth) {
     struct graphics_gc_priv *gc = g_new0(struct graphics_gc_priv, 1);
 
     *meth = gc_methods;
@@ -361,9 +354,8 @@ gc_new(struct graphics_priv *gr, struct graphics_gc_methods *meth) {
 
 static struct graphics_image_priv image_error;
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gr, struct graphics_image_methods *meth,
-          char *path, int *w, int *h, struct point *hot, int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth,
+        char *path, int *w, int *h, struct point *hot, int rotation) {
 #ifdef HAVE_FREEIMAGE
     FIBITMAP *image;
     RGBQUAD aPixel;
@@ -526,8 +518,7 @@ image_new(struct graphics_priv *gr, struct graphics_image_methods *meth,
 }
 
 
-static void
-set_color(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void set_color(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
 #ifdef USE_OPENGLES2
     GLfloat col[4];
     col[0]=gc->fr;
@@ -540,8 +531,7 @@ set_color(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
 #endif
 }
 
-static void
-draw_array(struct graphics_priv *gr, struct point *p, int count, GLenum mode) {
+static void draw_array(struct graphics_priv *gr, struct point *p, int count, GLenum mode) {
     int i;
 #ifdef USE_OPENGLES
     GLf x[count*2];
@@ -569,8 +559,7 @@ draw_array(struct graphics_priv *gr, struct point *p, int count, GLenum mode) {
 #endif
 }
 
-static void
-draw_rectangle_do(struct graphics_priv *gr, struct point *p, int w, int h) {
+static void draw_rectangle_do(struct graphics_priv *gr, struct point *p, int w, int h) {
     struct point pa[4];
     pa[0]=pa[1]=pa[2]=pa[3]=*p;
     pa[0].x+=w;
@@ -589,8 +578,7 @@ static int next_power2(int x) {
     return r;
 }
 
-static void
-draw_image_es(struct graphics_priv *gr, struct point *p, int w, int h, unsigned char *data) {
+static void draw_image_es(struct graphics_priv *gr, struct point *p, int w, int h, unsigned char *data) {
     GLf x[8];
 
     memset(x, 0, sizeof(x));
@@ -640,8 +628,7 @@ draw_image_es(struct graphics_priv *gr, struct point *p, int w, int h, unsigned 
 
 #endif
 
-static void
-get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
+static void get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
     if (gr->parent == NULL) {
         point_out->x = 0;
         point_out->y = 0;
@@ -658,9 +645,8 @@ get_overlay_pos(struct graphics_priv *gr, struct point *point_out) {
     }
 }
 
-static void
-draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-           struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc,
+                       struct point *p, int count) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -691,8 +677,7 @@ static int tess_count;
 static struct point tess_array[512];
 static GLenum tess_type;
 
-const char *
-getPrimitiveType(GLenum type) {
+const char *getPrimitiveType(GLenum type) {
     char *ret = "";
 
     switch (type) {
@@ -730,8 +715,7 @@ getPrimitiveType(GLenum type) {
     return ret;
 }
 
-void APIENTRY
-tessBeginCB(GLenum which) {
+void APIENTRY tessBeginCB(GLenum which) {
     dbg(lvl_debug, "glBegin( %s );", getPrimitiveType(which));
     tess_type=which;
     tess_count=0;
@@ -739,16 +723,14 @@ tessBeginCB(GLenum which) {
 
 
 
-void APIENTRY
-tessEndCB(void) {
+void APIENTRY tessEndCB(void) {
     dbg(lvl_debug, "glEnd();");
     draw_array(graphics_priv_root, tess_array, tess_count, tess_type);
 }
 
 
 
-void APIENTRY
-tessVertexCB(const GLvoid * data) {
+void APIENTRY tessVertexCB(const GLvoid * data) {
     // cast back to double type
     const GLdouble *ptr = (const GLdouble *) data;
     dbg(lvl_debug, "  glVertex3d();");
@@ -761,8 +743,7 @@ tessVertexCB(const GLvoid * data) {
         dbg(lvl_error,"overflow");
 }
 
-void APIENTRY
-tessCombineCB(GLdouble c[3], void *d[4], GLfloat w[4], void **out) {
+void APIENTRY tessCombineCB(GLdouble c[3], void *d[4], GLfloat w[4], void **out) {
     GLdouble *nv = (GLdouble *) malloc(sizeof(GLdouble) * 3);
     nv[0] = c[0];
     nv[1] = c[1];
@@ -773,9 +754,8 @@ tessCombineCB(GLdouble c[3], void *d[4], GLfloat w[4], void **out) {
 #endif
 
 
-static void
-draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-             struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
+                         struct point *p, int count) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -828,9 +808,8 @@ draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc,
 #endif
 }
 
-static void
-draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
-               struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
+                           struct point *p, int w, int h) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -841,10 +820,9 @@ draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc,
     graphics_priv_root->dirty = 1;
 }
 
-static void
-display_text_draw(struct font_freetype_text *text,
-                  struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                  struct graphics_gc_priv *bg, int color, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text,
+                              struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                              struct graphics_gc_priv *bg, int color, struct point *p) {
     int i, x, y, stride;
     struct font_freetype_glyph *g, **gp;
     unsigned char *shadow, *glyph;
@@ -995,10 +973,9 @@ display_text_draw(struct font_freetype_text *text,
     }
 }
 
-static void
-draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-          struct graphics_gc_priv *bg, struct graphics_font_priv *font,
-          char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                      struct graphics_gc_priv *bg, struct graphics_font_priv *font,
+                      char *text, struct point *p, int dx, int dy) {
     if ((gr->parent && !gr->parent->overlay_enabled)
             || (gr->parent && gr->parent->overlay_enabled
                 && !gr->overlay_enabled)) {
@@ -1028,9 +1005,8 @@ draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
 }
 
 
-static void
-draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-           struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                       struct point *p, struct graphics_image_priv *img) {
 #ifdef USE_OPENGLES
     draw_image_es(gr, p, img->w, img->h, img->data);
 #else
@@ -1059,8 +1035,7 @@ draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg,
 
 }
 
-static void
-draw_drag(struct graphics_priv *gr, struct point *p) {
+static void draw_drag(struct graphics_priv *gr, struct point *p) {
 
     if (p) {
         gr->p.x = p->x;
@@ -1068,13 +1043,11 @@ draw_drag(struct graphics_priv *gr, struct point *p) {
     }
 }
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     gr->background_gc = gc;
 }
 
-static void
-handle_mouse_queue(void) {
+static void handle_mouse_queue(void) {
 #ifdef USE_OPENGLES
 #else
     static int locked = 0;
@@ -1124,8 +1097,7 @@ handle_mouse_queue(void) {
 
 
 /*draws root graphics and its overlays*/
-static int
-redraw_screen(struct graphics_priv *gr) {
+static int redraw_screen(struct graphics_priv *gr) {
 #ifdef USE_OPENGLES
 #else
     graphics_priv_root->dirty = 0;
@@ -1154,8 +1126,7 @@ redraw_screen(struct graphics_priv *gr) {
 
 #ifndef USE_OPENGLES
 /*filters call to redraw in overlay enabled(map) mode*/
-static gboolean
-redraw_filter(gpointer data) {
+static gboolean redraw_filter(gpointer data) {
     struct graphics_priv *gr = (struct graphics_priv*) data;
     if (gr->overlay_enabled && gr->dirty) {
         redraw_screen(gr);
@@ -1166,8 +1137,7 @@ redraw_filter(gpointer data) {
 
 
 
-static void
-draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     if (gr->parent) {	//overlay
 #ifdef USE_OPENGLES
 #else
@@ -1207,18 +1177,15 @@ static struct graphics_priv *overlay_new(struct graphics_priv *gr,
         struct point *p, int w, int h,
         int wraparound);
 
-static int
-graphics_opengl_fullscreen(struct window *w, int on) {
+static int graphics_opengl_fullscreen(struct window *w, int on) {
     return 1;
 }
 
-static void
-graphics_opengl_disable_suspend(struct window *w) {
+static void graphics_opengl_disable_suspend(struct window *w) {
 }
 
 #ifdef USE_OPENGLES2
-static GLuint
-load_shader(const char *shader_source, GLenum type) {
+static GLuint load_shader(const char *shader_source, GLenum type) {
     GLuint shader = glCreateShader(type);
 
     glShaderSource(shader, 1, &shader_source, NULL);
@@ -1228,8 +1195,7 @@ load_shader(const char *shader_source, GLenum type) {
 }
 #endif
 
-static void *
-get_data(struct graphics_priv *this, const char *type) {
+static void *get_data(struct graphics_priv *this, const char *type) {
     /*TODO initialize gtkglext context when type=="gtk_widget" */
     if (!strcmp(type, "gtk_widget")) {
         fprintf(stderr,
@@ -1313,8 +1279,7 @@ get_data(struct graphics_priv *this, const char *type) {
 
 }
 
-static void
-image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
+static void image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
 //TODO free image data in hashtable when graphics is destroyed
 //currently graphics destroy is not called !!!
     /*
@@ -1325,16 +1290,14 @@ image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
     */
 }
 
-static void
-overlay_disable(struct graphics_priv *gr, int disable) {
+static void overlay_disable(struct graphics_priv *gr, int disable) {
     gr->overlay_enabled = !disable;
     gr->force_redraw = 1;
     draw_mode(gr, draw_mode_end);
 }
 
-static void
-overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h,
-               int wraparound) {
+static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h,
+                           int wraparound) {
     int changed = 0;
     int w2, h2;
 
@@ -1401,8 +1364,7 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *
-graphics_opengl_new_helper(struct graphics_methods *meth) {
+static struct graphics_priv *graphics_opengl_new_helper(struct graphics_methods *meth) {
     struct font_priv *(*font_freetype_new) (void *meth);
     font_freetype_new = plugin_get_category_font("freetype");
 
@@ -1425,9 +1387,8 @@ graphics_opengl_new_helper(struct graphics_methods *meth) {
     return this;
 }
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth,
-            struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth,
+        struct point *p, int w, int h, int wraparound) {
     struct graphics_priv *this = graphics_opengl_new_helper(meth);
     this->p = *p;
     this->width = w;
@@ -1453,16 +1414,14 @@ overlay_new(struct graphics_priv *gr, struct graphics_methods *meth,
 
 
 #ifdef USE_OPENGLES
-static void
-click_notify_do(struct graphics_priv *priv, int button, int state, int x, int y) {
+static void click_notify_do(struct graphics_priv *priv, int button, int state, int x, int y) {
     struct point p= {x,y};
     dbg(lvl_debug,"enter state %d button %d",state,button);
     callback_list_call_attr_3(priv->cbl, attr_button, (void *) state, (void *)button, (void *) &p);
 }
 #endif
 
-static void
-click_notify(int button, int state, int x, int y) {
+static void click_notify(int button, int state, int x, int y) {
     mouse_queue[mouse_event_queue_end_idx %
                                           mouse_event_queue_size].button = button;
     mouse_queue[mouse_event_queue_end_idx %
@@ -1479,8 +1438,7 @@ click_notify(int button, int state, int x, int y) {
     ++mouse_event_queue_end_idx;
 }
 
-static void
-motion_notify_do(struct graphics_priv *priv, int x, int y) {
+static void motion_notify_do(struct graphics_priv *priv, int x, int y) {
     struct point p;
 #ifdef MIRRORED_VIEW
     p.x = priv->width - x;
@@ -1493,14 +1451,12 @@ motion_notify_do(struct graphics_priv *priv, int x, int y) {
     return;
 }
 
-static void
-motion_notify(int x, int y) {
+static void motion_notify(int x, int y) {
     motion_notify_do(graphics_priv_root, x, y);
 }
 
 #ifndef USE_OPENGLES
-static gboolean
-graphics_opengl_idle(void *data) {
+static gboolean graphics_opengl_idle(void *data) {
     static int opengl_init_ok = 0;
     if (!opengl_init_ok) {
         callback_list_call_attr_2(graphics_priv_root->cbl,
@@ -1521,8 +1477,7 @@ graphics_opengl_idle(void *data) {
 }
 #endif
 
-static void
-ProcessNormalKeys(unsigned char key_in, int x, int y) {
+static void ProcessNormalKeys(unsigned char key_in, int x, int y) {
     int key = 0;
     char keybuf[2];
 
@@ -1541,8 +1496,7 @@ ProcessNormalKeys(unsigned char key_in, int x, int y) {
                               (void *) keybuf);
 }
 
-static void
-ProcessSpecialKeys(int key_in, int x, int y) {
+static void ProcessSpecialKeys(int key_in, int x, int y) {
     int key = 0;
     char keybuf[2];
 
@@ -1576,8 +1530,7 @@ ProcessSpecialKeys(int key_in, int x, int y) {
                               (void *) keybuf);
 }
 
-static void
-resize_callback_do(struct graphics_priv *priv, int w, int h) {
+static void resize_callback_do(struct graphics_priv *priv, int w, int h) {
     glViewport(0, 0, w, h);
 #ifndef USE_OPENGLES2
     glMatrixMode(GL_PROJECTION);
@@ -1595,29 +1548,25 @@ resize_callback_do(struct graphics_priv *priv, int w, int h) {
                               GINT_TO_POINTER(w), GINT_TO_POINTER(h));
 }
 
-static void
-resize_callback(int w, int h) {
+static void resize_callback(int w, int h) {
     resize_callback_do(graphics_priv_root, w, h);
 }
 
-static void
-display(void) {
+static void display(void) {
     graphics_priv_root->force_redraw = 1;
     redraw_screen(graphics_priv_root);
     resize_callback(graphics_priv_root->width,
                     graphics_priv_root->height);
 }
 
-static void
-glut_close(void) {
+static void glut_close(void) {
     callback_list_call_attr_0(graphics_priv_root->cbl,
                               attr_window_closed);
 }
 
 
-static struct graphics_priv *
-graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
-                    struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
+        struct attr **attrs, struct callback_list *cbl) {
     struct attr *attr;
 
     if (!event_request_system("glib", "graphics_opengl_new"))
@@ -1686,54 +1635,45 @@ graphics_opengl_new(struct navit *nav, struct graphics_methods *meth,
 }
 
 
-static void
-event_opengl_main_loop_run(void) {
+static void event_opengl_main_loop_run(void) {
     dbg(lvl_info, "enter");
 }
 
-static void
-event_opengl_main_loop_quit(void) {
+static void event_opengl_main_loop_quit(void) {
     dbg(lvl_debug, "enter");
 }
 
-static struct event_watch *
-event_opengl_add_watch(int fd, enum event_watch_cond cond,
-                       struct callback *cb) {
+static struct event_watch *event_opengl_add_watch(int fd, enum event_watch_cond cond,
+        struct callback *cb) {
     dbg(lvl_debug, "enter");
     return NULL;
 }
 
-static void
-event_opengl_remove_watch(struct event_watch *ev) {
+static void event_opengl_remove_watch(struct event_watch *ev) {
     dbg(lvl_debug, "enter");
 }
 
 
-static struct event_timeout *
-event_opengl_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_opengl_add_timeout(int timeout, int multi, struct callback *cb) {
     dbg(lvl_debug, "enter");
     return NULL;
 }
 
-static void
-event_opengl_remove_timeout(struct event_timeout *to) {
+static void event_opengl_remove_timeout(struct event_timeout *to) {
     dbg(lvl_debug, "enter");
 }
 
 
-static struct event_idle *
-event_opengl_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_opengl_add_idle(int priority, struct callback *cb) {
     dbg(lvl_debug, "enter");
     return NULL;
 }
 
-static void
-event_opengl_remove_idle(struct event_idle *ev) {
+static void event_opengl_remove_idle(struct event_idle *ev) {
     dbg(lvl_debug, "enter");
 }
 
-static void
-event_opengl_call_callback(struct callback_list *cb) {
+static void event_opengl_call_callback(struct callback_list *cb) {
     dbg(lvl_debug, "enter");
 }
 
@@ -1749,14 +1689,12 @@ static struct event_methods event_opengl_methods = {
     event_opengl_call_callback,
 };
 
-static struct event_priv *
-event_opengl_new(struct event_methods *meth) {
+static struct event_priv *event_opengl_new(struct event_methods *meth) {
     *meth = event_opengl_methods;
     return NULL;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_graphics("opengl", graphics_opengl_new);
     plugin_register_category_event("opengl", event_opengl_new);
 }

--- a/navit/graphics/opengl/graphics_opengl_egl.c
+++ b/navit/graphics/opengl/graphics_opengl_egl.c
@@ -34,13 +34,11 @@ EGLint aEGLContextAttributes[] = {
     EGL_NONE
 };
 
-static void
-graphics_opengl_egl_destroy(struct graphics_opengl_platform *egl) {
+static void graphics_opengl_egl_destroy(struct graphics_opengl_platform *egl) {
     g_free(egl);
 }
 
-static void
-graphics_opengl_egl_swap_buffers(struct graphics_opengl_platform *egl) {
+static void graphics_opengl_egl_swap_buffers(struct graphics_opengl_platform *egl) {
     eglSwapBuffers(egl->egldisplay, egl->eglwindow);
 }
 

--- a/navit/graphics/opengl/graphics_opengl_x11.c
+++ b/navit/graphics/opengl/graphics_opengl_x11.c
@@ -23,8 +23,7 @@ struct graphics_opengl_window_system {
 };
 
 
-static void
-graphics_opengl_x11_destroy(struct graphics_opengl_window_system *x11) {
+static void graphics_opengl_x11_destroy(struct graphics_opengl_window_system *x11) {
     if (x11->watch)
         event_remove_watch(x11->watch);
     if (x11->cb)
@@ -39,19 +38,17 @@ graphics_opengl_x11_destroy(struct graphics_opengl_window_system *x11) {
     g_free(x11);
 }
 
-static void *
-graphics_opengl_get_display(struct graphics_opengl_window_system *x11) {
+static void *graphics_opengl_get_display(struct graphics_opengl_window_system *x11) {
     return x11->display;
 }
 
-static void *
-graphics_opengl_get_window(struct graphics_opengl_window_system *x11) {
+static void *graphics_opengl_get_window(struct graphics_opengl_window_system *x11) {
     return (void *)x11->window;
 }
 
-static void
-graphics_opengl_set_callbacks(struct graphics_opengl_window_system *x11, void *data, void *resize, void *button,
-                              void *motion, void *keypress) {
+static void graphics_opengl_set_callbacks(struct graphics_opengl_window_system *x11, void *data, void *resize,
+        void *button,
+        void *motion, void *keypress) {
     x11->data=data;
     x11->resize=resize;
     x11->button=button;
@@ -67,8 +64,7 @@ struct graphics_opengl_window_system_methods graphics_opengl_x11_methods = {
     graphics_opengl_set_callbacks,
 };
 
-static void
-graphics_opengl_x11_watch(struct graphics_opengl_window_system *x11) {
+static void graphics_opengl_x11_watch(struct graphics_opengl_window_system *x11) {
     XEvent event;
     while (XPending(x11->display)) {
         XNextEvent(x11->display, &event);

--- a/navit/graphics/opengl/graphics_opengl_x11.c
+++ b/navit/graphics/opengl/graphics_opengl_x11.c
@@ -46,9 +46,7 @@ static void *graphics_opengl_get_window(struct graphics_opengl_window_system *x1
     return (void *)x11->window;
 }
 
-static void graphics_opengl_set_callbacks(struct graphics_opengl_window_system *x11, void *data, void *resize,
-        void *button,
-        void *motion, void *keypress) {
+static void graphics_opengl_set_callbacks(struct graphics_opengl_window_system *x11, void *data, void *resize, void *button, void *motion, void *keypress) {
     x11->data=data;
     x11->resize=resize;
     x11->button=button;
@@ -106,8 +104,7 @@ static void graphics_opengl_x11_watch(struct graphics_opengl_window_system *x11)
 }
 
 struct graphics_opengl_window_system *
-graphics_opengl_x11_new(void *displayname, int w, int h, int depth,
-                        struct graphics_opengl_window_system_methods **methods) {
+graphics_opengl_x11_new(void *displayname, int w, int h, int depth, struct graphics_opengl_window_system_methods **methods) {
     struct graphics_opengl_window_system *ret=g_new0(struct graphics_opengl_window_system, 1);
     XSetWindowAttributes attributes;
     unsigned long valuemask;

--- a/navit/graphics/qt5/event_qt5.cpp
+++ b/navit/graphics/qt5/event_qt5.cpp
@@ -92,8 +92,7 @@ void qt5_navit_timer::timerEvent(QTimerEvent* event) {
 
 qt5_navit_timer* qt5_timer = NULL;
 
-static void
-event_qt5_main_loop_run(void) {
+static void event_qt5_main_loop_run(void) {
 
     dbg(lvl_debug, "enter");
     if (navit_app != NULL)
@@ -105,8 +104,7 @@ static void event_qt5_main_loop_quit(void) {
     exit(0);
 }
 
-static struct event_watch*
-event_qt5_add_watch(int fd, enum event_watch_cond cond, struct callback* cb) {
+static struct event_watch* event_qt5_add_watch(int fd, enum event_watch_cond cond, struct callback* cb) {
     dbg(lvl_debug, "enter fd=%d", (int)(long)fd);
     struct event_watch* ret = g_new0(struct event_watch, 1);
     ret->fd = fd;
@@ -117,16 +115,14 @@ event_qt5_add_watch(int fd, enum event_watch_cond cond, struct callback* cb) {
     return ret;
 }
 
-static void
-event_qt5_remove_watch(struct event_watch* ev) {
+static void event_qt5_remove_watch(struct event_watch* ev) {
     dbg(lvl_debug, "enter");
     g_hash_table_remove(qt5_timer->watches, GINT_TO_POINTER(ev->fd));
     delete (ev->sn);
     g_free(ev);
 }
 
-static struct event_timeout*
-event_qt5_add_timeout(int timeout, int multi, struct callback* cb) {
+static struct event_timeout* event_qt5_add_timeout(int timeout, int multi, struct callback* cb) {
     int id;
     dbg(lvl_debug, "add timeout %d, mul %d, %p ==", timeout, multi, cb);
     id = qt5_timer->startTimer(timeout);
@@ -136,28 +132,24 @@ event_qt5_add_timeout(int timeout, int multi, struct callback* cb) {
     return (struct event_timeout*)(long)id;
 }
 
-static void
-event_qt5_remove_timeout(struct event_timeout* to) {
+static void event_qt5_remove_timeout(struct event_timeout* to) {
     dbg(lvl_debug, "remove timeout (%d)", (int)(long)to);
     qt5_timer->killTimer((int)(long)to);
     g_hash_table_remove(qt5_timer->timer_callback, to);
     g_hash_table_remove(qt5_timer->timer_type, to);
 }
 
-static struct event_idle*
-event_qt5_add_idle(int priority, struct callback* cb) {
+static struct event_idle* event_qt5_add_idle(int priority, struct callback* cb) {
     dbg(lvl_debug, "add idle event");
     return (struct event_idle*)event_qt5_add_timeout(0, 1, cb);
 }
 
-static void
-event_qt5_remove_idle(struct event_idle* ev) {
+static void event_qt5_remove_idle(struct event_idle* ev) {
     dbg(lvl_debug, "Remove idle timeout");
     event_qt5_remove_timeout((struct event_timeout*)ev);
 }
 
-static void
-event_qt5_call_callback(struct callback_list* cb) {
+static void event_qt5_call_callback(struct callback_list* cb) {
     dbg(lvl_debug, "enter");
 }
 
@@ -173,8 +165,7 @@ static struct event_methods event_qt5_methods = {
     event_qt5_call_callback,
 };
 
-static struct event_priv*
-event_qt5_new(struct event_methods* meth) {
+static struct event_priv* event_qt5_new(struct event_methods* meth) {
     *meth = event_qt5_methods;
     qt5_timer = new qt5_navit_timer(NULL);
     return NULL;

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -86,8 +86,7 @@ struct graphics_image_priv {
     QPixmap* pixmap;
 };
 
-static void
-graphics_destroy(struct graphics_priv* gr) {
+static void graphics_destroy(struct graphics_priv* gr) {
 //        dbg(lvl_debug,"enter");
 #if HAVE_FREETYPE
     gr->freetype_methods.destroy();
@@ -219,22 +218,19 @@ static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct grap
     return font_priv;
 }
 
-static void
-gc_destroy(struct graphics_gc_priv* gc) {
+static void gc_destroy(struct graphics_gc_priv* gc) {
     //        dbg(lvl_debug,"enter gc=%p", gc);
     delete (gc->pen);
     delete (gc->brush);
     g_free(gc);
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv* gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv* gc, int w) {
     //        dbg(lvl_debug,"enter gc=%p, %d", gc, w);
     gc->pen->setWidth(w);
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv* gc, int w, int offset, unsigned char* dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv* gc, int w, int offset, unsigned char* dash_list, int n) {
     if (n <= 0) {
         dbg(lvl_error, "Refuse to set dashes without dash pattern");
     }
@@ -254,8 +250,7 @@ gc_set_dashes(struct graphics_gc_priv* gc, int w, int offset, unsigned char* das
     gc->pen->setDashPattern(dashes);
 }
 
-static void
-gc_set_foreground(struct graphics_gc_priv* gc, struct color* c) {
+static void gc_set_foreground(struct graphics_gc_priv* gc, struct color* c) {
     QColor col(c->r >> 8, c->g >> 8, c->b >> 8, c->a >> 8);
     //        dbg(lvl_debug,"context %p: color %02x%02x%02x",gc, c->r >> 8, c->g >> 8, c->b >> 8);
     gc->pen->setColor(col);
@@ -263,8 +258,7 @@ gc_set_foreground(struct graphics_gc_priv* gc, struct color* c) {
     //gc->c=*c;
 }
 
-static void
-gc_set_background(struct graphics_gc_priv* gc, struct color* c) {
+static void gc_set_background(struct graphics_gc_priv* gc, struct color* c) {
     QColor col(c->r >> 8, c->g >> 8, c->b >> 8, c->a >> 8);
     //        dbg(lvl_debug,"context %p: color %02x%02x%02x",gc, c->r >> 8, c->g >> 8, c->b >> 8);
     //gc->pen->setColor(col);
@@ -302,9 +296,9 @@ struct graphics_image_methods image_methods = {
     image_destroy
 };
 
-static struct graphics_image_priv*
-image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* path, int* w, int* h, struct point* hot,
-          int rotation) {
+static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* path,
+        int* w, int* h, struct point* hot,
+        int rotation) {
     struct graphics_image_priv* image_priv;
     //        dbg(lvl_debug,"enter %s, %d %d", path, *w, *h);
     if (path[0] == 0) {
@@ -384,8 +378,7 @@ image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* p
     return image_priv;
 }
 
-static void
-draw_lines(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int count) {
+static void draw_lines(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int count) {
     int i;
     QPolygon polygon;
     //        dbg(lvl_debug,"enter gr=%p, gc=%p, (%d, %d)", gr, gc, p->x, p->y);
@@ -398,8 +391,7 @@ draw_lines(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* 
     gr->painter->drawPolyline(polygon);
 }
 
-static void
-draw_polygon(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int count) {
+static void draw_polygon(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int count) {
     int i;
     QPolygon polygon;
     //        dbg(lvl_debug,"enter gr=%p, gc=%p, (%d, %d)", gr, gc, p->x, p->y);
@@ -420,8 +412,7 @@ draw_polygon(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point
     gr->painter->drawPolygon(polygon);
 }
 
-static void
-draw_rectangle(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int w, int h) {
+static void draw_rectangle(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int w, int h) {
     //	dbg(lvl_debug,"gr=%p gc=%p %d,%d,%d,%d", gr, gc, p->x, p->y, w, h);
     if (gr->painter == NULL)
         return;
@@ -435,8 +426,7 @@ draw_rectangle(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct poi
     gr->painter->fillRect(p->x, p->y, w, h, *gc->brush);
 }
 
-static void
-draw_circle(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int r) {
+static void draw_circle(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point* p, int r) {
     //        dbg(lvl_debug,"enter gr=%p, gc=%p, (%d,%d) r=%d", gr, gc, p->x, p->y, r);
     if (gr->painter == NULL)
         return;
@@ -457,9 +447,8 @@ draw_circle(struct graphics_priv* gr, struct graphics_gc_priv* gc, struct point*
  *
  * Renders given text on gr surface. Draws nice contrast outline around text.
  */
-static void
-draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics_gc_priv* bg,
-          struct graphics_font_priv* font, char* text, struct point* p, int dx, int dy) {
+static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics_gc_priv* bg,
+                      struct graphics_font_priv* font, char* text, struct point* p, int dx, int dy) {
     dbg(lvl_debug, "enter gc=%p, fg=%p, bg=%p pos(%d,%d) d(%d, %d) %s", gr, fg, bg, p->x, p->y, dx, dy, text);
     QPainter* painter = gr->painter;
     if (painter == NULL)
@@ -550,8 +539,8 @@ draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics
 #endif
 }
 
-static void
-draw_image(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct point* p, struct graphics_image_priv* img) {
+static void draw_image(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct point* p,
+                       struct graphics_image_priv* img) {
     //        dbg(lvl_debug,"enter");
     if (gr->painter != NULL)
         gr->painter->drawPixmap(p->x, p->y, *img->pixmap);
@@ -604,14 +593,12 @@ static void draw_drag(struct graphics_priv* gr, struct point* p) {
     }
 }
 
-static void
-background_gc(struct graphics_priv* gr, struct graphics_gc_priv* gc) {
+static void background_gc(struct graphics_priv* gr, struct graphics_gc_priv* gc) {
     //        dbg(lvl_debug,"register context %p on %p", gc, gr);
     gr->background_graphics_gc_priv = gc;
 }
 
-static void
-draw_mode(struct graphics_priv* gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv* gr, enum draw_mode_num mode) {
     switch (mode) {
     case draw_mode_begin:
         dbg(lvl_debug, "Begin drawing on context %p (use == %d)", gr, gr->use_count);
@@ -662,8 +649,7 @@ void resize_callback(struct graphics_priv* gr, int w, int h) {
                               GINT_TO_POINTER(w), GINT_TO_POINTER(h));
 }
 
-static int
-graphics_qt5_fullscreen(struct window* w, int on) {
+static int graphics_qt5_fullscreen(struct window* w, int on) {
     struct graphics_priv* gr;
     //        dbg(lvl_debug,"enter");
     gr = (struct graphics_priv*)w->priv;
@@ -687,8 +673,7 @@ graphics_qt5_fullscreen(struct window* w, int on) {
 }
 
 #ifdef SAILFISH_OS
-static void
-keep_display_on(struct graphics_priv* priv) {
+static void keep_display_on(struct graphics_priv* priv) {
     //        dbg(lvl_debug,"enter");
     QDBusConnection system = QDBusConnection::connectToBus(QDBusConnection::SystemBus, "system");
     QDBusInterface interface("com.nokia.mce", "/com/nokia/mce/request", "com.nokia.mce.request", system);
@@ -697,8 +682,7 @@ keep_display_on(struct graphics_priv* priv) {
 }
 #endif
 
-static void
-graphics_qt5_disable_suspend(struct window* w) {
+static void graphics_qt5_disable_suspend(struct window* w) {
 //        dbg(lvl_debug,"enter");
 #ifdef SAILFISH_OS
     struct graphics_priv* gr;
@@ -711,8 +695,7 @@ graphics_qt5_disable_suspend(struct window* w) {
 #endif
 }
 
-static void*
-get_data(struct graphics_priv* this_priv, char const* type) {
+static void* get_data(struct graphics_priv* this_priv, char const* type) {
     //        dbg(lvl_debug,"enter: %s", type);
     if (strcmp(type, "window") == 0) {
         struct window* win;
@@ -833,8 +816,8 @@ static struct graphics_methods graphics_methods = {
 };
 
 /* create new graphics context on given context */
-static struct graphics_priv*
-overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p, int w, int h, int wraparound) {
+static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p,
+        int w, int h, int wraparound) {
     struct graphics_priv* graphics_priv = NULL;
     graphics_priv = g_new0(struct graphics_priv, 1);
     *meth = graphics_methods;
@@ -878,8 +861,8 @@ overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct poin
 }
 
 /* create application and initial graphics context */
-static struct graphics_priv*
-graphics_qt5_new(struct navit* nav, struct graphics_methods* meth, struct attr** attrs, struct callback_list* cbl) {
+static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics_methods* meth, struct attr** attrs,
+        struct callback_list* cbl) {
     struct graphics_priv* graphics_priv = NULL;
     struct attr* event_loop_system = NULL;
     struct attr* platform = NULL;

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -180,8 +180,7 @@ static const char* fontfamilies[] = {
  *
  * Allocates a font handle and returnes filled interface stucture
  */
-static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct graphics_font_methods* meth, char* font,
-        int size, int flags) {
+static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct graphics_font_methods* meth, char* font, int size, int flags) {
     int a = 0;
     struct graphics_font_priv* font_priv;
     dbg(lvl_debug, "enter (font %s, %d, 0x%x)", font, size, flags);
@@ -296,9 +295,7 @@ struct graphics_image_methods image_methods = {
     image_destroy
 };
 
-static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* path,
-        int* w, int* h, struct point* hot,
-        int rotation) {
+static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* path, int* w, int* h, struct point* hot, int rotation) {
     struct graphics_image_priv* image_priv;
     //        dbg(lvl_debug,"enter %s, %d %d", path, *w, *h);
     if (path[0] == 0) {
@@ -447,8 +444,7 @@ static void draw_circle(struct graphics_priv* gr, struct graphics_gc_priv* gc, s
  *
  * Renders given text on gr surface. Draws nice contrast outline around text.
  */
-static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics_gc_priv* bg,
-                      struct graphics_font_priv* font, char* text, struct point* p, int dx, int dy) {
+static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics_gc_priv* bg, struct graphics_font_priv* font, char* text, struct point* p, int dx, int dy) {
     dbg(lvl_debug, "enter gc=%p, fg=%p, bg=%p pos(%d,%d) d(%d, %d) %s", gr, fg, bg, p->x, p->y, dx, dy, text);
     QPainter* painter = gr->painter;
     if (painter == NULL)
@@ -539,8 +535,7 @@ static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, str
 #endif
 }
 
-static void draw_image(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct point* p,
-                       struct graphics_image_priv* img) {
+static void draw_image(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct point* p, struct graphics_image_priv* img) {
     //        dbg(lvl_debug,"enter");
     if (gr->painter != NULL)
         gr->painter->drawPixmap(p->x, p->y, *img->pixmap);
@@ -640,13 +635,11 @@ static void draw_mode(struct graphics_priv* gr, enum draw_mode_num mode) {
     }
 }
 
-static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p,
-        int w, int h, int wraparound);
+static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p, int w, int h, int wraparound);
 
 void resize_callback(struct graphics_priv* gr, int w, int h) {
     //        dbg(lvl_debug,"enter (%d, %d)", w, h);
-    callback_list_call_attr_2(gr->callbacks, attr_resize,
-                              GINT_TO_POINTER(w), GINT_TO_POINTER(h));
+    callback_list_call_attr_2(gr->callbacks, attr_resize, GINT_TO_POINTER(w), GINT_TO_POINTER(h));
 }
 
 static int graphics_qt5_fullscreen(struct window* w, int on) {
@@ -732,8 +725,7 @@ static void image_free(struct graphics_priv* gr, struct graphics_image_priv* pri
  *
  * Calculates the bounding box around the given text.
  */
-static void get_text_bbox(struct graphics_priv* gr, struct graphics_font_priv* font, char* text, int dx, int dy,
-                          struct point* ret, int estimate) {
+static void get_text_bbox(struct graphics_priv* gr, struct graphics_font_priv* font, char* text, int dx, int dy, struct point* ret, int estimate) {
     int i;
     struct point pt;
     QString tmp = QString::fromUtf8(text);
@@ -816,8 +808,7 @@ static struct graphics_methods graphics_methods = {
 };
 
 /* create new graphics context on given context */
-static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p,
-        int w, int h, int wraparound) {
+static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p, int w, int h, int wraparound) {
     struct graphics_priv* graphics_priv = NULL;
     graphics_priv = g_new0(struct graphics_priv, 1);
     *meth = graphics_methods;
@@ -861,8 +852,7 @@ static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphi
 }
 
 /* create application and initial graphics context */
-static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics_methods* meth, struct attr** attrs,
-        struct callback_list* cbl) {
+static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics_methods* meth, struct attr** attrs, struct callback_list* cbl) {
     struct graphics_priv* graphics_priv = NULL;
     struct attr* event_loop_system = NULL;
     struct attr* platform = NULL;

--- a/navit/graphics/qt_qpainter/graphics_qt_qpainter.cpp
+++ b/navit/graphics/qt_qpainter/graphics_qt_qpainter.cpp
@@ -35,8 +35,7 @@
 //# Comment:
 //# Authors: Martin Schaller (04/2008), Stefan Klumpp (04/2008)
 //##############################################################################################################
-static void
-overlay_rect(struct graphics_priv *parent, struct graphics_priv *overlay, int clean, QRect *r) {
+static void overlay_rect(struct graphics_priv *parent, struct graphics_priv *overlay, int clean, QRect *r) {
     struct point p;
     int w,h;
     if (clean) {
@@ -59,8 +58,7 @@ overlay_rect(struct graphics_priv *parent, struct graphics_priv *overlay, int cl
     r->setRect(p.x, p.y, w, h);
 }
 
-void
-qt_qpainter_draw(struct graphics_priv *gr, const QRect *r, int paintev) {
+void qt_qpainter_draw(struct graphics_priv *gr, const QRect *r, int paintev) {
     if (!paintev) {
 #ifndef QT_QPAINTER_NO_WIDGET
         dbg(lvl_debug,"update %d,%d %d x %d", r->x(), r->y(), r->width(), r->height());
@@ -445,8 +443,7 @@ static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, st
     gr->painter->drawPixmap(p->x, p->y, *img->pixmap);
 }
 
-static void
-draw_drag(struct graphics_priv *gr, struct point *p) {
+static void draw_drag(struct graphics_priv *gr, struct point *p) {
     if (!gr->cleanup) {
         gr->pclean=gr->p;
         gr->cleanup=1;
@@ -519,8 +516,7 @@ static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graph
 static int argc=1;
 static char *argv[]= {NULL,NULL,NULL};
 
-static int
-fullscreen(struct window *win, int on) {
+static int fullscreen(struct window *win, int on) {
 #ifndef QT_QPAINTER_NO_WIDGET
     struct graphics_priv *this_=(struct graphics_priv *)win->priv;
     QWidget* _outerWidget;
@@ -537,8 +533,7 @@ fullscreen(struct window *win, int on) {
     return 1;
 }
 
-static void
-disable_suspend(struct window *win) {
+static void disable_suspend(struct window *win) {
 #ifdef HAVE_QPE
     struct graphics_priv *this_=(struct graphics_priv *)win->priv;
     this_->app->setTempScreenSaverMode(QPEApplication::DisableLightOff);
@@ -588,15 +583,14 @@ static void * get_data(struct graphics_priv *this_, const char *type) {
     return NULL;
 }
 
-static void
-image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
+static void image_free(struct graphics_priv *gr, struct graphics_image_priv *priv) {
     delete priv->pixmap;
     g_free(priv);
 }
 
-static void
-get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy, struct point *ret,
-              int estimate) {
+static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy,
+                          struct point *ret,
+                          int estimate) {
     QPainter *painter=gr->painter;
     QString tmp=QString::fromUtf8(text);
     painter->setFont(*font->font);
@@ -716,8 +710,7 @@ static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graph
 
 static struct graphics_priv *event_gr;
 
-static void
-event_qt_main_loop_run(void) {
+static void event_qt_main_loop_run(void) {
     event_gr->app->exec();
 }
 
@@ -726,8 +719,7 @@ static void event_qt_main_loop_quit(void) {
     exit(0);
 }
 
-static struct event_watch *
-event_qt_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_qt_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug,"enter fd=%d",(int)(long)fd);
     struct event_watch *ret=g_new0(struct event_watch, 1);
     ret->fd=fd;
@@ -738,16 +730,14 @@ event_qt_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     return ret;
 }
 
-static void
-event_qt_remove_watch(struct event_watch *ev) {
+static void event_qt_remove_watch(struct event_watch *ev) {
     g_hash_table_remove(event_gr->widget->watches, GINT_TO_POINTER(ev->fd));
     delete(ev->sn);
     g_free(ev);
 
 }
 
-static struct event_timeout *
-event_qt_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_qt_add_timeout(int timeout, int multi, struct callback *cb) {
     int id;
     id=event_gr->widget->startTimer(timeout);
     g_hash_table_insert(event_gr->widget->timer_callback, (void *)id, cb);
@@ -755,27 +745,23 @@ event_qt_add_timeout(int timeout, int multi, struct callback *cb) {
     return (struct event_timeout *)id;
 }
 
-void
-event_qt_remove_timeout(struct event_timeout *ev) {
+void event_qt_remove_timeout(struct event_timeout *ev) {
     event_gr->widget->killTimer((int)(long)ev);
     g_hash_table_remove(event_gr->widget->timer_callback, ev);
     g_hash_table_remove(event_gr->widget->timer_type, ev);
 }
 
-static struct event_idle *
-event_qt_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_qt_add_idle(int priority, struct callback *cb) {
     dbg(lvl_debug,"enter");
     return (struct event_idle *)event_qt_add_timeout(0, 1, cb);
 }
 
-static void
-event_qt_remove_idle(struct event_idle *ev) {
+static void event_qt_remove_idle(struct event_idle *ev) {
     dbg(lvl_debug,"enter");
     event_qt_remove_timeout((struct event_timeout *) ev);
 }
 
-static void
-event_qt_call_callback(struct callback_list *cb) {
+static void event_qt_call_callback(struct callback_list *cb) {
     dbg(lvl_debug,"enter");
 }
 

--- a/navit/graphics/qt_qpainter/graphics_qt_qpainter.cpp
+++ b/navit/graphics/qt_qpainter/graphics_qt_qpainter.cpp
@@ -170,8 +170,7 @@ static struct graphics_font_methods font_methods = {
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct graphics_font_methods *meth,
-        char *fontfamily, int size, int flags) {
+static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct graphics_font_methods *meth, char *fontfamily, int size, int flags) {
     struct graphics_font_priv *ret=g_new0(struct graphics_font_priv, 1);
     ret->font=new QFont("Arial",size/20);
     *meth=font_methods;
@@ -257,8 +256,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static struct graphics_image_priv * image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path,
-        int *w, int *h, struct point *hot, int rotation) {
+static struct graphics_image_priv * image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot, int rotation) {
     struct graphics_image_priv *ret;
     QPixmap *cachedPixmap;
     QString key(path);
@@ -364,8 +362,7 @@ static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, s
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
-                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     QPainter *painter=gr->painter;
 #ifndef QT_QPAINTER_USE_FREETYPE
     QString tmp=QString::fromUtf8(text);
@@ -438,8 +435,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, str
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
-                       struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
     gr->painter->drawPixmap(p->x, p->y, *img->pixmap);
 }
 
@@ -588,9 +584,7 @@ static void image_free(struct graphics_priv *gr, struct graphics_image_priv *pri
     g_free(priv);
 }
 
-static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy,
-                          struct point *ret,
-                          int estimate) {
+static void get_text_bbox(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy, struct point *ret, int estimate) {
     QPainter *painter=gr->painter;
     QString tmp=QString::fromUtf8(text);
     painter->setFont(*font->font);
@@ -678,8 +672,7 @@ static struct graphics_methods graphics_methods = {
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h,int wraparound) {
+static struct graphics_priv * overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h,int wraparound) {
     *meth=graphics_methods;
     struct graphics_priv *ret=g_new0(struct graphics_priv, 1);
 #ifdef QT_QPAINTER_USE_FREETYPE
@@ -793,8 +786,7 @@ event_qt_new(struct event_methods *meth) {
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static struct graphics_priv * graphics_qt_qpainter_new(struct navit *nav, struct graphics_methods *meth,
-        struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv * graphics_qt_qpainter_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct graphics_priv *ret;
     struct font_priv * (*font_freetype_new)(void *meth);
     struct attr *attr;

--- a/navit/graphics/sdl/event.c
+++ b/navit/graphics/sdl/event.c
@@ -215,8 +215,7 @@ static void event_sdl_watch_stopthread() {
     }
 }
 
-static struct event_watch *
-event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug, "fd(%d) cond(%x) cb(%x)", fd, cond, cb);
 
     event_sdl_watch_stopthread();
@@ -267,8 +266,7 @@ static void event_sdl_remove_watch(struct event_watch *ew) {
 
 /* Timeout */
 
-static struct event_timeout *
-event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
     struct event_timeout * ret = g_new0(struct event_timeout, 1);
     if (!ret)
         return ret;
@@ -307,8 +305,7 @@ static gint sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
     return 0;
 }
 
-static struct event_idle *
-event_sdl_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_sdl_add_idle(int priority, struct callback *cb) {
     dbg(lvl_debug, "add idle priority(%d) cb(%p)", priority, cb);
 
     struct idle_task *task = g_new0(struct idle_task, 1);
@@ -368,8 +365,7 @@ static struct event_methods event_sdl_methods = { event_sdl_main_loop_run,
            event_sdl_remove_idle, event_sdl_call_callback,
 };
 
-static struct event_priv *
-event_sdl_new(struct event_methods* methods) {
+static struct event_priv *event_sdl_new(struct event_methods* methods) {
     idle_tasks = g_ptr_array_new();
     *methods = event_sdl_methods;
     return NULL;

--- a/navit/graphics/sdl/event_sdl.c
+++ b/navit/graphics/sdl/event_sdl.c
@@ -43,8 +43,7 @@ static struct event_idle *event_sdl_add_idle(int, struct callback *);
 static void event_sdl_remove_idle(struct event_idle *);
 static void event_sdl_call_callback(struct callback_list *);
 
-static Uint32
-sdl_timer_callback(Uint32 interval, void* param) {
+static Uint32 sdl_timer_callback(Uint32 interval, void* param) {
     struct event_timeout *timeout=(struct event_timeout*)param;
 
     dbg(lvl_debug,"timer(%p) multi(%d) interval(%d) fired", param, timeout->multi, interval);
@@ -71,21 +70,18 @@ sdl_timer_callback(Uint32 interval, void* param) {
 
 /* SDL Mainloop */
 
-static void
-event_sdl_main_loop_run(void) {
+static void event_sdl_main_loop_run(void) {
     graphics_sdl_idle(NULL);
     event_sdl_watch_stopthread();
 }
 
-static void
-event_sdl_main_loop_quit(void) {
+static void event_sdl_main_loop_quit(void) {
     quit_event_loop = 1;
 }
 
 /* Watch */
 
-void
-event_sdl_watch_thread (GPtrArray *watch_list) {
+void event_sdl_watch_thread (GPtrArray *watch_list) {
     struct pollfd *pfds = g_new0 (struct pollfd, watch_list->len);
     struct event_watch *ew;
     int ret;
@@ -123,8 +119,7 @@ event_sdl_watch_thread (GPtrArray *watch_list) {
     pthread_exit(0);
 }
 
-static void
-event_sdl_watch_startthread(GPtrArray *watch_list) {
+static void event_sdl_watch_startthread(GPtrArray *watch_list) {
     dbg(lvl_debug,"enter");
     if (sdl_watch_thread)
         event_sdl_watch_stopthread();
@@ -135,8 +130,7 @@ event_sdl_watch_startthread(GPtrArray *watch_list) {
     dbg_assert (ret == 0);
 }
 
-static void
-event_sdl_watch_stopthread() {
+static void event_sdl_watch_stopthread() {
     dbg(lvl_debug,"enter");
     if (sdl_watch_thread) {
         /* Notify the watch thread that the list of FDs will change */
@@ -146,8 +140,7 @@ event_sdl_watch_stopthread() {
     }
 }
 
-static struct event_watch *
-event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug,"fd(%d) cond(%x) cb(%x)", fd, cond, cb);
 
     event_sdl_watch_stopthread();
@@ -183,8 +176,7 @@ event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     return new_ew;
 }
 
-static void
-event_sdl_remove_watch(struct event_watch *ew) {
+static void event_sdl_remove_watch(struct event_watch *ew) {
     dbg(lvl_debug,"enter %p",ew);
 
     event_sdl_watch_stopthread();
@@ -199,8 +191,7 @@ event_sdl_remove_watch(struct event_watch *ew) {
 
 /* Timeout */
 
-static struct event_timeout *
-event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
     struct event_timeout * ret = g_new0(struct event_timeout, 1);
     if(!ret) {
         dbg(lvl_error,"g_new0 failed");
@@ -214,8 +205,7 @@ event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
     return ret;
 }
 
-static void
-event_sdl_remove_timeout(struct event_timeout *to) {
+static void event_sdl_remove_timeout(struct event_timeout *to) {
     dbg(lvl_info,"enter %p", to);
     if(to) {
         /* do not SDL_RemoveTimer if oneshot timer has already fired */
@@ -232,8 +222,7 @@ event_sdl_remove_timeout(struct event_timeout *to) {
 /* Idle */
 
 /* sort ptr_array by priority, increasing order */
-static gint
-sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
+static gint sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
     struct idle_task *a = (struct idle_task *)parama;
     struct idle_task *b = (struct idle_task *)paramb;
     if (a->priority < b->priority)
@@ -243,8 +232,7 @@ sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
     return 0;
 }
 
-static struct event_idle *
-event_sdl_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_sdl_add_idle(int priority, struct callback *cb) {
     dbg(lvl_debug,"add idle priority(%d) cb(%p)", priority, cb);
 
     struct idle_task *task = g_new0(struct idle_task, 1);
@@ -274,16 +262,14 @@ event_sdl_add_idle(int priority, struct callback *cb) {
     return (struct event_idle *)task;
 }
 
-static void
-event_sdl_remove_idle(struct event_idle *task) {
+static void event_sdl_remove_idle(struct event_idle *task) {
     dbg(lvl_debug,"remove task(%p)", task);
     g_ptr_array_remove(idle_tasks, (gpointer)task);
 }
 
 /* callback */
 
-static void
-event_sdl_call_callback(struct callback_list *cbl) {
+static void event_sdl_call_callback(struct callback_list *cbl) {
     dbg(lvl_debug,"call_callback cbl(%p)",cbl);
     SDL_Event event;
     SDL_UserEvent userevent;
@@ -311,14 +297,12 @@ static struct event_methods event_sdl_methods = {
     event_sdl_call_callback,
 };
 
-static struct event_priv *
-event_sdl_new(struct event_methods* methods) {
+static struct event_priv *event_sdl_new(struct event_methods* methods) {
     idle_tasks = g_ptr_array_new();
     *methods = event_sdl_methods;
     return NULL;
 }
 
-void
-event_sdl_register(void) {
+void event_sdl_register(void) {
     plugin_register_category_event("sdl", event_sdl_new);
 }

--- a/navit/graphics/sdl/graphics_sdl.c
+++ b/navit/graphics/sdl/graphics_sdl.c
@@ -182,8 +182,7 @@ struct graphics_image_priv {
 };
 
 
-static void
-graphics_destroy(struct graphics_priv *gr) {
+static void graphics_destroy(struct graphics_priv *gr) {
     dbg(lvl_debug, "graphics_destroy %p %u", gr, gr->overlay_mode);
 
     if(gr->overlay_mode) {
@@ -207,24 +206,20 @@ graphics_destroy(struct graphics_priv *gr) {
 
 /* graphics_gc */
 
-static void
-gc_destroy(struct graphics_gc_priv *gc) {
+static void gc_destroy(struct graphics_gc_priv *gc) {
     g_free(gc);
 }
 
-static void
-gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
+static void gc_set_linewidth(struct graphics_gc_priv *gc, int w) {
     dbg(lvl_debug, "gc_set_linewidth %p %d", gc, w);
     gc->linewidth = w;
 }
 
-static void
-gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
+static void gc_set_dashes(struct graphics_gc_priv *gc, int w, int offset, unsigned char *dash_list, int n) {
     /* TODO */
 }
 
-static void
-gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     dbg(lvl_debug, "gc_set_foreground: %p %d %d %d %d", gc, c->a, c->r, c->g, c->b);
     gc->fore_r = c->r/256;
     gc->fore_g = c->g/256;
@@ -232,8 +227,7 @@ gc_set_foreground(struct graphics_gc_priv *gc, struct color *c) {
     gc->fore_a = c->a/256;
 }
 
-static void
-gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
+static void gc_set_background(struct graphics_gc_priv *gc, struct color *c) {
     dbg(lvl_debug, "gc_set_background: %p %d %d %d %d", gc, c->a, c->r, c->g, c->b);
     gc->back_r = c->r/256;
     gc->back_g = c->g/256;
@@ -258,9 +252,9 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 }
 
 
-static struct graphics_image_priv *
-image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h,
-          struct point *hot, int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
+        int *w, int *h,
+        struct point *hot, int rotation) {
     struct graphics_image_priv *gi;
 
     /* FIXME: meth is not used yet.. so gi leaks. at least xpm is small */
@@ -286,14 +280,12 @@ image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *n
     return gi;
 }
 
-static void
-image_free(struct graphics_priv *gr, struct graphics_image_priv * gi) {
+static void image_free(struct graphics_priv *gr, struct graphics_image_priv * gi) {
     SDL_FreeSurface(gi->img);
     g_free(gi);
 }
 
-static void
-draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable) || (gr->overlay_parent
             && gr->overlay_parent->overlay_enable && !gr->overlay_enable) ) {
         return;
@@ -332,8 +324,7 @@ draw_polygon(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point
     }
 }
 
-static void
-draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
+static void draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable) || (gr->overlay_parent
             && gr->overlay_parent->overlay_enable && !gr->overlay_enable) ) {
         return;
@@ -356,8 +347,7 @@ draw_rectangle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct poi
                             gc->fore_a));
 }
 
-static void
-draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
+static void draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable) || (gr->overlay_parent
             && gr->overlay_parent->overlay_enable && !gr->overlay_enable) ) {
         return;
@@ -388,8 +378,7 @@ draw_circle(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point 
 }
 
 
-static void
-draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
+static void draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable) || (gr->overlay_parent
             && gr->overlay_parent->overlay_enable && !gr->overlay_enable) ) {
         return;
@@ -498,8 +487,7 @@ draw_lines(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *
 }
 
 
-static void
-set_pixel(SDL_Surface *surface, int x, int y, Uint8 r2, Uint8 g2, Uint8 b2, Uint8 a2) {
+static void set_pixel(SDL_Surface *surface, int x, int y, Uint8 r2, Uint8 g2, Uint8 b2, Uint8 a2) {
     if(x<0 || y<0 || x>=surface->w || y>=surface->h) {
         return;
     }
@@ -531,8 +519,7 @@ set_pixel(SDL_Surface *surface, int x, int y, Uint8 r2, Uint8 g2, Uint8 b2, Uint
 }
 
 
-static void
-resize_ft_buffer (unsigned int new_size) {
+static void resize_ft_buffer (unsigned int new_size) {
     if (new_size > ft_buffer_size) {
         g_free (ft_buffer);
         ft_buffer = g_malloc (new_size);
@@ -541,10 +528,9 @@ resize_ft_buffer (unsigned int new_size) {
     }
 }
 
-static void
-display_text_draw(struct font_freetype_text *text,
-                  struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                  struct graphics_gc_priv *bg, int color, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text,
+                              struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                              struct graphics_gc_priv *bg, int color, struct point *p) {
     int i, x, y, stride;
     struct font_freetype_glyph *g, **gp;
     struct color transparent = { 0x0000, 0x0000, 0x0000, 0x0000 };
@@ -679,10 +665,9 @@ display_text_draw(struct font_freetype_text *text,
     }
 }
 
-static void
-draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-          struct graphics_gc_priv *bg, struct graphics_font_priv *font,
-          char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
+                      struct graphics_gc_priv *bg, struct graphics_font_priv *font,
+                      char *text, struct point *p, int dx, int dy) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable)
             || (gr->overlay_parent && gr->overlay_parent->overlay_enable
                 && !gr->overlay_enable)) {
@@ -708,8 +693,8 @@ draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
     gr->freetype_methods.text_destroy(t);
 }
 
-static void
-draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
+                       struct graphics_image_priv *img) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable) || (gr->overlay_parent
             && gr->overlay_parent->overlay_enable && !gr->overlay_enable) ) {
         return;
@@ -725,14 +710,12 @@ draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *
     SDL_BlitSurface(img->img, NULL, gr->screen, &r);
 }
 
-static void
-background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
+static void background_gc(struct graphics_priv *gr, struct graphics_gc_priv *gc) {
     dbg(lvl_debug, "background_gc");
 }
 
 
-static void
-draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
+static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
     struct graphics_priv *ov;
     SDL_Rect rect;
     int i;
@@ -775,8 +758,8 @@ static void overlay_disable(struct graphics_priv *gr, int disable) {
     draw_mode(curr_gr,draw_mode_end);
 }
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound);
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h, int wraparound);
 
 static int window_fullscreen(struct window *win, int on) {
     struct graphics_priv *gr=(struct graphics_priv *)win->priv;
@@ -798,8 +781,7 @@ static int window_fullscreen(struct window *win, int on) {
     return 1;
 }
 
-static void *
-get_data(struct graphics_priv *this, char const *type) {
+static void *get_data(struct graphics_priv *this, char const *type) {
     if(strcmp(type, "window") == 0) {
         struct window *win;
         win=g_new(struct window, 1);
@@ -845,8 +827,8 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h,int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h,int wraparound) {
     struct graphics_priv *ov;
     Uint32 rmask, gmask, bmask, amask;
     int i;
@@ -1304,8 +1286,8 @@ static gboolean graphics_sdl_idle(void *data) {
 }
 
 
-static struct graphics_priv *
-graphics_sdl_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv *graphics_sdl_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
+        struct callback_list *cbl) {
     struct graphics_priv *this=g_new0(struct graphics_priv, 1);
     struct font_priv *(*font_freetype_new) (void *meth);
     struct attr *attr;
@@ -1456,8 +1438,7 @@ graphics_sdl_new(struct navit *nav, struct graphics_methods *meth, struct attr *
 #ifdef USE_WEBOS
 /* ---------- SDL Eventhandling ---------- */
 
-static Uint32
-sdl_timer_callback(Uint32 interval, void* param) {
+static Uint32 sdl_timer_callback(Uint32 interval, void* param) {
     struct event_timeout *timeout=(struct event_timeout*)param;
 
     dbg(lvl_debug,"timer(%p) multi(%d) interval(%d) fired", param, timeout->multi, interval);
@@ -1484,22 +1465,19 @@ sdl_timer_callback(Uint32 interval, void* param) {
 
 /* SDL Mainloop */
 
-static void
-event_sdl_main_loop_run(void) {
+static void event_sdl_main_loop_run(void) {
     PDL_ScreenTimeoutEnable(PDL_FALSE);
     graphics_sdl_idle(NULL);
     PDL_ScreenTimeoutEnable(PDL_TRUE);
 }
 
-static void
-event_sdl_main_loop_quit(void) {
+static void event_sdl_main_loop_quit(void) {
     quit_event_loop = 1;
 }
 
 /* Watch */
 
-static void
-event_sdl_watch_thread (GPtrArray *watch_list) {
+static void event_sdl_watch_thread (GPtrArray *watch_list) {
     struct pollfd *pfds = g_new0 (struct pollfd, watch_list->len);
     struct event_watch *ew;
     int ret;
@@ -1537,8 +1515,7 @@ event_sdl_watch_thread (GPtrArray *watch_list) {
     pthread_exit(0);
 }
 
-static void
-event_sdl_watch_startthread(GPtrArray *watch_list) {
+static void event_sdl_watch_startthread(GPtrArray *watch_list) {
     dbg(lvl_debug,"enter");
     if (sdl_watch_thread)
         event_sdl_watch_stopthread();
@@ -1549,8 +1526,7 @@ event_sdl_watch_startthread(GPtrArray *watch_list) {
     dbg_assert (ret == 0);
 }
 
-static void
-event_sdl_watch_stopthread() {
+static void event_sdl_watch_stopthread() {
     dbg(lvl_debug,"enter");
     if (sdl_watch_thread) {
         /* Notify the watch thread that the list of FDs will change */
@@ -1560,8 +1536,7 @@ event_sdl_watch_stopthread() {
     }
 }
 
-static struct event_watch *
-event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug,"fd(%d) cond(%x) cb(%x)", fd, cond, cb);
 
     event_sdl_watch_stopthread();
@@ -1597,8 +1572,7 @@ event_sdl_add_watch(int fd, enum event_watch_cond cond, struct callback *cb) {
     return new_ew;
 }
 
-static void
-event_sdl_remove_watch(struct event_watch *ew) {
+static void event_sdl_remove_watch(struct event_watch *ew) {
     dbg(lvl_debug,"enter %p",ew);
 
     event_sdl_watch_stopthread();
@@ -1613,8 +1587,7 @@ event_sdl_remove_watch(struct event_watch *ew) {
 
 /* Timeout */
 
-static struct event_timeout *
-event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
     struct event_timeout * ret =  g_new0(struct event_timeout, 1);
     if(!ret) {
         dbg(lvl_error,"g_new0 failed");
@@ -1628,8 +1601,7 @@ event_sdl_add_timeout(int timeout, int multi, struct callback *cb) {
     return ret;
 }
 
-static void
-event_sdl_remove_timeout(struct event_timeout *to) {
+static void event_sdl_remove_timeout(struct event_timeout *to) {
     dbg(lvl_info,"enter %p", to);
     if(to) {
         /* do not SDL_RemoveTimer if oneshot timer has already fired */
@@ -1646,8 +1618,7 @@ event_sdl_remove_timeout(struct event_timeout *to) {
 /* Idle */
 
 /* sort ptr_array by priority, increasing order */
-static gint
-sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
+static gint sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
     struct idle_task *a = (struct idle_task *)parama;
     struct idle_task *b = (struct idle_task *)paramb;
     if (a->priority < b->priority)
@@ -1657,8 +1628,7 @@ sdl_sort_idle_tasks(gconstpointer parama, gconstpointer paramb) {
     return 0;
 }
 
-static struct event_idle *
-event_sdl_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_sdl_add_idle(int priority, struct callback *cb) {
     dbg(lvl_debug,"add idle priority(%d) cb(%p)", priority, cb);
 
     struct idle_task *task = g_new0(struct idle_task, 1);
@@ -1688,16 +1658,14 @@ event_sdl_add_idle(int priority, struct callback *cb) {
     return (struct event_idle *)task;
 }
 
-static void
-event_sdl_remove_idle(struct event_idle *task) {
+static void event_sdl_remove_idle(struct event_idle *task) {
     dbg(lvl_debug,"remove task(%p)", task);
     g_ptr_array_remove(idle_tasks, (gpointer)task);
 }
 
 /* callback */
 
-static void
-event_sdl_call_callback(struct callback_list *cbl) {
+static void event_sdl_call_callback(struct callback_list *cbl) {
     dbg(lvl_debug,"call_callback cbl(%p)",cbl);
     SDL_Event event;
     SDL_UserEvent userevent;
@@ -1725,8 +1693,7 @@ static struct event_methods event_sdl_methods = {
     event_sdl_call_callback,
 };
 
-static struct event_priv *
-event_sdl_new(struct event_methods* methods) {
+static struct event_priv *event_sdl_new(struct event_methods* methods) {
     idle_tasks = g_ptr_array_new();
     *methods = event_sdl_methods;
     return NULL;
@@ -1735,8 +1702,7 @@ event_sdl_new(struct event_methods* methods) {
 /* ---------- SDL Eventhandling ---------- */
 #endif
 
-void
-plugin_init(void) {
+void plugin_init(void) {
 #ifdef USE_WEBOS
     plugin_register_category_event("sdl", event_sdl_new);
 #endif

--- a/navit/graphics/sdl/graphics_sdl.c
+++ b/navit/graphics/sdl/graphics_sdl.c
@@ -252,9 +252,7 @@ static struct graphics_gc_priv *gc_new(struct graphics_priv *gr, struct graphics
 }
 
 
-static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name,
-        int *w, int *h,
-        struct point *hot, int rotation) {
+static struct graphics_image_priv *image_new(struct graphics_priv *gr, struct graphics_image_methods *meth, char *name, int *w, int *h, struct point *hot, int rotation) {
     struct graphics_image_priv *gi;
 
     /* FIXME: meth is not used yet.. so gi leaks. at least xpm is small */
@@ -528,9 +526,7 @@ static void resize_ft_buffer (unsigned int new_size) {
     }
 }
 
-static void display_text_draw(struct font_freetype_text *text,
-                              struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                              struct graphics_gc_priv *bg, int color, struct point *p) {
+static void display_text_draw(struct font_freetype_text *text, struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, int color, struct point *p) {
     int i, x, y, stride;
     struct font_freetype_glyph *g, **gp;
     struct color transparent = { 0x0000, 0x0000, 0x0000, 0x0000 };
@@ -665,9 +661,7 @@ static void display_text_draw(struct font_freetype_text *text,
     }
 }
 
-static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
-                      struct graphics_gc_priv *bg, struct graphics_font_priv *font,
-                      char *text, struct point *p, int dx, int dy) {
+static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable)
             || (gr->overlay_parent && gr->overlay_parent->overlay_enable
                 && !gr->overlay_enable)) {
@@ -681,9 +675,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
         dbg(lvl_error, "no font, returning");
         return;
     }
-    t = gr->freetype_methods.text_new(text,
-                                      (struct font_freetype_font *) font,
-                                      dx, dy);
+    t = gr->freetype_methods.text_new(text, (struct font_freetype_font *) font, dx, dy);
 
     struct point p_eff;
     p_eff.x = p->x;
@@ -693,8 +685,7 @@ static void draw_text(struct graphics_priv *gr, struct graphics_gc_priv *fg,
     gr->freetype_methods.text_destroy(t);
 }
 
-static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
-                       struct graphics_image_priv *img) {
+static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img) {
     if ((gr->overlay_parent && !gr->overlay_parent->overlay_enable) || (gr->overlay_parent
             && gr->overlay_parent->overlay_enable && !gr->overlay_enable) ) {
         return;
@@ -736,8 +727,7 @@ static void draw_mode(struct graphics_priv *gr, enum draw_mode_num mode) {
                         if(rect.y<0) rect.y += gr->screen->h;
                         rect.w = ov->screen->w;
                         rect.h = ov->screen->h;
-                        SDL_BlitSurface(ov->screen, NULL,
-                                        gr->screen, &rect);
+                        SDL_BlitSurface(ov->screen, NULL, gr->screen, &rect);
                     }
                 }
             }
@@ -827,8 +817,7 @@ static struct graphics_methods graphics_methods = {
     NULL, /* hide_native_keyboard */
 };
 
-static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
-        int w, int h,int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h,int wraparound) {
     struct graphics_priv *ov;
     Uint32 rmask, gmask, bmask, amask;
     int i;
@@ -1286,8 +1275,7 @@ static gboolean graphics_sdl_idle(void *data) {
 }
 
 
-static struct graphics_priv *graphics_sdl_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
-        struct callback_list *cbl) {
+static struct graphics_priv *graphics_sdl_new(struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct graphics_priv *this=g_new0(struct graphics_priv, 1);
     struct font_priv *(*font_freetype_new) (void *meth);
     struct attr *attr;

--- a/navit/graphics/win32/graphics_win32.c
+++ b/navit/graphics/win32/graphics_win32.c
@@ -589,8 +589,7 @@ static int fullscreen(struct window *win, int on) {
 }
 
 extern void WINAPI SystemIdleTimerReset(void);
-static struct event_timeout *
-event_win32_add_timeout(int timeout, int multi, struct callback *cb);
+static struct event_timeout *event_win32_add_timeout(int timeout, int multi, struct callback *cb);
 
 static void disable_suspend(struct window *win) {
 #ifdef HAVE_API_WIN32_CE
@@ -1036,8 +1035,7 @@ static struct graphics_font_priv *font_new(struct graphics_priv *gr, struct grap
 
 #include "png.h"
 
-static int
-pngdecode(struct graphics_priv *gr, char *name, struct graphics_image_priv *img) {
+static int pngdecode(struct graphics_priv *gr, char *name, struct graphics_image_priv *img) {
     png_struct    *png_ptr = NULL;
     png_info      *info_ptr = NULL;
     png_byte      buf[8];
@@ -1233,8 +1231,7 @@ static void pngscale(struct graphics_image_priv *img, struct graphics_priv *gr, 
 }
 
 
-static void
-pngrender(struct graphics_image_priv *img, struct graphics_priv *gr, int x0, int y0) {
+static void pngrender(struct graphics_image_priv *img, struct graphics_priv *gr, int x0, int y0) {
     if (gr->AlphaBlend && img->hBitmap) {
         HDC hdc;
         HBITMAP oldBitmap;
@@ -1295,8 +1292,7 @@ pngrender(struct graphics_image_priv *img, struct graphics_priv *gr, int x0, int
     }
 }
 
-static int
-xpmdecode(char *name, struct graphics_image_priv *img) {
+static int xpmdecode(char *name, struct graphics_image_priv *img) {
     img->pxpm = Xpm2bmp_new();
     if (Xpm2bmp_load( img->pxpm, name ) != 0) {
         g_free(img->pxpm);
@@ -1371,8 +1367,7 @@ static void draw_image(struct graphics_priv *gr, struct graphics_gc_priv *fg, st
         pngrender(img, gr, p->x, p->y);
 }
 
-static struct graphics_priv *
-graphics_win32_new_helper(struct graphics_methods *meth);
+static struct graphics_priv *graphics_win32_new_helper(struct graphics_methods *meth);
 
 static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound) {
     dbg(lvl_debug, "resize overlay: %x, x: %d, y: %d, w: %d, h: %d, wraparound: %d", gr, p->x, p->y, w, h, wraparound);
@@ -1388,8 +1383,8 @@ static void overlay_resize(struct graphics_priv *gr, struct point *p, int w, int
 }
 
 
-static struct graphics_priv *
-overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound) {
+static struct graphics_priv *overlay_new(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p,
+        int w, int h, int wraparound) {
     struct graphics_priv *this=graphics_win32_new_helper(meth);
     dbg(lvl_debug, "overlay: %x, x: %d, y: %d, w: %d, h: %d, wraparound: %d", this, p->x, p->y, w, h, wraparound);
     this->width  = w;
@@ -1476,8 +1471,7 @@ static struct graphics_methods graphics_methods = {
 };
 
 
-static struct graphics_priv *
-graphics_win32_new_helper(struct graphics_methods *meth) {
+static struct graphics_priv *graphics_win32_new_helper(struct graphics_methods *meth) {
     struct graphics_priv *this_=g_new0(struct graphics_priv,1);
     *meth=graphics_methods;
     this_->mode = -1;
@@ -1517,8 +1511,8 @@ static void bind_late(struct graphics_priv* gra_priv) {
 
 
 
-static struct graphics_priv*
-graphics_win32_new( struct navit *nav, struct graphics_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct graphics_priv* graphics_win32_new( struct navit *nav, struct graphics_methods *meth, struct attr **attrs,
+        struct callback_list *cbl) {
     struct attr *attr;
 
     struct graphics_priv* this_;
@@ -1554,8 +1548,7 @@ graphics_win32_new( struct navit *nav, struct graphics_methods *meth, struct att
 }
 
 
-static void
-event_win32_main_loop_run(void) {
+static void event_win32_main_loop_run(void) {
     MSG msg;
 
     dbg(lvl_debug,"enter");
@@ -1585,14 +1578,12 @@ static void event_win32_main_loop_quit(void) {
     DestroyWindow(g_hwnd);
 }
 
-static struct event_watch *
-event_win32_add_watch(int h, enum event_watch_cond cond, struct callback *cb) {
+static struct event_watch *event_win32_add_watch(int h, enum event_watch_cond cond, struct callback *cb) {
     dbg(lvl_debug,"enter");
     return NULL;
 }
 
-static void
-event_win32_remove_watch(struct event_watch *ev) {
+static void event_win32_remove_watch(struct event_watch *ev) {
     dbg(lvl_debug,"enter");
 }
 
@@ -1632,8 +1623,7 @@ static VOID CALLBACK win32_timer_cb(HWND hwnd, UINT uMsg,
     run_timer(idEvent);
 }
 
-static struct event_timeout *
-event_win32_add_timeout(int timeout, int multi, struct callback *cb) {
+static struct event_timeout *event_win32_add_timeout(int timeout, int multi, struct callback *cb) {
     struct event_timeout *t;
     t = g_new0(struct event_timeout, 1);
     if (!t)
@@ -1646,8 +1636,7 @@ event_win32_add_timeout(int timeout, int multi, struct callback *cb) {
     return t;
 }
 
-static void
-event_win32_remove_timeout(struct event_timeout *to) {
+static void event_win32_remove_timeout(struct event_timeout *to) {
     if (to) {
         GList *l;
         struct event_timeout *t=NULL;
@@ -1669,18 +1658,15 @@ event_win32_remove_timeout(struct event_timeout *to) {
     }
 }
 
-static struct event_idle *
-event_win32_add_idle(int priority, struct callback *cb) {
+static struct event_idle *event_win32_add_idle(int priority, struct callback *cb) {
     return (struct event_idle *)event_win32_add_timeout(1, 1, cb);
 }
 
-static void
-event_win32_remove_idle(struct event_idle *ev) {
+static void event_win32_remove_idle(struct event_idle *ev) {
     event_win32_remove_timeout((struct event_timeout *)ev);
 }
 
-static void
-event_win32_call_callback(struct callback_list *cb) {
+static void event_win32_call_callback(struct callback_list *cb) {
     PostMessage(g_hwnd, WM_USER+2, (WPARAM)cb, (LPARAM)0);
 }
 
@@ -1696,14 +1682,12 @@ static struct event_methods event_win32_methods = {
     event_win32_call_callback,
 };
 
-static struct event_priv *
-event_win32_new(struct event_methods *meth) {
+static struct event_priv *event_win32_new(struct event_methods *meth) {
     *meth=event_win32_methods;
     return NULL;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_graphics("win32", graphics_win32_new);
     plugin_register_category_event("win32", event_win32_new);
 }

--- a/navit/gui.c
+++ b/navit/gui.c
@@ -58,8 +58,7 @@ gui_new(struct attr *parent, struct attr **attrs) {
     return this_;
 }
 
-int
-gui_get_attr(struct gui *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int gui_get_attr(struct gui *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     int ret;
     if (this_->meth.get_attr) {
         ret=this_->meth.get_attr(this_->priv, type, attr);
@@ -74,8 +73,7 @@ gui_get_attr(struct gui *this_, enum attr_type type, struct attr *attr, struct a
 }
 
 
-int
-gui_set_attr(struct gui *this_, struct attr *attr) {
+int gui_set_attr(struct gui *this_, struct attr *attr) {
     int ret=1;
     if (this_->meth.set_attr)
         ret=this_->meth.set_attr(this_->priv, attr);
@@ -84,8 +82,7 @@ gui_set_attr(struct gui *this_, struct attr *attr) {
     return ret != 0;
 }
 
-int
-gui_add_attr(struct gui *this_, struct attr *attr) {
+int gui_add_attr(struct gui *this_, struct attr *attr) {
     int ret=0;
     if (this_->meth.add_attr)
         ret=this_->meth.add_attr(this_->priv, attr);
@@ -134,8 +131,7 @@ gui_datawindow_new(struct gui *gui, const char *name, struct callback *click, st
     return this_;
 }
 
-int
-gui_add_bookmark(struct gui *gui, struct pcoord *c, char *description) {
+int gui_add_bookmark(struct gui *gui, struct pcoord *c, char *description) {
     int ret;
     dbg(lvl_info,"enter");
     if (! gui->meth.add_bookmark)
@@ -146,8 +142,7 @@ gui_add_bookmark(struct gui *gui, struct pcoord *c, char *description) {
     return ret;
 }
 
-int
-gui_set_graphics(struct gui *this_, struct graphics *gra) {
+int gui_set_graphics(struct gui *this_, struct graphics *gra) {
     if (! this_->meth.set_graphics) {
         dbg(lvl_error, "cannot set graphics, method 'set_graphics' not available");
         return 1;
@@ -155,21 +150,18 @@ gui_set_graphics(struct gui *this_, struct graphics *gra) {
     return this_->meth.set_graphics(this_->priv, gra);
 }
 
-void
-gui_disable_suspend(struct gui *this_) {
+void gui_disable_suspend(struct gui *this_) {
     if (this_->meth.disable_suspend)
         this_->meth.disable_suspend(this_->priv);
 }
 
-int
-gui_has_main_loop(struct gui *this_) {
+int gui_has_main_loop(struct gui *this_) {
     if (! this_->meth.run_main_loop)
         return 0;
     return 1;
 }
 
-int
-gui_run_main_loop(struct gui *this_) {
+int gui_run_main_loop(struct gui *this_) {
     if (! gui_has_main_loop(this_))
         return 1;
     return this_->meth.run_main_loop(this_->priv);

--- a/navit/gui/gtk/datawindow.c
+++ b/navit/gui/gtk/datawindow.c
@@ -40,8 +40,7 @@ struct datawindow_priv {
 };
 
 static GValue value;
-static void
-select_row(GtkTreeView *tree, GtkTreePath *path, GtkTreeViewColumn *column, struct datawindow_priv *win) {
+static void select_row(GtkTreeView *tree, GtkTreePath *path, GtkTreeViewColumn *column, struct datawindow_priv *win) {
     char *cols[20];
     GtkTreeIter iter;
     GtkTreeModel *model;
@@ -61,8 +60,7 @@ select_row(GtkTreeView *tree, GtkTreePath *path, GtkTreeViewColumn *column, stru
     callback_call_1(win->click, cols);
 }
 
-static void
-gui_gtk_datawindow_add(struct datawindow_priv *win, struct param_list *param, int count) {
+static void gui_gtk_datawindow_add(struct datawindow_priv *win, struct param_list *param, int count) {
     int i;
     GtkCellRenderer *cell;
     GtkTreeIter iter;
@@ -118,8 +116,7 @@ gui_gtk_datawindow_add(struct datawindow_priv *win, struct param_list *param, in
     }
 }
 
-static void
-gui_gtk_datawindow_mode(struct datawindow_priv *win, int start) {
+static void gui_gtk_datawindow_mode(struct datawindow_priv *win, int start) {
     if (start) {
         if (win && win->treeview) {
             gtk_tree_view_set_model (GTK_TREE_VIEW (win->treeview), NULL);
@@ -127,8 +124,7 @@ gui_gtk_datawindow_mode(struct datawindow_priv *win, int start) {
     }
 }
 
-static gboolean
-gui_gtk_datawindow_delete(GtkWidget *widget, GdkEvent *event, struct datawindow_priv *win) {
+static gboolean gui_gtk_datawindow_delete(GtkWidget *widget, GdkEvent *event, struct datawindow_priv *win) {
     callback_call_0(win->close);
 
     if (win->button) {
@@ -138,8 +134,7 @@ gui_gtk_datawindow_delete(GtkWidget *widget, GdkEvent *event, struct datawindow_
     return FALSE;
 }
 
-void
-gui_gtk_datawindow_destroy(struct datawindow_priv *win) {
+void gui_gtk_datawindow_destroy(struct datawindow_priv *win) {
     if ((!win->gui) || (!win->gui->datawindow)) {
         return;
     }
@@ -151,13 +146,11 @@ gui_gtk_datawindow_destroy(struct datawindow_priv *win) {
     return;
 }
 
-void
-gui_gtk_datawindow_set_button(struct datawindow_priv *this_, GtkWidget *btn) {
+void gui_gtk_datawindow_set_button(struct datawindow_priv *this_, GtkWidget *btn) {
     this_->button = btn;
 }
 
-static gboolean
-keypress(GtkWidget *widget, GdkEventKey *event, struct datawindow_priv *win) {
+static gboolean keypress(GtkWidget *widget, GdkEventKey *event, struct datawindow_priv *win) {
     if (event->type != GDK_KEY_PRESS)
         return FALSE;
     if (event->keyval == GDK_Cancel) {

--- a/navit/gui/gtk/destination.c
+++ b/navit/gui/gtk/destination.c
@@ -195,8 +195,7 @@ static void tree_view_button_release(GtkWidget *widget, GdkEventButton *event, s
     gtk_tree_view_row_activated(GTK_TREE_VIEW(search->treeview), path, column);
 
 }
-static void
-next_focus(struct search_param *search, GtkWidget *widget) {
+static void next_focus(struct search_param *search, GtkWidget *widget) {
     if (widget == search->entry_country)
         gtk_widget_grab_focus(search->entry_city);
     if (widget == search->entry_city)
@@ -316,8 +315,7 @@ static void changed(GtkWidget *widget, struct search_param *search) {
 
 #define MAX_ARGS 8
 
-static void
-parse_xkbd_args (const char *cmd, char **argv) {
+static void parse_xkbd_args (const char *cmd, char **argv) {
     const char *p = cmd;
     char buf[strlen (cmd) + 1], *bufp = buf;
     int nargs = 0;
@@ -370,8 +368,7 @@ parse_xkbd_args (const char *cmd, char **argv) {
 
 int kbd_pid;
 
-static int
-spawn_xkbd (char *xkbd_path, char *xkbd_str) {
+static int spawn_xkbd (char *xkbd_path, char *xkbd_str) {
 #ifdef _WIN32 // AF FIXME for WIN32
 #ifndef F_SETFD
 #define F_SETFD 2

--- a/navit/gui/gtk/gui_gtk_action.c
+++ b/navit/gui/gtk/gui_gtk_action.c
@@ -50,18 +50,15 @@ struct menu_priv {
 
 /* Create callbacks that implement our Actions */
 
-static void
-zoom_in_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void zoom_in_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     navit_zoom_in(gui->nav, 2, NULL);
 }
 
-static void
-zoom_out_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void zoom_out_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     navit_zoom_out(gui->nav, 2, NULL);
 }
 
-static void
-refresh_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void refresh_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     navit_draw(gui->nav);
 }
 
@@ -70,8 +67,7 @@ refresh_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
 void gui_gtk_datawindow_set_button(struct datawindow_priv *this_, GtkWidget *btn);
 void gui_gtk_datawindow_destroy(struct datawindow_priv *win);
 
-static void
-roadbook_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void roadbook_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
 
     if (! gtk_toggle_action_get_active(GTK_TOGGLE_ACTION(w))) {
         gui_gtk_datawindow_destroy(gui->datawindow);
@@ -83,8 +79,7 @@ roadbook_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     }
 }
 
-static void
-autozoom_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void autozoom_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     struct attr autozoom_attr;
 
     autozoom_attr.type = attr_autozoom_active;
@@ -97,8 +92,7 @@ autozoom_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     navit_set_attr(gui->nav, &autozoom_attr);
 }
 
-static void
-cursor_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void cursor_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     struct attr attr;
 
     attr.type=attr_cursor;
@@ -108,8 +102,7 @@ cursor_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     }
 }
 
-static void
-tracking_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void tracking_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     struct attr attr;
 
     attr.type=attr_tracking;
@@ -128,8 +121,7 @@ tracking_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
  *  @return void
  */
 
-static void
-follow_vehicle_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void follow_vehicle_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     struct attr attr;
 
     attr.type=attr_follow_cursor;
@@ -139,8 +131,7 @@ follow_vehicle_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     }
 }
 
-static void
-orient_north_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void orient_north_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     struct attr attr;
 
     attr.type=attr_orientation;
@@ -150,8 +141,7 @@ orient_north_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     }
 }
 
-static void
-window_fullscreen_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void window_fullscreen_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     if(gtk_toggle_action_get_active(GTK_TOGGLE_ACTION(w)))
         gtk_window_fullscreen(GTK_WINDOW(gui->win));
     else
@@ -162,8 +152,7 @@ window_fullscreen_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
 #include "point.h"
 #include "transform.h"
 
-static void
-info_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void info_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     char buffer[512];
     int mw,mh;
     struct coord lt, rb;
@@ -185,23 +174,19 @@ info_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
 }
 
 
-static void
-route_clear_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void route_clear_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     navit_set_destination(gui->nav, NULL, NULL, 0);
 }
 
-static void
-poi_search_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void poi_search_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     gtk_gui_poi(gui->nav);
 }
 
-static void
-destination_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void destination_action(GtkWidget *w, struct gui_priv *gui, void *dummy) {
     destination_address(gui->nav);
 }
 
-static void
-quit_action (GtkWidget *w, struct gui_priv *gui, void *dummy) {
+static void quit_action (GtkWidget *w, struct gui_priv *gui, void *dummy) {
     navit_destroy(gui->nav);
     exit(0);
 }
@@ -357,8 +342,7 @@ static struct {
 static gint n_stock_icons = G_N_ELEMENTS (stock_icons);
 
 
-static void
-register_my_stock_icons (void) {
+static void register_my_stock_icons (void) {
     GtkIconFactory *icon_factory;
     GtkIconSet *icon_set;
     GdkPixbuf *pixbuf;
@@ -447,16 +431,15 @@ static char layout[] =
 	</ui>";
 
 
-static void
-activate(void *dummy, struct menu_priv *menu) {
+static void activate(void *dummy, struct menu_priv *menu) {
     if (menu->cb)
         callback_call_0(menu->cb);
 }
 
 static struct menu_methods menu_methods;
 
-static struct menu_priv *
-add_menu(struct menu_priv *menu, struct menu_methods *meth, char *name, enum menu_type type, struct callback *cb) {
+static struct menu_priv *add_menu(struct menu_priv *menu, struct menu_methods *meth, char *name, enum menu_type type,
+                                  struct callback *cb) {
     struct menu_priv *ret;
     char *dynname;
 
@@ -490,8 +473,7 @@ add_menu(struct menu_priv *menu, struct menu_methods *meth, char *name, enum men
 
 }
 
-static void
-remove_menu(struct menu_priv *item, int recursive) {
+static void remove_menu(struct menu_priv *item, int recursive) {
 
     if (recursive) {
         struct menu_priv *next,*child=item->child;
@@ -514,13 +496,11 @@ remove_menu(struct menu_priv *item, int recursive) {
     g_free(item);
 }
 
-static void
-set_toggle(struct menu_priv *menu, int active) {
+static void set_toggle(struct menu_priv *menu, int active) {
     gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(menu->action), active);
 }
 
-static  int
-get_toggle(struct menu_priv *menu) {
+static  int get_toggle(struct menu_priv *menu) {
     return gtk_toggle_action_get_active(GTK_TOGGLE_ACTION(menu->action));
 }
 
@@ -537,14 +517,12 @@ static struct menu_methods menu_methods = {
 };
 
 
-static void
-popup_deactivate(GtkWidget *widget, struct menu_priv *menu) {
+static void popup_deactivate(GtkWidget *widget, struct menu_priv *menu) {
     g_signal_handler_disconnect(widget, menu->handler_id);
     remove_menu(menu, 1);
 }
 
-static void
-popup_activate(struct menu_priv *menu) {
+static void popup_activate(struct menu_priv *menu) {
 #ifdef _WIN32
     menu->widget=gtk_ui_manager_get_widget(menu->gui->ui_manager, menu->path );
 #endif
@@ -552,8 +530,7 @@ popup_activate(struct menu_priv *menu) {
     menu->handler_id=g_signal_connect(menu->widget, "selection-done", G_CALLBACK(popup_deactivate), menu);
 }
 
-void
-gui_gtk_ui_init(struct gui_priv *this) {
+void gui_gtk_ui_init(struct gui_priv *this) {
     GError *error = NULL;
     struct attr attr;
     GtkToggleAction *toggle_action;
@@ -603,8 +580,8 @@ gui_gtk_ui_init(struct gui_priv *this) {
 
 }
 
-static struct menu_priv *
-gui_gtk_ui_new (struct gui_priv *this, struct menu_methods *meth, char *path, int popup, GtkWidget **widget_ret) {
+static struct menu_priv *gui_gtk_ui_new (struct gui_priv *this, struct menu_methods *meth, char *path, int popup,
+        GtkWidget **widget_ret) {
     struct menu_priv *ret;
     GtkWidget *widget;
 

--- a/navit/gui/gtk/gui_gtk_poi.c
+++ b/navit/gui/gtk/gui_gtk_poi.c
@@ -51,8 +51,7 @@ static struct gtk_poi_search {
     struct navit *nav;
 } gtk_poi_search;
 
-static GdkPixbuf *
-geticon(const char *name) {
+static GdkPixbuf *geticon(const char *name) {
     GdkPixbuf *icon=NULL;
     GError *error=NULL;
     icon=gdk_pixbuf_new_from_file(graphics_icon_path(name),&error);
@@ -63,8 +62,7 @@ geticon(const char *name) {
 }
 
 /** Build the category list model with icons. */
-static GtkTreeModel *
-category_list_model(struct gtk_poi_search *search) {
+static GtkTreeModel *category_list_model(struct gtk_poi_search *search) {
     GtkTreeIter iter;
     gtk_list_store_append(search->store_cat, &iter);
     gtk_list_store_set(search->store_cat, &iter, 0,geticon("pharmacy.png"), 1, _("Pharmacy"), 2, "poi_pharmacy", -1);
@@ -103,8 +101,7 @@ category_list_model(struct gtk_poi_search *search) {
 
 
 /** Construct model of POIs from map information. */
-static GtkTreeModel *
-model_poi (struct gtk_poi_search *search) {
+static GtkTreeModel *model_poi (struct gtk_poi_search *search) {
     GtkTreeIter iter;
     struct map_selection *sel,*selm;
     struct coord coord_item,center;
@@ -187,8 +184,7 @@ model_poi (struct gtk_poi_search *search) {
 }
 
 /** Enable button if there is a selected row. */
-static void
-treeview_poi_changed(GtkWidget *widget, struct gtk_poi_search *search) {
+static void treeview_poi_changed(GtkWidget *widget, struct gtk_poi_search *search) {
     GtkTreePath *path;
     GtkTreeViewColumn *focus_column;
     GtkTreeIter iter;
@@ -203,8 +199,7 @@ treeview_poi_changed(GtkWidget *widget, struct gtk_poi_search *search) {
 }
 
 /** Reload the POI list and disable buttons. */
-static void
-treeview_poi_reload(GtkWidget *widget, struct gtk_poi_search *search) {
+static void treeview_poi_reload(GtkWidget *widget, struct gtk_poi_search *search) {
     GtkTreePath *path;
     GtkTreeViewColumn *focus_column;
     GtkTreeIter iter;
@@ -221,8 +216,7 @@ treeview_poi_reload(GtkWidget *widget, struct gtk_poi_search *search) {
 }
 
 /** Set the selected POI as destination. */
-static void
-button_destination_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
+static void button_destination_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
     GtkTreePath *path;
     GtkTreeViewColumn *focus_column;
     GtkTreeIter iter;
@@ -255,8 +249,7 @@ button_destination_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
 }
 
 /* Show the POI's position in the map. */
-static void
-button_map_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
+static void button_map_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
     GtkTreePath *path;
     GtkTreeViewColumn *focus_column;
     GtkTreeIter iter;
@@ -277,8 +270,7 @@ button_map_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
 }
 
 /** Set POI as the first "visit before". */
-static void
-button_visit_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
+static void button_visit_clicked(GtkWidget *widget, struct gtk_poi_search *search) {
     GtkTreePath *path;
     GtkTreeViewColumn *focus_column;
     GtkTreeIter iter;

--- a/navit/gui/gtk/gui_gtk_statusbar.c
+++ b/navit/gui/gtk/gui_gtk_statusbar.c
@@ -46,14 +46,12 @@ struct statusbar_priv {
 };
 
 #if 0
-static void
-statusbar_destroy(struct statusbar_priv *this) {
+static void statusbar_destroy(struct statusbar_priv *this) {
     g_free(this);
 }
 
-static void
-statusbar_gps_update(struct statusbar_priv *this, int sats, int qual, double lng, double lat, double height,
-                     double direction, double speed) {
+static void statusbar_gps_update(struct statusbar_priv *this, int sats, int qual, double lng, double lat, double height,
+                                 double direction, double speed) {
     char *dirs[]= {_("N"),_("NE"),_("E"),_("SE"),_("S"),_("SW"),_("W"),_("NW"),_("N")};
     char *dir;
     int dir_idx;
@@ -81,8 +79,7 @@ static const char *status_fix2str(int type) {
     }
 }
 
-static void
-statusbar_route_update(struct statusbar_priv *this, struct navit *navit, struct vehicle *v) {
+static void statusbar_route_update(struct statusbar_priv *this, struct navit *navit, struct vehicle *v) {
     struct navigation *nav=NULL;
     struct map *map=NULL;
     struct map_rect *mr=NULL;

--- a/navit/gui/gtk/gui_gtk_window.c
+++ b/navit/gui/gtk/gui_gtk_window.c
@@ -338,8 +338,7 @@ static void gui_gtk_del_menu(struct gui_priv *this, struct gui_menu_info *meninf
     gtk_ui_manager_remove_ui(this->ui_manager, meninfo->merge_id);
 }
 
-static struct gui_menu_info gui_gtk_add_menu(struct gui_priv *this, char *name, char *label, char *path, int submenu,
-        struct action_cb_data *data) {
+static struct gui_menu_info gui_gtk_add_menu(struct gui_priv *this, char *name, char *label, char *path, int submenu, struct action_cb_data *data) {
     struct gui_menu_info meninfo;
     GtkAction *action;
     guint merge_id;
@@ -365,9 +364,7 @@ static void gui_gtk_action_toggled(GtkToggleAction *action, struct action_cb_dat
     navit_draw(data->gui->nav);
 }
 
-static void gui_gtk_add_toggle_menu(struct gui_priv *this, char *name, char *label, char *path,
-                                    struct action_cb_data *data,
-                                    gboolean active) {
+static void gui_gtk_add_toggle_menu(struct gui_priv *this, char *name, char *label, char *path, struct action_cb_data *data, gboolean active) {
     GtkToggleAction *toggle_action;
     guint merge_id;
 
@@ -385,9 +382,7 @@ static void gui_gtk_action_changed(GtkRadioAction *action, GtkRadioAction *curre
     }
 }
 
-static struct gui_menu_info gui_gtk_add_radio_menu(struct gui_priv *this, char *name, char *label, char *path,
-        struct action_cb_data *data,
-        GSList **g) {
+static struct gui_menu_info gui_gtk_add_radio_menu(struct gui_priv *this, char *name, char *label, char *path, struct action_cb_data *data, GSList **g) {
     struct gui_menu_info meninfo;
     GtkRadioAction *radio_action;
     guint merge_id;

--- a/navit/gui/gtk/gui_gtk_window.c
+++ b/navit/gui/gtk/gui_gtk_window.c
@@ -73,8 +73,7 @@
 #define KEY_RIGHT GDK_Right
 #endif
 
-static gboolean
-keypress(GtkWidget *widget, GdkEventKey *event, struct gui_priv *this) {
+static gboolean keypress(GtkWidget *widget, GdkEventKey *event, struct gui_priv *this) {
     int w,h;
     struct transformation *t;
 #ifdef USE_HILDON
@@ -200,8 +199,7 @@ keypress(GtkWidget *widget, GdkEventKey *event, struct gui_priv *this) {
     return TRUE;
 }
 
-static int
-gui_gtk_set_graphics(struct gui_priv *this, struct graphics *gra) {
+static int gui_gtk_set_graphics(struct gui_priv *this, struct graphics *gra) {
     GtkWidget *graphics;
 
     graphics=graphics_get_data(gra, "gtk_widget");
@@ -217,8 +215,7 @@ gui_gtk_set_graphics(struct gui_priv *this, struct graphics *gra) {
     return 0;
 }
 
-static void
-gui_gtk_route_callback(struct gui_priv *gui) {
+static void gui_gtk_route_callback(struct gui_priv *gui) {
     struct attr route_attr;
     GtkAction *roadbookAction=gtk_ui_manager_get_action (gui->ui_manager,"/ui/ToolBar/ToolItems/Roadbook");
     if (roadbookAction) {
@@ -235,16 +232,14 @@ gui_gtk_route_callback(struct gui_priv *gui) {
     }
 }
 
-static void
-gui_gtk_add_bookmark_do(struct gui_priv *gui) {
+static void gui_gtk_add_bookmark_do(struct gui_priv *gui) {
     struct attr attr;
     navit_get_attr(gui->nav, attr_bookmarks, &attr, NULL);
     bookmarks_add_bookmark(attr.u.bookmarks, &gui->dialog_coord, gtk_entry_get_text(GTK_ENTRY(gui->dialog_entry)));
     gtk_widget_destroy(gui->dialog_win);
 }
 
-static int
-gui_gtk_add_bookmark(struct gui_priv *gui, struct pcoord *c, char *description) {
+static int gui_gtk_add_bookmark(struct gui_priv *gui, struct pcoord *c, char *description) {
     GtkWidget *button_ok,*button_cancel,*label,*vbox,*hbox;
 
     gui->dialog_coord=*c;
@@ -287,8 +282,7 @@ struct gui_methods gui_gtk_methods = {
     gui_gtk_add_bookmark,
 };
 
-static gboolean
-gui_gtk_delete(GtkWidget *widget, GdkEvent *event, struct navit *nav) {
+static gboolean gui_gtk_delete(GtkWidget *widget, GdkEvent *event, struct navit *nav) {
     /* FIXME remove attr_navit callback */
     navit_destroy(nav);
     exit(0);
@@ -296,8 +290,7 @@ gui_gtk_delete(GtkWidget *widget, GdkEvent *event, struct navit *nav) {
     return TRUE;
 }
 
-static void
-gui_gtk_toggle_init(struct gui_priv *this) {
+static void gui_gtk_toggle_init(struct gui_priv *this) {
     struct attr attr;
     GtkToggleAction *toggle_action;
 
@@ -326,8 +319,7 @@ struct action_cb_data {
     struct attr attr;
 };
 
-static void
-gui_gtk_action_activate(GtkAction *action, struct action_cb_data *data) {
+static void gui_gtk_action_activate(GtkAction *action, struct action_cb_data *data) {
     if(data->attr.type == attr_destination) {
         char * label;
         g_object_get(G_OBJECT(action), "label", &label,NULL);
@@ -341,14 +333,13 @@ struct gui_menu_info {
     GtkAction *action;
 };
 
-static void
-gui_gtk_del_menu(struct gui_priv *this, struct gui_menu_info *meninfo) {
+static void gui_gtk_del_menu(struct gui_priv *this, struct gui_menu_info *meninfo) {
     gtk_action_group_remove_action(this->dyn_group, meninfo->action);
     gtk_ui_manager_remove_ui(this->ui_manager, meninfo->merge_id);
 }
 
-static struct gui_menu_info
-gui_gtk_add_menu(struct gui_priv *this, char *name, char *label, char *path, int submenu, struct action_cb_data *data) {
+static struct gui_menu_info gui_gtk_add_menu(struct gui_priv *this, char *name, char *label, char *path, int submenu,
+        struct action_cb_data *data) {
     struct gui_menu_info meninfo;
     GtkAction *action;
     guint merge_id;
@@ -366,8 +357,7 @@ gui_gtk_add_menu(struct gui_priv *this, char *name, char *label, char *path, int
     return meninfo;
 }
 
-static void
-gui_gtk_action_toggled(GtkToggleAction *action, struct action_cb_data *data) {
+static void gui_gtk_action_toggled(GtkToggleAction *action, struct action_cb_data *data) {
     struct attr active;
     active.type=attr_active;
     active.u.num=gtk_toggle_action_get_active(action);
@@ -375,9 +365,9 @@ gui_gtk_action_toggled(GtkToggleAction *action, struct action_cb_data *data) {
     navit_draw(data->gui->nav);
 }
 
-static void
-gui_gtk_add_toggle_menu(struct gui_priv *this, char *name, char *label, char *path, struct action_cb_data *data,
-                        gboolean active) {
+static void gui_gtk_add_toggle_menu(struct gui_priv *this, char *name, char *label, char *path,
+                                    struct action_cb_data *data,
+                                    gboolean active) {
     GtkToggleAction *toggle_action;
     guint merge_id;
 
@@ -389,16 +379,15 @@ gui_gtk_add_toggle_menu(struct gui_priv *this, char *name, char *label, char *pa
     gtk_ui_manager_add_ui(this->ui_manager, merge_id, path, name, name, GTK_UI_MANAGER_MENUITEM, FALSE);
 }
 
-static void
-gui_gtk_action_changed(GtkRadioAction *action, GtkRadioAction *current, struct action_cb_data *data) {
+static void gui_gtk_action_changed(GtkRadioAction *action, GtkRadioAction *current, struct action_cb_data *data) {
     if (action == current) {
         navit_set_attr(data->gui->nav, &data->attr);
     }
 }
 
-static struct gui_menu_info
-gui_gtk_add_radio_menu(struct gui_priv *this, char *name, char *label, char *path, struct action_cb_data *data,
-                       GSList **g) {
+static struct gui_menu_info gui_gtk_add_radio_menu(struct gui_priv *this, char *name, char *label, char *path,
+        struct action_cb_data *data,
+        GSList **g) {
     struct gui_menu_info meninfo;
     GtkRadioAction *radio_action;
     guint merge_id;
@@ -416,8 +405,7 @@ gui_gtk_add_radio_menu(struct gui_priv *this, char *name, char *label, char *pat
     return meninfo;
 }
 
-static void
-gui_gtk_layouts_init(struct gui_priv *this) {
+static void gui_gtk_layouts_init(struct gui_priv *this) {
     struct attr_iter *iter;
     struct attr attr;
     struct action_cb_data *data;
@@ -438,8 +426,7 @@ gui_gtk_layouts_init(struct gui_priv *this) {
     navit_attr_iter_destroy(iter);
 }
 
-static void
-gui_gtk_projections_init(struct gui_priv *this) {
+static void gui_gtk_projections_init(struct gui_priv *this) {
     struct action_cb_data *data;
 
     data=g_new(struct action_cb_data, 1);
@@ -457,8 +444,7 @@ gui_gtk_projections_init(struct gui_priv *this) {
                            &this->projection_group);
 }
 
-static void
-gui_gtk_vehicles_update(struct gui_priv *this) {
+static void gui_gtk_vehicles_update(struct gui_priv *this) {
     struct attr_iter *iter;
     struct attr attr,vattr;
     struct action_cb_data *data;
@@ -496,14 +482,12 @@ gui_gtk_vehicles_update(struct gui_priv *this) {
     navit_attr_iter_destroy(iter);
 }
 
-static void
-gui_gtk_vehicles_init(struct gui_priv *this) {
+static void gui_gtk_vehicles_init(struct gui_priv *this) {
     navit_add_callback(this->nav, callback_new_attr_1(callback_cast(gui_gtk_vehicles_update), attr_vehicle, this));
     gui_gtk_vehicles_update(this);
 }
 
-static void
-gui_gtk_maps_init(struct gui_priv *this) {
+static void gui_gtk_maps_init(struct gui_priv *this) {
     struct attr_iter *iter;
     struct attr attr,active,type,data;
     struct action_cb_data *cb_data;
@@ -532,8 +516,7 @@ gui_gtk_maps_init(struct gui_priv *this) {
 
 }
 
-static void
-gui_gtk_destinations_update(struct gui_priv *this) {
+static void gui_gtk_destinations_update(struct gui_priv *this) {
     GList *curr;
     struct attr attr;
     struct action_cb_data *data;
@@ -581,14 +564,12 @@ gui_gtk_destinations_update(struct gui_priv *this) {
     }
 }
 
-static void
-gui_gtk_destinations_init(struct gui_priv *this) {
+static void gui_gtk_destinations_init(struct gui_priv *this) {
     navit_add_callback(this->nav, callback_new_attr_1(callback_cast(gui_gtk_destinations_update), attr_destination, this));
     gui_gtk_destinations_update(this);
 }
 
-static void
-gui_gtk_bookmarks_update(struct gui_priv *this) {
+static void gui_gtk_bookmarks_update(struct gui_priv *this) {
     GList *curr;
     struct attr attr;
     struct action_cb_data *data;
@@ -658,8 +639,7 @@ gui_gtk_bookmarks_update(struct gui_priv *this) {
     }
 }
 
-static void
-gui_gtk_bookmarks_init(struct gui_priv *this) {
+static void gui_gtk_bookmarks_init(struct gui_priv *this) {
     struct attr attr;
     navit_get_attr(this->nav, attr_bookmarks, &attr, NULL);
     bookmarks_add_callback(attr.u.bookmarks, callback_new_attr_1(callback_cast(gui_gtk_bookmarks_update), attr_bookmark_map,
@@ -667,8 +647,7 @@ gui_gtk_bookmarks_init(struct gui_priv *this) {
     gui_gtk_bookmarks_update(this);
 }
 
-static void
-gui_gtk_init(struct gui_priv *this, struct navit *nav) {
+static void gui_gtk_init(struct gui_priv *this, struct navit *nav) {
 
     struct attr route_attr;
 
@@ -689,8 +668,7 @@ gui_gtk_init(struct gui_priv *this, struct navit *nav) {
     gui_gtk_route_callback(this); //Set initial state
 }
 
-static struct gui_priv *
-gui_gtk_new(struct navit *nav, struct gui_methods *meth, struct attr **attrs, struct gui *gui) {
+static struct gui_priv *gui_gtk_new(struct navit *nav, struct gui_methods *meth, struct attr **attrs, struct gui *gui) {
     struct gui_priv *this;
     int w=792, h=547;
     char *cp = getenv("NAVIT_XID");
@@ -782,8 +760,7 @@ gui_gtk_new(struct navit *nav, struct gui_methods *meth, struct attr **attrs, st
 static int gtk_argc;
 static char **gtk_argv= {NULL};
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     gtk_init(&gtk_argc, &gtk_argv);
     gtk_set_locale();
 #ifdef HAVE_API_WIN32

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -127,8 +127,7 @@ static int gui_internal_is_active_vehicle(struct gui_priv *this, struct vehicle 
  *
  * @return image_struct Ptr to scaled image struct or NULL if not scaled or found
  */
-static struct graphics_image *
-image_new_scaled(struct gui_priv *this, const char *name, int w, int h) {
+static struct graphics_image *image_new_scaled(struct gui_priv *this, const char *name, int w, int h) {
     struct graphics_image *ret=NULL;
     char *full_path=NULL;
     full_path=graphics_icon_path(name);
@@ -145,8 +144,7 @@ image_new_scaled(struct gui_priv *this, const char *name, int w, int h) {
 }
 
 #if 0
-static struct graphics_image *
-image_new_o(struct gui_priv *this, char *name) {
+static struct graphics_image *image_new_o(struct gui_priv *this, char *name) {
     return image_new_scaled(this, name, -1, -1);
 }
 #endif
@@ -193,8 +191,7 @@ image_new_l(struct gui_priv *this, const char *name) {
 
 
 
-static int
-gui_internal_button_attr_update(struct gui_priv *this, struct widget *w) {
+static int gui_internal_button_attr_update(struct gui_priv *this, struct widget *w) {
     struct widget *wi;
     int is_on=0;
     struct attr curr;
@@ -224,13 +221,11 @@ gui_internal_button_attr_update(struct gui_priv *this, struct widget *w) {
     return 0;
 }
 
-static void
-gui_internal_button_attr_callback(struct gui_priv *this, struct widget *w) {
+static void gui_internal_button_attr_callback(struct gui_priv *this, struct widget *w) {
     if (gui_internal_button_attr_update(this, w))
         gui_internal_widget_render(this, w);
 }
-static void
-gui_internal_button_attr_pressed(struct gui_priv *this, struct widget *w, void *data) {
+static void gui_internal_button_attr_pressed(struct gui_priv *this, struct widget *w, void *data) {
     if (w->is_on)
         w->set_attr(w->instance, &w->off);
     else
@@ -402,8 +397,7 @@ static void gui_internal_call_highlighted(struct gui_priv *this) {
     this->highlighted->func(this, this->highlighted, this->highlighted->data);
 }
 
-void
-gui_internal_say(struct gui_priv *this, struct widget *w, int questionmark) {
+void gui_internal_say(struct gui_priv *this, struct widget *w, int questionmark) {
     char *text=w->speech;
     if (! this->speech)
         return;
@@ -422,20 +416,17 @@ gui_internal_say(struct gui_priv *this, struct widget *w, int questionmark) {
 
 
 
-void
-gui_internal_back(struct gui_priv *this, struct widget *w, void *data) {
+void gui_internal_back(struct gui_priv *this, struct widget *w, void *data) {
     gui_internal_prune_menu_count(this, 1, 1);
 }
 
-void
-gui_internal_cmd_return(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_return(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_prune_menu(this, wm->data);
 }
 
 
 
-void
-gui_internal_cmd_main_menu(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_main_menu(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w=this->root.children->data;
     if (w && w->menu_data && w->menu_data->href && !strcmp(w->menu_data->href,"#Main Menu"))
         gui_internal_prune_menu(this, w);
@@ -491,8 +482,7 @@ gui_internal_time_help(struct gui_priv *this) {
  *
  * @author Steve Singer <ssinger_pg@sympatico.ca> (09/2008)
  */
-void
-gui_internal_apply_config(struct gui_priv *this) {
+void gui_internal_apply_config(struct gui_priv *this) {
     struct gui_config_settings *  current_config=0;
 
     dbg(lvl_debug,"w=%d h=%d", this->root.w, this->root.h);
@@ -555,8 +545,7 @@ gui_internal_apply_config(struct gui_priv *this) {
 
 
 
-static void
-gui_internal_cmd_set_destination(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_set_destination(struct gui_priv *this, struct widget *wm, void *data) {
     char *name=data;
     dbg(lvl_info,"c=%d:0x%x,0x%x", wm->c.pro, wm->c.x, wm->c.y);
     navit_set_destination(this->nav, &wm->c, name, 1);
@@ -571,8 +560,7 @@ gui_internal_cmd_set_destination(struct gui_priv *this, struct widget *wm, void 
     gui_internal_prune_menu(this, NULL);
 }
 
-static void
-gui_internal_cmd_insert_destination_do(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_insert_destination_do(struct gui_priv *this, struct widget *wm, void *data) {
     char *name=data;
     int dstcount=navit_get_destination_count(this->nav)+1;
     int pos,i;
@@ -609,9 +597,8 @@ gui_internal_cmd_insert_destination_do(struct gui_priv *this, struct widget *wm,
  * @param cmd Callback function which will be called on item selection
  * @param data data argument to be passed to the callback function
  */
-void
-gui_internal_select_waypoint(struct gui_priv *this, const char *title, const char *hint, struct widget *wm_,
-                             void(*cmd)(struct gui_priv *priv, struct widget *widget, void *data),void *data) {
+void gui_internal_select_waypoint(struct gui_priv *this, const char *title, const char *hint, struct widget *wm_,
+                                  void(*cmd)(struct gui_priv *priv, struct widget *widget, void *data),void *data) {
     struct widget *wb,*w,*wtable,*row,*wc;
     struct map *map;
     struct map_rect *mr;
@@ -667,16 +654,14 @@ gui_internal_select_waypoint(struct gui_priv *this, const char *title, const cha
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd_insert_destination(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_insert_destination(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_select_waypoint(this, data, _("Select waypoint to insert the new one before"), wm,
                                  gui_internal_cmd_insert_destination_do, data);
 }
 
 
 
-static void
-gui_internal_cmd_set_position(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_set_position(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr v;
     if(data) {
         v.type=attr_vehicle;
@@ -696,8 +681,7 @@ gui_internal_cmd_set_position(struct gui_priv *this, struct widget *wm, void *da
  * @brief Generic notification function for Editable widgets to call Another widget notification function when Enter is pressed in editable field.
  * The Editable widget should have data member pointing to the Another widget.
  */
-void
-gui_internal_call_linked_on_finish(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_call_linked_on_finish(struct gui_priv *this, struct widget *wm, void *data) {
     if (wm->reason==gui_internal_reason_keypress_finish && data) {
         struct widget *w=data;
         if(w->func)
@@ -711,8 +695,7 @@ struct widget * gui_internal_keyboard(struct gui_priv *this, int mode);
 struct widget * gui_internal_keyboard_show_native(struct gui_priv *this, struct widget *w, int mode, char *lang);
 
 
-static void
-gui_internal_cmd_delete_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_delete_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
     GList *l;
     navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL);
@@ -727,15 +710,13 @@ gui_internal_cmd_delete_bookmark(struct gui_priv *this, struct widget *wm, void 
 /**
  *  Get a utf-8 string, return the same prepared for case insensitive search. Result should be g_free()d after use.
  */
-char *
-removecase(char *s) {
+char *removecase(char *s) {
     char *r;
     r=linguistics_casefold(s);
     return r;
 }
 
-static void
-gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *wm, void *data) {
     if (wm->item.type != type_none) {
         enum item_type type;
         if (wm->item.type < type_line)
@@ -752,8 +733,7 @@ gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *wm, void *dat
 }
 
 
-static void
-gui_internal_cmd_view_attribute_details(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_view_attribute_details(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb;
     struct map_rect *mr;
     struct item *item;
@@ -798,8 +778,7 @@ gui_internal_cmd_view_attribute_details(struct gui_priv *this, struct widget *wm
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd_view_attributes(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_view_attributes(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb;
     struct map_rect *mr;
     struct item *item;
@@ -846,8 +825,7 @@ gui_internal_cmd_view_attributes(struct gui_priv *this, struct widget *wm, void 
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd_view_in_browser(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_view_in_browser(struct gui_priv *this, struct widget *wm, void *data) {
     struct map_rect *mr;
     struct item *item;
     struct attr attr;
@@ -886,8 +864,7 @@ gui_internal_cmd_view_in_browser(struct gui_priv *this, struct widget *wm, void 
  * @param wm called widget.
  * @param data event data (pointer to the table widget containing results, or NULL to clean the result map without adding any new data).
  */
-static void
-gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w;
     struct mapset *ms;
     struct map *map;
@@ -1009,15 +986,13 @@ gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget *wm, void *
  * @param wm called widget.
  * @param data event data
  */
-static void
-gui_internal_cmd_results_map_clean(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_results_map_clean(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_cmd_results_to_map(this,wm,NULL);
     gui_internal_prune_menu(this, NULL);
     navit_draw(this->nav);
 }
 
-static void
-gui_internal_cmd_delete_waypoint(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_delete_waypoint(struct gui_priv *this, struct widget *wm, void *data) {
     int dstcount=navit_get_destination_count(this->nav);
     int i;
     struct map_rect *mr;
@@ -1074,9 +1049,9 @@ gui_internal_cmd_delete_waypoint(struct gui_priv *this, struct widget *wm, void 
  * 2048: "Show search results on the map"
  * TODO define constants for these values
  */
-void
-gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, struct coord_geo *g_in, struct widget *wm,
-                             const char *name, int flags) {
+void gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, struct coord_geo *g_in,
+                                  struct widget *wm,
+                                  const char *name, int flags) {
     struct widget *wb,*w,*wtable,*row,*wc,*wbc,*wclosest=NULL;
     struct coord_geo g;
     struct pcoord pc;
@@ -1378,8 +1353,7 @@ gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, struct
 		9 Item from the POI list
 */
 
-void
-gui_internal_cmd_position(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_position(struct gui_priv *this, struct widget *wm, void *data) {
     int flags;
 
     if(!data)
@@ -1441,8 +1415,7 @@ gui_internal_cmd_position(struct gui_priv *this, struct widget *wm, void *data) 
   * The "Bookmarks" section of the OSD
   *
   */
-void
-gui_internal_cmd_bookmarks(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_bookmarks(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr attr,mattr;
     struct item *item;
     char *label_full,*prefix=0;
@@ -1592,20 +1565,15 @@ gui_internal_cmd_bookmarks(struct gui_priv *this, struct widget *wm, void *data)
 
 
 
-static void
-gui_internal_keynav_highlight_next(struct gui_priv *this, int dx, int dy, int rotary);
+static void gui_internal_keynav_highlight_next(struct gui_priv *this, int dx, int dy, int rotary);
 
-static int
-gui_internal_keynav_find_next(struct widget *wi, struct widget *current_highlight, struct widget **result);
+static int gui_internal_keynav_find_next(struct widget *wi, struct widget *current_highlight, struct widget **result);
 
-static int
-gui_internal_keynav_find_prev(struct widget *wi, struct widget *current_highlight, struct widget **result);
+static int gui_internal_keynav_find_prev(struct widget *wi, struct widget *current_highlight, struct widget **result);
 
-static struct widget*
-gui_internal_keynav_find_next_sensitive_child(struct widget *wi);
+static struct widget* gui_internal_keynav_find_next_sensitive_child(struct widget *wi);
 
-void
-gui_internal_keypress_do(struct gui_priv *this, char *key) {
+void gui_internal_keypress_do(struct gui_priv *this, char *key) {
     struct widget *wi,*menu,*search_list;
     int len=0;
     char *text=NULL;
@@ -1665,8 +1633,7 @@ gui_internal_keypress_do(struct gui_priv *this, char *key) {
 
 
 
-char *
-gui_internal_cmd_match_expand(char *pattern, struct attr **in) {
+char *gui_internal_cmd_match_expand(char *pattern, struct attr **in) {
     char p,*ret=g_strdup(pattern),*r=ret,*a;
     int len;
     while ((p=*pattern++)) {
@@ -1693,8 +1660,7 @@ gui_internal_cmd_match_expand(char *pattern, struct attr **in) {
     return ret;
 }
 
-static int
-gui_internal_match(const char *pattern, const char *string) {
+static int gui_internal_match(const char *pattern, const char *string) {
     char p,s;
     while ((p=*pattern++)) {
         switch (p) {
@@ -1715,8 +1681,7 @@ gui_internal_match(const char *pattern, const char *string) {
     return 1;
 }
 
-int
-gui_internal_set(char *remove, char *add) {
+int gui_internal_set(char *remove, char *add) {
     char *gui_file=g_strjoin(NULL, navit_get_user_data_directory(TRUE), "/gui_internal.txt", NULL);
     char *gui_file_new=g_strjoin(NULL, navit_get_user_data_directory(TRUE), "/gui_internal_new.txt", NULL);
     FILE *fo=fopen(gui_file_new,"w");
@@ -1750,14 +1715,12 @@ gui_internal_set(char *remove, char *add) {
 
 
 
-static void
-gui_internal_window_closed(struct gui_priv *this) {
+static void gui_internal_window_closed(struct gui_priv *this) {
     gui_internal_cmd2_quit(this, NULL, NULL, NULL, NULL);
 }
 
 
-static void
-gui_internal_cmd_map_download_do(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_map_download_do(struct gui_priv *this, struct widget *wm, void *data) {
     char *text=g_strdup_printf(_("Download %s"),wm->name);
     struct widget *w, *wb;
     struct map *map=data;
@@ -1795,8 +1758,7 @@ gui_internal_cmd_map_download_do(struct gui_priv *this, struct widget *wm, void 
     gui_internal_menu_render(this);
 }
 
-void
-gui_internal_cmd_map_download(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_map_download(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr on, off, download_enabled, download_disabled;
     struct widget *w,*wb,*wma;
     struct map *map=data;
@@ -1882,14 +1844,12 @@ gui_internal_cmd_map_download(struct gui_priv *this, struct widget *wm, void *da
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd_set_active_vehicle(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_set_active_vehicle(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr vehicle = {attr_vehicle,{wm->data}};
     navit_set_attr(this->nav, &vehicle);
 }
 
-static void
-gui_internal_cmd_show_satellite_status(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_show_satellite_status(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb,*row;
     struct attr attr,sat_attr;
     struct vehicle *v=wm->data;
@@ -1925,8 +1885,7 @@ gui_internal_cmd_show_satellite_status(struct gui_priv *this, struct widget *wm,
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd_show_nmea_data(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_show_nmea_data(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb;
     struct attr attr;
     struct vehicle *v=wm->data;
@@ -1954,9 +1913,8 @@ struct vehicle_and_profilename {
  *
  * @return true if the vehicle is active, false otherwise.
  */
-static int
-gui_internal_is_active_vehicle(struct gui_priv *this, struct vehicle
-                               *vehicle) {
+static int gui_internal_is_active_vehicle(struct gui_priv *this, struct vehicle
+        *vehicle) {
     struct attr active_vehicle;
 
     if (!navit_get_attr(this->nav, attr_vehicle, &active_vehicle, NULL))
@@ -1965,8 +1923,7 @@ gui_internal_is_active_vehicle(struct gui_priv *this, struct vehicle
     return active_vehicle.u.vehicle == vehicle;
 }
 
-static void
-save_vehicle_xml(struct vehicle *v) {
+static void save_vehicle_xml(struct vehicle *v) {
     struct attr attr;
     struct attr_iter *iter=vehicle_attr_iter_new();
     int childs=0;
@@ -1994,9 +1951,8 @@ save_vehicle_xml(struct vehicle *v) {
  *
  * @see gui_internal_add_vehicle_profile
  */
-static void
-gui_internal_cmd_set_active_profile(struct gui_priv *this, struct
-                                    widget *wm, void *data) {
+static void gui_internal_cmd_set_active_profile(struct gui_priv *this, struct
+        widget *wm, void *data) {
     struct vehicle_and_profilename *vapn = data;
     struct vehicle *v = vapn->vehicle;
     char *profilename = vapn->profilename;
@@ -2044,9 +2000,8 @@ gui_internal_cmd_set_active_profile(struct gui_priv *this, struct
  * Adds the vehicle profile to the GUI, allowing the user to pick a
  * profile for the currently selected vehicle.
  */
-static void
-gui_internal_add_vehicle_profile(struct gui_priv *this, struct widget
-                                 *parent, struct vehicle *v, struct vehicleprofile *profile) {
+static void gui_internal_add_vehicle_profile(struct gui_priv *this, struct widget
+        *parent, struct vehicle *v, struct vehicleprofile *profile) {
     // Just here to show up in the translation file, nice and close to
     // where the translations are actually used.
     struct attr profile_attr;
@@ -2100,8 +2055,7 @@ gui_internal_add_vehicle_profile(struct gui_priv *this, struct widget
     free(label);
 }
 
-void
-gui_internal_menu_vehicle_settings(struct gui_priv *this, struct vehicle *v, char *name) {
+void gui_internal_menu_vehicle_settings(struct gui_priv *this, struct vehicle *v, char *name) {
     struct widget *w,*wb,*row;
     struct attr attr;
     struct vehicleprofile *profile = NULL;
@@ -2153,8 +2107,7 @@ gui_internal_menu_vehicle_settings(struct gui_priv *this, struct vehicle *v, cha
     gui_internal_menu_render(this);
 }
 
-void
-gui_internal_cmd_vehicle_settings(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_vehicle_settings(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_menu_vehicle_settings(this, wm->data, wm->text);
 }
 
@@ -2182,15 +2135,13 @@ static void gui_internal_motion(void *data, struct point *p) {
         this->motion_timeout_event=event_add_timeout(30,0, this->motion_timeout_callback);
 }
 
-void
-gui_internal_evaluate(struct gui_priv *this, const char *command) {
+void gui_internal_evaluate(struct gui_priv *this, const char *command) {
     if (command)
         command_evaluate(&this->self, command);
 }
 
 
-void
-gui_internal_enter(struct gui_priv *this, int ignore) {
+void gui_internal_enter(struct gui_priv *this, int ignore) {
     struct graphics *gra=this->gra;
     if (ignore != -1)
         this->ignore_button=ignore;
@@ -2202,13 +2153,11 @@ gui_internal_enter(struct gui_priv *this, int ignore) {
     this->root.background=this->background;
 }
 
-void
-gui_internal_leave(struct gui_priv *this) {
+void gui_internal_leave(struct gui_priv *this) {
     graphics_draw_mode(this->gra, draw_mode_end);
 }
 
-void
-gui_internal_set_click_coord(struct gui_priv *this, struct point *p) {
+void gui_internal_set_click_coord(struct gui_priv *this, struct point *p) {
     struct coord c;
     struct coord_geo g;
     struct attr attr;
@@ -2229,8 +2178,7 @@ gui_internal_set_click_coord(struct gui_priv *this, struct point *p) {
     }
 }
 
-static void
-gui_internal_set_position_coord(struct gui_priv *this) {
+static void gui_internal_set_position_coord(struct gui_priv *this) {
     struct transformation *trans;
     struct attr attr,attrp;
     struct coord c;
@@ -2248,14 +2196,12 @@ gui_internal_set_position_coord(struct gui_priv *this) {
     }
 }
 
-void
-gui_internal_enter_setup(struct gui_priv *this) {
+void gui_internal_enter_setup(struct gui_priv *this) {
     if (!this->mouse_button_clicked_on_map)
         gui_internal_set_position_coord(this);
 }
 
-void
-gui_internal_cmd_menu(struct gui_priv *this, int ignore, char *href) {
+void gui_internal_cmd_menu(struct gui_priv *this, int ignore, char *href) {
     dbg(lvl_debug,"enter");
     gui_internal_enter(this, ignore);
     gui_internal_enter_setup(this);
@@ -2268,8 +2214,7 @@ gui_internal_cmd_menu(struct gui_priv *this, int ignore, char *href) {
 
 
 
-static void
-gui_internal_cmd_log_do(struct gui_priv *this, struct widget *widget) {
+static void gui_internal_cmd_log_do(struct gui_priv *this, struct widget *widget) {
     if (widget->text && strlen(widget->text)) {
         if (this->position_coord_geo)
             navit_textfile_debug_log_at(this->nav, &this->vehiclep, "type=log_entry label=\"%s\"",widget->text);
@@ -2282,14 +2227,12 @@ gui_internal_cmd_log_do(struct gui_priv *this, struct widget *widget) {
     gui_internal_check_exit(this);
 }
 
-void
-gui_internal_cmd_log_clicked(struct gui_priv *this, struct widget *widget, void *data) {
+void gui_internal_cmd_log_clicked(struct gui_priv *this, struct widget *widget, void *data) {
     gui_internal_cmd_log_do(this, widget->data);
 }
 
 
-void
-gui_internal_check_exit(struct gui_priv *this) {
+void gui_internal_check_exit(struct gui_priv *this) {
     struct graphics *gra=this->gra;
     if (! this->root.children) {
         gui_internal_search_idle_end(this);
@@ -2304,8 +2247,7 @@ gui_internal_check_exit(struct gui_priv *this) {
     }
 }
 
-static int
-gui_internal_get_attr(struct gui_priv *this, enum attr_type type, struct attr *attr) {
+static int gui_internal_get_attr(struct gui_priv *this, enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_active:
         attr->u.num=this->root.children != NULL;
@@ -2339,8 +2281,7 @@ gui_internal_get_attr(struct gui_priv *this, enum attr_type type, struct attr *a
     return 1;
 }
 
-static int
-gui_internal_add_attr(struct gui_priv *this, struct attr *attr) {
+static int gui_internal_add_attr(struct gui_priv *this, struct attr *attr) {
     switch (attr->type) {
     case attr_xml_text:
         g_free(this->html_text);
@@ -2351,8 +2292,7 @@ gui_internal_add_attr(struct gui_priv *this, struct attr *attr) {
     }
 }
 
-static int
-gui_internal_set_attr(struct gui_priv *this, struct attr *attr) {
+static int gui_internal_set_attr(struct gui_priv *this, struct attr *attr) {
     switch (attr->type) {
     case attr_fullscreen:
         if ((this->fullscreen > 0) != (attr->u.num > 0)) {
@@ -2407,8 +2347,7 @@ static void gui_internal_dbus_signal(struct gui_priv *this, struct point *p) {
  *
  * @author Martin Bruns (05/2012), mdankov
  */
-static int
-gui_internal_coordinate_parse(char *s, char plus, char minus, double *x) {
+static int gui_internal_coordinate_parse(char *s, char plus, char minus, double *x) {
     int sign=0;
     char *degree, *minute, *second;
     double tmp;
@@ -2462,8 +2401,7 @@ gui_internal_coordinate_parse(char *s, char plus, char minus, double *x) {
 //# Comment:
 //# Authors: Martin Bruns (05/2012)
 //##############################################################################################################
-static void
-gui_internal_cmd_enter_coord_do(struct gui_priv *this, struct widget *widget) {
+static void gui_internal_cmd_enter_coord_do(struct gui_priv *this, struct widget *widget) {
     char *lat, *lng;
     char *widgettext;
     double latitude, longitude;
@@ -2498,8 +2436,7 @@ gui_internal_cmd_enter_coord_do(struct gui_priv *this, struct widget *widget) {
 //# Comment:
 //# Authors: Martin Bruns (05/2012)
 //##############################################################################################################
-void
-gui_internal_cmd_enter_coord_clicked(struct gui_priv *this, struct widget *widget, void *data) {
+void gui_internal_cmd_enter_coord_clicked(struct gui_priv *this, struct widget *widget, void *data) {
     dbg(lvl_debug,"entered");
     gui_internal_cmd_enter_coord_do(this, widget->data);
 }
@@ -2572,8 +2509,7 @@ static void gui_internal_button(void *data, int pressed, int button, struct poin
     }
 }
 
-static void
-gui_internal_setup(struct gui_priv *this) {
+static void gui_internal_setup(struct gui_priv *this) {
     struct color cbh= {0x9fff,0x9fff,0x9fff,0xffff};
     struct color cf= {0xbfff,0xbfff,0xbfff,0xffff};
     struct graphics *gra=this->gra;
@@ -2640,8 +2576,7 @@ static void gui_internal_resize(void *data, int w, int h) {
     }
 }
 
-static void
-gui_internal_keynav_point(struct widget *w, int dx, int dy, struct point *p) {
+static void gui_internal_keynav_point(struct widget *w, int dx, int dy, struct point *p) {
     p->x=w->p.x+w->w/2;
     p->y=w->p.y+w->h/2;
     if (dx < 0)
@@ -2654,8 +2589,7 @@ gui_internal_keynav_point(struct widget *w, int dx, int dy, struct point *p) {
         p->y=w->p.y+w->h;
 }
 
-static struct widget*
-gui_internal_keynav_find_next_sensitive_child(struct widget *wi) {
+static struct widget* gui_internal_keynav_find_next_sensitive_child(struct widget *wi) {
     GList *l=wi->children;
     if (wi->state & STATE_OFFSCREEN)
         return NULL;
@@ -2670,8 +2604,7 @@ gui_internal_keynav_find_next_sensitive_child(struct widget *wi) {
     return NULL;
 }
 
-static int
-gui_internal_keynav_find_next(struct widget *wi, struct widget *current_highlight, struct widget **result) {
+static int gui_internal_keynav_find_next(struct widget *wi, struct widget *current_highlight, struct widget **result) {
     GList *l=wi->children;
     if (wi == current_highlight)
         return 1;
@@ -2698,8 +2631,7 @@ gui_internal_keynav_find_next(struct widget *wi, struct widget *current_highligh
 #define RESULT_FOUND 1
 #define NO_RESULT_YET 0
 
-static int
-gui_internal_keynav_find_prev(struct widget *wi, struct widget *current_highlight, struct widget **result) {
+static int gui_internal_keynav_find_prev(struct widget *wi, struct widget *current_highlight, struct widget **result) {
     if (wi == current_highlight && *result) {
         // Reached current widget; last widget found is the result.
         return RESULT_FOUND;
@@ -2722,9 +2654,8 @@ gui_internal_keynav_find_prev(struct widget *wi, struct widget *current_highligh
     return NO_RESULT_YET;
 }
 
-static void
-gui_internal_keynav_find_closest(struct widget *wi, struct point *p, int dx, int dy, int *distance,
-                                 struct widget **result) {
+static void gui_internal_keynav_find_closest(struct widget *wi, struct point *p, int dx, int dy, int *distance,
+        struct widget **result) {
     GList *l=wi->children;
     // Skip hidden elements
     if (wi->p.x==0 && wi->p.y==0 && wi->w==0 && wi->h==0)
@@ -2777,8 +2708,7 @@ gui_internal_keynav_find_closest(struct widget *wi, struct point *p, int dx, int
  * @param rotary (0/1) input from rotary encoder - dx indicates forwards/backwards movement
  *        through all widgets
  */
-static void
-gui_internal_keynav_highlight_next(struct gui_priv *this, int dx, int dy, int rotary) {
+static void gui_internal_keynav_highlight_next(struct gui_priv *this, int dx, int dy, int rotary) {
     struct widget *result,*menu=g_list_last(this->root.children)->data;
     struct widget *current_highlight = NULL;
     struct point p;
@@ -2981,13 +2911,11 @@ struct gui_methods gui_internal_methods = {
 };
 
 
-static void
-gui_internal_add_callback(struct gui_priv *priv, struct callback *cb) {
+static void gui_internal_add_callback(struct gui_priv *priv, struct callback *cb) {
     callback_list_add(priv->cbl, cb);
 }
 
-static void
-gui_internal_remove_callback(struct gui_priv *priv, struct callback *cb) {
+static void gui_internal_remove_callback(struct gui_priv *priv, struct callback *cb) {
     callback_list_remove(priv->cbl, cb);
 }
 
@@ -3001,38 +2929,32 @@ static struct gui_internal_methods gui_internal_methods_ext = {
 };
 
 
-static enum flags
-gui_internal_get_flags(struct widget *widget) {
+static enum flags gui_internal_get_flags(struct widget *widget) {
     return widget->flags;
 }
 
-static void
-gui_internal_set_flags(struct widget *widget, enum flags flags) {
+static void gui_internal_set_flags(struct widget *widget, enum flags flags) {
     widget->flags=flags;
 }
 
-static int
-gui_internal_get_state(struct widget *widget) {
+static int gui_internal_get_state(struct widget *widget) {
     return widget->state;
 }
 
-static void
-gui_internal_set_state(struct widget *widget, int state) {
+static void gui_internal_set_state(struct widget *widget, int state) {
     widget->state=state;
 }
 
-static void
-gui_internal_set_func(struct widget *widget, void (*func)(struct gui_priv *priv, struct widget *widget, void *data)) {
+static void gui_internal_set_func(struct widget *widget, void (*func)(struct gui_priv *priv, struct widget *widget,
+                                  void *data)) {
     widget->func=func;
 }
 
-static void
-gui_internal_set_data(struct widget *widget, void *data) {
+static void gui_internal_set_data(struct widget *widget, void *data) {
     widget->data=data;
 }
 
-static void
-gui_internal_set_default_background(struct gui_priv *this, struct widget *widget) {
+static void gui_internal_set_default_background(struct gui_priv *this, struct widget *widget) {
     widget->background=this->background;
 }
 
@@ -3062,8 +2984,7 @@ static struct gui_internal_widget_methods gui_internal_widget_methods = {
  * @param coord res, will become the coords of the intersection if found
  * @return : TRUE if intersection found, otherwise FALSE
  */
-int
-line_intersection(struct coord* a1, struct coord *a2, struct coord * b1, struct coord *b2, struct coord *res) {
+int line_intersection(struct coord* a1, struct coord *a2, struct coord * b1, struct coord *b2, struct coord *res) {
     int n, a, b;
     int adx=a2->x-a1->x;
     int ady=a2->y-a1->y;
@@ -3122,8 +3043,7 @@ item_get_heightline(struct item *item) {
 /**
  * @brief Called when the route is updated.
  */
-void
-gui_internal_route_update(struct gui_priv * this, struct navit * navit, struct vehicle *v) {
+void gui_internal_route_update(struct gui_priv * this, struct navit * navit, struct vehicle *v) {
 
     if(this->route_data.route_showing) {
         gui_internal_populate_route_table(this,navit);
@@ -3142,8 +3062,7 @@ gui_internal_route_update(struct gui_priv * this, struct navit * navit, struct v
  * The main purpose of this function is to remove the widgets from
  * references route_data because those widgets are about to be freed.
  */
-void
-gui_internal_route_screen_free(struct gui_priv * this_,struct widget * w) {
+void gui_internal_route_screen_free(struct gui_priv * this_,struct widget * w) {
     if(this_) {
         this_->route_data.route_showing=0;
         this_->route_data.route_table=NULL;
@@ -3158,8 +3077,7 @@ gui_internal_route_screen_free(struct gui_priv * this_,struct widget * w) {
  * @param this The gui context
  * @param navit The navit object
  */
-void
-gui_internal_populate_route_table(struct gui_priv * this, struct navit * navit) {
+void gui_internal_populate_route_table(struct gui_priv * this, struct navit * navit) {
     struct map * map=NULL;
     struct map_rect * mr=NULL;
     struct navigation * nav = NULL;

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -235,8 +235,7 @@ static void gui_internal_button_attr_pressed(struct gui_priv *this, struct widge
 }
 
 struct widget *
-gui_internal_button_navit_attr_new(struct gui_priv *this, const char *text, enum flags flags, struct attr *on,
-                                   struct attr *off) {
+gui_internal_button_navit_attr_new(struct gui_priv *this, const char *text, enum flags flags, struct attr *on, struct attr *off) {
     struct graphics_image *image=NULL;
     struct widget *ret;
     if (!on && !off)
@@ -258,8 +257,7 @@ gui_internal_button_navit_attr_new(struct gui_priv *this, const char *text, enum
 }
 
 struct widget *
-gui_internal_button_map_attr_new(struct gui_priv *this, const char *text, enum flags flags, struct map *map,
-                                 struct attr *on, struct attr *off, int deflt) {
+gui_internal_button_map_attr_new(struct gui_priv *this, const char *text, enum flags flags, struct map *map, struct attr *on, struct attr *off, int deflt) {
     struct graphics_image *image=NULL;
     struct widget *ret;
     image=image_new_xs(this, "gui_inactive");
@@ -1049,9 +1047,7 @@ static void gui_internal_cmd_delete_waypoint(struct gui_priv *this, struct widge
  * 2048: "Show search results on the map"
  * TODO define constants for these values
  */
-void gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, struct coord_geo *g_in,
-                                  struct widget *wm,
-                                  const char *name, int flags) {
+void gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, struct coord_geo *g_in, struct widget *wm, const char *name, int flags) {
     struct widget *wb,*w,*wtable,*row,*wc,*wbc,*wclosest=NULL;
     struct coord_geo g;
     struct pcoord pc;
@@ -1965,8 +1961,7 @@ static void gui_internal_cmd_set_active_profile(struct gui_priv *this, struct
     vehicle_get_attr(v, attr_name, &vehicle_name_attr, NULL);
     vehicle_name = vehicle_name_attr.u.str;
 
-    dbg(lvl_debug, "Changing vehicle %s to profile %s", vehicle_name,
-        profilename);
+    dbg(lvl_debug, "Changing vehicle %s to profile %s", vehicle_name, profilename);
 
     // Change the profile name
     profilename_attr.type = attr_profilename;
@@ -2029,8 +2024,7 @@ static void gui_internal_add_vehicle_profile(struct gui_priv *this, struct widge
         active_profile = profile_attr.u.str;
     active = active_profile != NULL && !strcmp(name, active_profile);
 
-    dbg(lvl_debug, "Adding vehicle profile %s, active=%s/%i", name,
-        active_profile, active);
+    dbg(lvl_debug, "Adding vehicle profile %s, active=%s/%i", name, active_profile, active);
 
     // Build a translatable label.
     if(active) {
@@ -2654,8 +2648,7 @@ static int gui_internal_keynav_find_prev(struct widget *wi, struct widget *curre
     return NO_RESULT_YET;
 }
 
-static void gui_internal_keynav_find_closest(struct widget *wi, struct point *p, int dx, int dy, int *distance,
-        struct widget **result) {
+static void gui_internal_keynav_find_closest(struct widget *wi, struct point *p, int dx, int dy, int *distance, struct widget **result) {
     GList *l=wi->children;
     // Skip hidden elements
     if (wi->p.x==0 && wi->p.y==0 && wi->w==0 && wi->h==0)
@@ -3162,8 +3155,7 @@ void gui_internal_populate_route_table(struct gui_priv * this, struct navit * na
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-static struct gui_priv * gui_internal_new(struct navit *nav, struct gui_methods *meth, struct attr **attrs,
-        struct gui *gui) {
+static struct gui_priv * gui_internal_new(struct navit *nav, struct gui_methods *meth, struct attr **attrs, struct gui *gui) {
     struct color color_white= {0xffff,0xffff,0xffff,0xffff};
     struct color color_black= {0x0,0x0,0x0,0xffff};
     struct color back2_color= {0x4141,0x4141,0x4141,0xffff};

--- a/navit/gui/internal/gui_internal_bookmark.c
+++ b/navit/gui/internal/gui_internal_bookmark.c
@@ -16,8 +16,7 @@
 #include "gui_internal_keyboard.h"
 #include "gui_internal_bookmark.h"
 
-static void
-gui_internal_cmd_add_bookmark_do(struct gui_priv *this, struct widget *widget) {
+static void gui_internal_cmd_add_bookmark_do(struct gui_priv *this, struct widget *widget) {
     GList *l;
     struct attr attr;
     dbg(lvl_debug,"text='%s'", widget->text);
@@ -31,8 +30,7 @@ gui_internal_cmd_add_bookmark_do(struct gui_priv *this, struct widget *widget) {
     gui_internal_prune_menu(this, l->data);
 }
 
-static void
-gui_internal_cmd_add_bookmark_folder_do(struct gui_priv *this, struct widget *widget) {
+static void gui_internal_cmd_add_bookmark_folder_do(struct gui_priv *this, struct widget *widget) {
     GList *l;
     struct attr attr;
     dbg(lvl_debug,"text='%s'", widget->text);
@@ -46,18 +44,15 @@ gui_internal_cmd_add_bookmark_folder_do(struct gui_priv *this, struct widget *wi
     gui_internal_prune_menu(this, l->data);
 }
 
-static void
-gui_internal_cmd_add_bookmark_clicked(struct gui_priv *this, struct widget *widget, void *data) {
+static void gui_internal_cmd_add_bookmark_clicked(struct gui_priv *this, struct widget *widget, void *data) {
     gui_internal_cmd_add_bookmark_do(this, widget->data);
 }
 
-static void
-gui_internal_cmd_add_bookmark_folder_clicked(struct gui_priv *this, struct widget *widget, void *data) {
+static void gui_internal_cmd_add_bookmark_folder_clicked(struct gui_priv *this, struct widget *widget, void *data) {
     gui_internal_cmd_add_bookmark_folder_do(this, widget->data);
 }
 
-static void
-gui_internal_cmd_rename_bookmark_clicked(struct gui_priv *this, struct widget *widget,void *data) {
+static void gui_internal_cmd_rename_bookmark_clicked(struct gui_priv *this, struct widget *widget,void *data) {
     struct widget *w=(struct widget*)widget->data;
     GList *l;
     struct attr attr;
@@ -74,8 +69,7 @@ gui_internal_cmd_rename_bookmark_clicked(struct gui_priv *this, struct widget *w
     gui_internal_prune_menu(this, l->data);
 }
 
-void
-gui_internal_cmd_add_bookmark2(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_add_bookmark2(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb,*wk,*wl,*we,*wnext;
     char *name=data;
     wb=gui_internal_menu(this,_("Add Bookmark"));
@@ -105,8 +99,7 @@ gui_internal_cmd_add_bookmark2(struct gui_priv *this, struct widget *wm, void *d
     gui_internal_menu_render(this);
 }
 
-void
-gui_internal_cmd_add_bookmark_folder2(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_add_bookmark_folder2(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb,*wk,*wl,*we,*wnext;
     char *name=data;
     wb=gui_internal_menu(this,_("Add Bookmark folder"));
@@ -136,8 +129,7 @@ gui_internal_cmd_add_bookmark_folder2(struct gui_priv *this, struct widget *wm, 
     gui_internal_menu_render(this);
 }
 
-void
-gui_internal_cmd_rename_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_rename_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w,*wb,*wk,*wl,*we,*wnext;
     char *name=wm->text;
     wb=gui_internal_menu(this,_("Rename"));
@@ -168,8 +160,7 @@ gui_internal_cmd_rename_bookmark(struct gui_priv *this, struct widget *wm, void 
     gui_internal_menu_render(this);
 }
 
-void
-gui_internal_cmd_cut_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_cut_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
     GList *l;
     navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL);
@@ -178,8 +169,7 @@ gui_internal_cmd_cut_bookmark(struct gui_priv *this, struct widget *wm, void *da
     gui_internal_prune_menu(this, l->data);
 }
 
-void
-gui_internal_cmd_copy_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_copy_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
     GList *l;
     navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL);
@@ -188,8 +178,7 @@ gui_internal_cmd_copy_bookmark(struct gui_priv *this, struct widget *wm, void *d
     gui_internal_prune_menu(this, l->data);
 }
 
-void
-gui_internal_cmd_paste_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_paste_bookmark(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
     GList *l;
     navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL);
@@ -199,8 +188,7 @@ gui_internal_cmd_paste_bookmark(struct gui_priv *this, struct widget *wm, void *
         gui_internal_prune_menu(this, l->data);
 }
 
-void
-gui_internal_cmd_delete_bookmark_folder(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_delete_bookmark_folder(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
     GList *l;
     navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL);
@@ -210,8 +198,7 @@ gui_internal_cmd_delete_bookmark_folder(struct gui_priv *this, struct widget *wm
     gui_internal_prune_menu(this, l->data);
 }
 
-void
-gui_internal_cmd_load_bookmarks_as_waypoints(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_load_bookmarks_as_waypoints(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
 
     if(navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL) ) {
@@ -259,8 +246,7 @@ gui_internal_cmd_load_bookmarks_as_waypoints(struct gui_priv *this, struct widge
     gui_internal_prune_menu(this, NULL);
 }
 
-void
-gui_internal_cmd_replace_bookmarks_from_waypoints(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_replace_bookmarks_from_waypoints(struct gui_priv *this, struct widget *wm, void *data) {
     struct attr mattr;
 
     if(navit_get_attr(this->nav, attr_bookmarks, &mattr, NULL) ) {

--- a/navit/gui/internal/gui_internal_command.c
+++ b/navit/gui/internal/gui_internal_command.c
@@ -54,8 +54,7 @@ extern char *version;
  *
  * @return The coordinates as a formatted string
  */
-static char *
-coordinates_geo(const struct coord_geo *gc, char sep) {
+static char *coordinates_geo(const struct coord_geo *gc, char sep) {
     char latc='N',lngc='E';
     int lat_deg,lat_min,lat_sec;
     int lng_deg,lng_min,lng_sec;
@@ -90,8 +89,7 @@ coordinates_geo(const struct coord_geo *gc, char sep) {
  *
  * @return The coordinates as a formatted string
  */
-char *
-gui_internal_coordinates(struct pcoord *pc, char sep) {
+char *gui_internal_coordinates(struct pcoord *pc, char sep) {
     struct coord_geo g;
     struct coord c;
     c.x=pc->x;
@@ -112,8 +110,7 @@ enum escape_mode {
 
 /* todo &=&amp;, < = &lt; */
 
-static char *
-gui_internal_escape(enum escape_mode mode, char *in) {
+static char *gui_internal_escape(enum escape_mode mode, char *in) {
     int len=mode & escape_mode_string ? 3:1;
     char *dst,*out,*src=in;
     char *quot="&quot;";
@@ -153,8 +150,8 @@ gui_internal_escape(enum escape_mode mode, char *in) {
     return out;
 }
 
-static void
-gui_internal_cmd_escape(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_escape(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                    int *valid) {
     struct attr escaped;
     if (!in || !in[0]) {
         dbg(lvl_error,"first parameter missing or wrong type");
@@ -179,8 +176,8 @@ gui_internal_cmd_escape(struct gui_priv *this, char *function, struct attr **in,
     g_free(escaped.u.str);
 }
 
-static void
-gui_internal_cmd2_about(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_about(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                    int *valid) {
     struct widget *menu,*wb,*w;
     char *text;
 
@@ -248,13 +245,13 @@ gui_internal_cmd2_about(struct gui_priv *this, char *function, struct attr **in,
     graphics_draw_mode(this->gra, draw_mode_end);
 }
 
-static void
-gui_internal_cmd2_waypoints(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_waypoints(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                        int *valid) {
     gui_internal_select_waypoint(this, _("Waypoints"), NULL, NULL, gui_internal_cmd_position, (void*)2);
 }
 
-static void
-gui_internal_cmd_enter_coord(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_enter_coord(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+        int *valid) {
     struct widget *w, *wb, *wk, *wr, *we, *wnext, *row;
     wb=gui_internal_menu(this, _("Enter Coordinates"));
     w=gui_internal_box_new(this, gravity_center|orientation_vertical|flags_expand|flags_fill);
@@ -297,16 +294,16 @@ gui_internal_cmd_enter_coord(struct gui_priv *this, char *function, struct attr 
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd2_town(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_town(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     if (this->sl)
         search_list_select(this->sl, attr_country_all, 0, 0);
     gui_internal_search(this,_("Town"),"Town",1);
 }
 
-static void
-gui_internal_cmd2_setting_vehicle(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                                  int *valid) {
+static void gui_internal_cmd2_setting_vehicle(struct gui_priv *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     struct attr attr,attr2,vattr;
     struct widget *w,*wb,*wl;
     struct attr_iter *iter;
@@ -341,9 +338,8 @@ gui_internal_cmd2_setting_vehicle(struct gui_priv *this, char *function, struct 
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd2_setting_rules(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                                int *valid) {
+static void gui_internal_cmd2_setting_rules(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+        int *valid) {
     struct widget *wb,*w;
     struct attr on,off;
     wb=gui_internal_menu(this, _("Rules"));
@@ -379,9 +375,8 @@ gui_internal_cmd2_setting_rules(struct gui_priv *this, char *function, struct at
     gui_internal_menu_render(this);
 }
 
-static void
-gui_internal_cmd2_setting_maps(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                               int *valid) {
+static void gui_internal_cmd2_setting_maps(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+        int *valid) {
     struct attr attr, on, off, description, type, data, url, active;
     struct widget *w,*wb,*row,*wma;
     char *label;
@@ -426,9 +421,9 @@ gui_internal_cmd2_setting_maps(struct gui_priv *this, char *function, struct att
 
 }
 
-static void
-gui_internal_cmd2_setting_layout(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                                 int *valid) {
+static void gui_internal_cmd2_setting_layout(struct gui_priv *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     struct attr attr;
     struct widget *w,*wb,*wl,*row;
     struct attr_iter *iter;
@@ -459,9 +454,9 @@ gui_internal_cmd2_setting_layout(struct gui_priv *this, char *function, struct a
  * comply with *.heightlines.bin
  *
  */
-static void
-gui_internal_cmd2_route_height_profile(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                                       int *valid) {
+static void gui_internal_cmd2_route_height_profile(struct gui_priv *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     struct widget * menu, *box;
     struct map * map=NULL;
     struct map_rect * mr=NULL;
@@ -675,9 +670,9 @@ gui_internal_cmd2_route_height_profile(struct gui_priv *this, char *function, st
     }
 }
 
-static void
-gui_internal_cmd2_route_description(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                                    int *valid) {
+static void gui_internal_cmd2_route_description(struct gui_priv *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
 
 
     struct widget * menu;
@@ -715,8 +710,8 @@ gui_internal_cmd2_route_description(struct gui_priv *this, char *function, struc
 
 }
 
-static void
-gui_internal_cmd2_pois(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_pois(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     struct widget *w;
     struct poi_param *param;
     struct attr pro;
@@ -746,8 +741,8 @@ gui_internal_cmd2_pois(struct gui_priv *this, char *function, struct attr **in, 
     gui_internal_poi_param_free(param);
 }
 
-static void
-gui_internal_cmd2_locale(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_locale(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                     int *valid) {
     struct widget *menu,*wb,*w;
     char *text;
 
@@ -802,9 +797,8 @@ gui_internal_cmd2_locale(struct gui_priv *this, char *function, struct attr **in
  * Currently only works on non Windows systems.
  *
  */
-static void
-gui_internal_cmd2_network_info(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                               int *valid) {
+static void gui_internal_cmd2_network_info(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+        int *valid) {
 #if HAS_IFADDRS
     struct widget *menu,*wb,*w;
     char *text;
@@ -840,8 +834,8 @@ gui_internal_cmd2_network_info(struct gui_priv *this, char *function, struct att
 #endif
 }
 
-static void
-gui_internal_cmd_formerdests(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_formerdests(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+        int *valid) {
     struct widget *wb,*w,*wbm,*tbl=NULL;
     struct map *formerdests;
     struct map_rect *mr_formerdests;
@@ -907,8 +901,8 @@ gui_internal_cmd_formerdests(struct gui_priv *this, char *function, struct attr 
     map_rect_destroy(mr_formerdests);
 }
 
-static void
-gui_internal_cmd2_bookmarks(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_bookmarks(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                        int *valid) {
     char *str=NULL;
     if (in && in[0] && ATTR_IS_STRING(in[0]->type)) {
         str=in[0]->u.str;
@@ -917,36 +911,34 @@ gui_internal_cmd2_bookmarks(struct gui_priv *this, char *function, struct attr *
     gui_internal_cmd_bookmarks(this, NULL, str);
 }
 
-static void
-gui_internal_cmd2_abort_navigation(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
-                                   int *valid) {
+static void gui_internal_cmd2_abort_navigation(struct gui_priv *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     navit_set_destination(this->nav, NULL, NULL, 0);
 }
 
-static void
-gui_internal_cmd2_back(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_back(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     graphics_draw_mode(this->gra, draw_mode_begin);
     gui_internal_back(this, NULL, NULL);
     graphics_draw_mode(this->gra, draw_mode_end);
     gui_internal_check_exit(this);
 }
 
-static void
-gui_internal_cmd2_back_to_map(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_back_to_map(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+        int *valid) {
     gui_internal_prune_menu(this, NULL);
     gui_internal_check_exit(this);
 }
 
 
-static void
-gui_internal_get_data(struct gui_priv *priv, char *command, struct attr **in, struct attr ***out) {
+static void gui_internal_get_data(struct gui_priv *priv, char *command, struct attr **in, struct attr ***out) {
     struct attr private_data = { attr_private_data, {(void *)&priv->data}};
     if (out)
         *out=attr_generic_add_attr(*out, &private_data);
 }
 
-static void
-gui_internal_cmd_log(struct gui_priv *this) {
+static void gui_internal_cmd_log(struct gui_priv *this) {
     struct widget *w,*wb,*wk,*wl,*we,*wnext;
     gui_internal_enter(this, 1);
     gui_internal_set_click_coord(this, NULL);
@@ -978,8 +970,8 @@ gui_internal_cmd_log(struct gui_priv *this) {
     gui_internal_leave(this);
 }
 
-static void
-gui_internal_cmd_menu2(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_menu2(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     char *href=NULL;
     int i=0, ignore=0, replace=0;
 
@@ -1001,8 +993,8 @@ gui_internal_cmd_menu2(struct gui_priv *this, char *function, struct attr **in, 
     gui_internal_cmd_menu(this, ignore, href);
 }
 
-static void
-gui_internal_cmd2_position(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_position(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                       int *valid) {
     const char *name=_("Position");
     int flags=-1;
 
@@ -1020,20 +1012,20 @@ gui_internal_cmd2_position(struct gui_priv *this, char *function, struct attr **
     gui_internal_cmd_position_do(this, NULL, in[0]->u.coord_geo, NULL, name, flags);
 }
 
-static void
-gui_internal_cmd_redraw_map(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_redraw_map(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                        int *valid) {
     this->redraw=1;
 }
 
-static void
-gui_internal_cmd2_refresh(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_refresh(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                      int *valid) {
     char *href=g_strdup(this->href);
     gui_internal_html_load_href(this, href, 1);
     g_free(href);
 }
 
-static void
-gui_internal_cmd2_set(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2_set(struct gui_priv *this, char *function, struct attr **in, struct attr ***out,
+                                  int *valid) {
     char *pattern,*command=NULL;
     if (!in || !in[0] || !ATTR_IS_STRING(in[0]->type)) {
         dbg(lvl_error,"first parameter missing or wrong type");
@@ -1053,8 +1045,7 @@ gui_internal_cmd2_set(struct gui_priv *this, char *function, struct attr **in, s
 
 }
 
-void
-gui_internal_cmd2_quit(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+void gui_internal_cmd2_quit(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     struct attr navit;
     gui_internal_prune_menu(this, NULL);
     navit.type=attr_navit;
@@ -1063,8 +1054,7 @@ gui_internal_cmd2_quit(struct gui_priv *this, char *function, struct attr **in, 
     event_main_loop_quit();
 }
 
-static char *
-gui_internal_append_attr(char *str, enum escape_mode mode, char *pre, struct attr *attr, char *post) {
+static char *gui_internal_append_attr(char *str, enum escape_mode mode, char *pre, struct attr *attr, char *post) {
     char *astr=NULL;
     if (ATTR_IS_STRING(attr->type))
         astr=gui_internal_escape(mode, attr->u.str);
@@ -1081,8 +1071,8 @@ gui_internal_append_attr(char *str, enum escape_mode mode, char *pre, struct att
     return str;
 }
 
-static void
-gui_internal_cmd_write(struct gui_priv * this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_write(struct gui_priv * this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     char *str=NULL;
     dbg(lvl_debug,"enter %s %p %p %p",function,in,out,valid);
     if (!in)
@@ -1101,8 +1091,7 @@ gui_internal_cmd_write(struct gui_priv * this, char *function, struct attr **in,
     g_free(str);
 }
 
-static void
-gui_internal_onclick(struct attr ***in, char **onclick, char *set) {
+static void gui_internal_onclick(struct attr ***in, char **onclick, char *set) {
     struct attr **i=*in;
     char *c,*str=NULL,*args=NULL,*sep="";
 
@@ -1180,8 +1169,8 @@ error:
     return;
 }
 
-static void
-gui_internal_cmd_img(struct gui_priv * this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_img(struct gui_priv * this, char *function, struct attr **in, struct attr ***out,
+                                 int *valid) {
     char *str=g_strdup("<img"),*suffix=NULL,*onclick=g_strdup(""),*html;
 
     if (ATTR_IS_STRING((*in)->type)) {
@@ -1231,8 +1220,8 @@ error:
     return;
 }
 
-static void
-gui_internal_cmd_debug(struct gui_priv * this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd_debug(struct gui_priv * this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     char *str;
     dbg(lvl_debug,"begin");
     if (in) {
@@ -1246,8 +1235,7 @@ gui_internal_cmd_debug(struct gui_priv * this, char *function, struct attr **in,
     dbg(lvl_debug,"done");
 }
 
-static void
-gui_internal_cmd2(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_internal_cmd2(struct gui_priv *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     int entering=0;
     int ignore=1;
     if (in && in[0] && ATTR_IS_INT(in[0]->type)) {
@@ -1334,8 +1322,7 @@ static struct command_table commands[] = {
 #endif
 };
 
-void
-gui_internal_command_init(struct gui_priv *this, struct attr **attrs) {
+void gui_internal_command_init(struct gui_priv *this, struct attr **attrs) {
     struct attr *attr;
     if ((attr=attr_search(attrs, NULL, attr_callback_list))) {
         command_add_table(attr->u.callback_list, commands, sizeof(commands)/sizeof(struct command_table), this);

--- a/navit/gui/internal/gui_internal_gesture.c
+++ b/navit/gui/internal/gui_internal_gesture.c
@@ -27,21 +27,18 @@
 #include "gui_internal_menu.h"
 #include "gui_internal_gesture.h"
 
-void
-gui_internal_gesture_ring_clear(struct gui_priv *this) {
+void gui_internal_gesture_ring_clear(struct gui_priv *this) {
     this->gesture_ring_last=this->gesture_ring_first=0;
 };
 
-static struct gesture_elem *
-gui_internal_gesture_ring_get(struct gui_priv *this, int i) {
+static struct gesture_elem *gui_internal_gesture_ring_get(struct gui_priv *this, int i) {
     int n=(this->gesture_ring_last-i+GESTURE_RINGSIZE)%GESTURE_RINGSIZE;
     if(n==this->gesture_ring_first)
         return NULL;
     return this->gesture_ring+n;
 };
 
-void
-gui_internal_gesture_ring_add(struct gui_priv *this, struct point *p) {
+void gui_internal_gesture_ring_add(struct gui_priv *this, struct point *p) {
     long long msec;
 #ifndef HAVE_API_WIN32_CE
     struct timeval tv;
@@ -61,8 +58,7 @@ gui_internal_gesture_ring_add(struct gui_priv *this, struct point *p) {
     dbg(lvl_info,"msec="LONGLONG_FMT" x=%d y=%d",msec,p->x,p->y);
 };
 
-int
-gui_internal_gesture_get_vector(struct gui_priv *this, long long msec, struct point *p0, int *dx, int *dy) {
+int gui_internal_gesture_get_vector(struct gui_priv *this, long long msec, struct point *p0, int *dx, int *dy) {
     struct gesture_elem *g;
     int x,y,dt;
     int i;
@@ -100,8 +96,7 @@ gui_internal_gesture_get_vector(struct gui_priv *this, long long msec, struct po
     return dt;
 }
 
-int
-gui_internal_gesture_do(struct gui_priv *this) {
+int gui_internal_gesture_do(struct gui_priv *this) {
     int dt;
     int dx,dy;
 

--- a/navit/gui/internal/gui_internal_html.c
+++ b/navit/gui/internal/gui_internal_html.c
@@ -40,8 +40,7 @@ struct html_tag_map {
 };
 
 
-static const char *
-find_attr(const char **names, const char **values, const char *name) {
+static const char *find_attr(const char **names, const char **values, const char *name) {
     while (*names) {
         if (!g_ascii_strcasecmp(*names, name))
             return *values;
@@ -51,24 +50,20 @@ find_attr(const char **names, const char **values, const char *name) {
     return NULL;
 }
 
-static char *
-find_attr_dup(const char **names, const char **values, const char *name) {
+static char *find_attr_dup(const char **names, const char **values, const char *name) {
     return g_strdup(find_attr(names, values, name));
 }
 
-void
-gui_internal_html_main_menu(struct gui_priv *this) {
+void gui_internal_html_main_menu(struct gui_priv *this) {
     gui_internal_prune_menu(this, NULL);
     gui_internal_html_load_href(this, "#Main Menu", 0);
 }
 
-static void
-gui_internal_html_command(struct gui_priv *this, struct widget *w, void *data) {
+static void gui_internal_html_command(struct gui_priv *this, struct widget *w, void *data) {
     gui_internal_evaluate(this,w->command);
 }
 
-static void
-gui_internal_html_submit_set(struct gui_priv *this, struct widget *w, struct form *form) {
+static void gui_internal_html_submit_set(struct gui_priv *this, struct widget *w, struct form *form) {
     GList *l;
     if (w->form == form && w->name) {
         struct attr *attr=attr_new_from_text(w->name, w->text?w->text:"");
@@ -85,8 +80,7 @@ gui_internal_html_submit_set(struct gui_priv *this, struct widget *w, struct for
 
 }
 
-static void
-gui_internal_html_submit(struct gui_priv *this, struct widget *w, void *data) {
+static void gui_internal_html_submit(struct gui_priv *this, struct widget *w, void *data) {
     struct widget *menu;
     GList *l;
 
@@ -101,8 +95,7 @@ gui_internal_html_submit(struct gui_priv *this, struct widget *w, void *data) {
     gui_internal_evaluate(this,w->form->onsubmit);
 }
 
-void
-gui_internal_html_load_href(struct gui_priv *this, char *href, int replace) {
+void gui_internal_html_load_href(struct gui_priv *this, char *href, int replace) {
     if (replace)
         gui_internal_prune_menu_count(this, 1, 0);
     if (href && href[0] == '#') {
@@ -113,8 +106,7 @@ gui_internal_html_load_href(struct gui_priv *this, char *href, int replace) {
     }
 }
 
-void
-gui_internal_html_href(struct gui_priv *this, struct widget *w, void *data) {
+void gui_internal_html_href(struct gui_priv *this, struct widget *w, void *data) {
     gui_internal_html_load_href(this, w->command, 0);
 }
 
@@ -146,8 +138,7 @@ struct div_flags_map {
     {"orientation","horizontal_vertical",orientation_horizontal_vertical},
 };
 
-static enum flags
-div_flag(const char **names, const char **values, char *name) {
+static enum flags div_flag(const char **names, const char **values, char *name) {
     int i;
     enum flags ret=0;
     const char *value=find_attr(names, values, name);
@@ -160,8 +151,7 @@ div_flag(const char **names, const char **values, char *name) {
     return ret;
 }
 
-static enum flags
-div_flags(const char **names, const char **values) {
+static enum flags div_flags(const char **names, const char **values) {
     enum flags flags;
     flags = div_flag(names, values, "gravity");
     flags |= div_flag(names, values, "orientation");
@@ -170,8 +160,7 @@ div_flags(const char **names, const char **values) {
     return flags;
 }
 
-static struct widget *
-html_image(struct gui_priv *this, const char **names, const char **values) {
+static struct widget *html_image(struct gui_priv *this, const char **names, const char **values) {
     const char *src, *size;
     struct graphics_image *img=NULL;
 
@@ -197,9 +186,9 @@ html_image(struct gui_priv *this, const char **names, const char **values) {
     return gui_internal_image_new(this, img);
 }
 
-static void
-gui_internal_html_start(xml_context *dummy, const char *tag_name, const char **names, const char **values, void *data,
-                        GError **error) {
+static void gui_internal_html_start(xml_context *dummy, const char *tag_name, const char **names, const char **values,
+                                    void *data,
+                                    GError **error) {
     struct gui_priv *this=data;
     int i;
     enum html_tag tag=html_tag_none;
@@ -298,8 +287,7 @@ gui_internal_html_start(xml_context *dummy, const char *tag_name, const char **n
     this->html_depth++;
 }
 
-static void
-gui_internal_html_end(xml_context *dummy, const char *tag_name, void *data, GError **error) {
+static void gui_internal_html_end(xml_context *dummy, const char *tag_name, void *data, GError **error) {
     struct gui_priv *this=data;
     struct html *html;
     struct html *parent=NULL;
@@ -351,8 +339,7 @@ gui_internal_html_end(xml_context *dummy, const char *tag_name, void *data, GErr
     g_free(html->refresh_cond);
 }
 
-static void
-gui_internal_refresh_callback_called(struct gui_priv *this, struct menu_data *menu_data) {
+static void gui_internal_refresh_callback_called(struct gui_priv *this, struct menu_data *menu_data) {
     if (gui_internal_menu_data(this) == menu_data) {
         char *href=g_strdup(menu_data->href);
         gui_internal_html_load_href(this, href, 1);
@@ -360,8 +347,7 @@ gui_internal_refresh_callback_called(struct gui_priv *this, struct menu_data *me
     }
 }
 
-static void
-gui_internal_set_refresh_callback(struct gui_priv *this, char *cond) {
+static void gui_internal_set_refresh_callback(struct gui_priv *this, char *cond) {
     dbg(lvl_info,"cond=%s",cond);
     if (cond) {
         enum attr_type type;
@@ -387,8 +373,7 @@ gui_internal_set_refresh_callback(struct gui_priv *this, char *cond) {
     }
 }
 
-static void
-gui_internal_html_text(xml_context *dummy, const char *text, gsize len, void *data, GError **error) {
+static void gui_internal_html_text(xml_context *dummy, const char *text, gsize len, void *data, GError **error) {
     struct gui_priv *this=data;
     struct widget *w;
     int depth=this->html_depth-1;
@@ -459,13 +444,11 @@ gui_internal_html_text(xml_context *dummy, const char *text, gsize len, void *da
     g_free(text_stripped);
 }
 
-void
-gui_internal_html_parse_text(struct gui_priv *this, char *doc) {
+void gui_internal_html_parse_text(struct gui_priv *this, char *doc) {
     xml_parse_text(doc, this, gui_internal_html_start, gui_internal_html_end, gui_internal_html_text);
 }
 
-void
-gui_internal_html_menu(struct gui_priv *this, const char *document, char *anchor) {
+void gui_internal_html_menu(struct gui_priv *this, const char *document, char *anchor) {
     char *doc=g_strdup(document);
     graphics_draw_mode(this->gra, draw_mode_begin);
     this->html_container=NULL;

--- a/navit/gui/internal/gui_internal_keyboard.c
+++ b/navit/gui/internal/gui_internal_keyboard.c
@@ -19,8 +19,7 @@
  *
  * @param this The internal GUI instance
  */
-void
-gui_internal_keyboard_to_upper_case(struct gui_priv *this) {
+void gui_internal_keyboard_to_upper_case(struct gui_priv *this) {
     struct menu_data *md;
 
     if (!this->keyboard)
@@ -43,8 +42,7 @@ gui_internal_keyboard_to_upper_case(struct gui_priv *this) {
  *
  * @param this The internal GUI instance
  */
-void
-gui_internal_keyboard_to_lower_case(struct gui_priv *this) {
+void gui_internal_keyboard_to_lower_case(struct gui_priv *this) {
     struct menu_data *md;
 
     if (!this->keyboard)
@@ -70,15 +68,13 @@ gui_internal_keyboard_to_lower_case(struct gui_priv *this) {
  * @param wm
  * @param data Not used
  */
-static void
-gui_internal_cmd_keypress(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_keypress(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_keypress_do(this, (char *) wm->data);
 }
 
-static struct widget *
-gui_internal_keyboard_key_data(struct gui_priv *this, struct widget *wkbd, char *text, int font,
-                               void(*func)(struct gui_priv *priv, struct widget *widget, void *data), void *data, void (*data_free)(void *data), int w,
-                               int h) {
+static struct widget *gui_internal_keyboard_key_data(struct gui_priv *this, struct widget *wkbd, char *text, int font,
+        void(*func)(struct gui_priv *priv, struct widget *widget, void *data), void *data, void (*data_free)(void *data), int w,
+        int h) {
     struct widget *wk;
     gui_internal_widget_append(wkbd, wk=gui_internal_button_font_new_with_callback(this, text, font,
                                         NULL, gravity_center|orientation_vertical, func, data));
@@ -93,8 +89,8 @@ gui_internal_keyboard_key_data(struct gui_priv *this, struct widget *wkbd, char 
     return wk;
 }
 
-static struct widget *
-gui_internal_keyboard_key(struct gui_priv *this, struct widget *wkbd, char *text, char *key, int w, int h) {
+static struct widget *gui_internal_keyboard_key(struct gui_priv *this, struct widget *wkbd, char *text, char *key,
+        int w, int h) {
     return gui_internal_keyboard_key_data(this, wkbd, text, 0, gui_internal_cmd_keypress, g_strdup(key), g_free_func,w,h);
 }
 
@@ -552,8 +548,7 @@ gui_internal_keyboard(struct gui_priv *this, int mode) {
     return gui_internal_keyboard_do(this, NULL, mode);
 }
 
-static void
-gui_internal_keyboard_change(struct gui_priv *this, struct widget *key, void *data) {
+static void gui_internal_keyboard_change(struct gui_priv *this, struct widget *key, void *data) {
     gui_internal_keyboard_do(this, key->data, key->datai);
 }
 
@@ -568,8 +563,7 @@ gui_internal_keyboard_change(struct gui_priv *this, struct widget *key, void *da
  * @return {@code VKBD_CYRILLIC_UPPER} for countries using the Cyrillic alphabet,
  * {@code VKBD_LATIN_UPPER} otherwise
  */
-int
-gui_internal_keyboard_init_mode(char *lang) {
+int gui_internal_keyboard_init_mode(char *lang) {
     int ret=0;
     /* do not crash if lang is NULL, which may be returned by getenv*/
     if(lang == NULL)

--- a/navit/gui/internal/gui_internal_menu.c
+++ b/navit/gui/internal/gui_internal_menu.c
@@ -17,8 +17,7 @@
 
 extern char *version;
 
-static void
-gui_internal_menu_destroy(struct gui_priv *this, struct widget *w) {
+static void gui_internal_menu_destroy(struct gui_priv *this, struct widget *w) {
     struct menu_data *menu_data=w->menu_data;
     if (menu_data) {
         if (menu_data->refresh_callback_obj.type) {
@@ -37,8 +36,7 @@ gui_internal_menu_destroy(struct gui_priv *this, struct widget *w) {
     this->root.children=g_list_remove(this->root.children, w);
 }
 
-static void
-gui_internal_prune_menu_do(struct gui_priv *this, struct widget *w, int render) {
+static void gui_internal_prune_menu_do(struct gui_priv *this, struct widget *w, int render) {
     GList *l;
     struct widget *wr,*wd;
     gui_internal_search_idle_end(this);
@@ -70,13 +68,11 @@ gui_internal_prune_menu_do(struct gui_priv *this, struct widget *w, int render) 
     }
 }
 
-void
-gui_internal_prune_menu(struct gui_priv *this, struct widget *w) {
+void gui_internal_prune_menu(struct gui_priv *this, struct widget *w) {
     gui_internal_prune_menu_do(this, w, 1);
 }
 
-void
-gui_internal_prune_menu_count(struct gui_priv *this, int count, int render) {
+void gui_internal_prune_menu_count(struct gui_priv *this, int count, int render) {
     GList *l=g_list_last(this->root.children);
     struct widget *w=NULL;
     while (l && count-- > 0)
@@ -206,8 +202,7 @@ gui_internal_menu_data(struct gui_priv *this) {
     return menu->menu_data;
 }
 
-void
-gui_internal_menu_reset_pack(struct gui_priv *this) {
+void gui_internal_menu_reset_pack(struct gui_priv *this) {
     GList *l;
     struct widget *top_box;
 
@@ -216,8 +211,7 @@ gui_internal_menu_reset_pack(struct gui_priv *this) {
     gui_internal_widget_reset_pack(this, top_box);
 }
 
-void
-gui_internal_menu_render(struct gui_priv *this) {
+void gui_internal_menu_render(struct gui_priv *this) {
     GList *l;
     struct widget *menu;
 

--- a/navit/gui/internal/gui_internal_poi.c
+++ b/navit/gui/internal/gui_internal_poi.c
@@ -94,8 +94,7 @@ struct selector selectors[]= {
  * @return  Pointer to graphics_image object, or NULL if no picture available.
  */
 
-static struct graphics_image *
-gui_internal_poi_icon(struct gui_priv *this, struct item *item) {
+static struct graphics_image *gui_internal_poi_icon(struct gui_priv *this, struct item *item) {
     struct attr layout;
     struct attr icon_src;
     GList *layer;
@@ -155,8 +154,7 @@ gui_internal_poi_icon(struct gui_priv *this, struct item *item) {
  * @param p reference to the object to be freed.
  */
 
-void
-gui_internal_poi_param_free(void *p) {
+void gui_internal_poi_param_free(void *p) {
     if(((struct poi_param *)p)->filterstr)
         g_free(((struct poi_param *)p)->filterstr);
     if(((struct poi_param *)p)->filter)
@@ -171,8 +169,7 @@ gui_internal_poi_param_free(void *p) {
  * @return  Cloned object reference.
  */
 
-static struct poi_param *
-gui_internal_poi_param_clone(struct poi_param *p) {
+static struct poi_param *gui_internal_poi_param_clone(struct poi_param *p) {
     struct poi_param *r=g_new(struct poi_param,1);
     GList *l=p->filter;
     memcpy(r,p,sizeof(struct poi_param));
@@ -196,8 +193,7 @@ gui_internal_poi_param_clone(struct poi_param *p) {
  * @param text filter text.
  */
 
-void
-gui_internal_poi_param_set_filter(struct poi_param *param, char *text) {
+void gui_internal_poi_param_set_filter(struct poi_param *param, char *text) {
     char *s1, *s2;
 
     param->filterstr=removecase(text);
@@ -215,8 +211,7 @@ gui_internal_poi_param_set_filter(struct poi_param *param, char *text) {
     } while(s2 && *s2);
 }
 
-static struct widget *
-gui_internal_cmd_pois_selector(struct gui_priv *this, struct pcoord *c, int pagenb) {
+static struct widget *gui_internal_cmd_pois_selector(struct gui_priv *this, struct pcoord *c, int pagenb) {
     struct widget *wl,*wb;
     int nitems,nrows;
     int i;
@@ -266,8 +261,7 @@ gui_internal_cmd_pois_selector(struct gui_priv *this, struct pcoord *c, int page
  * @return  Pointer to new widget.
  */
 
-static void
-format_dist(int dist, char *distbuf) {
+static void format_dist(int dist, char *distbuf) {
     if (dist > 10000)
         sprintf(distbuf,"%d ", dist/1000);
     else if (dist>0)
@@ -336,8 +330,7 @@ gui_internal_cmd_pois_item(struct gui_priv *this, struct coord *center, struct i
  * @return  Pointer to string representation of address. To be g_free()d after use.
  */
 
-char *
-gui_internal_compose_item_address_string(struct item *item, int prependPostal) {
+char *gui_internal_compose_item_address_string(struct item *item, int prependPostal) {
     char *s=g_strdup("");
     struct attr attr;
     if(prependPostal && item_attr_get(item, attr_postal, &attr))
@@ -362,8 +355,7 @@ gui_internal_compose_item_address_string(struct item *item, int prependPostal) {
     return s;
 }
 
-static int
-gui_internal_cmd_pois_item_selected(struct poi_param *param, struct item *item) {
+static int gui_internal_cmd_pois_item_selected(struct poi_param *param, struct item *item) {
     enum item_type *types;
     struct selector *sel = param->sel? &selectors[param->selnb]: NULL;
     enum item_type type=item->type;
@@ -424,8 +416,7 @@ gui_internal_cmd_pois_item_selected(struct poi_param *param, struct item *item) 
  * @param wm called widget.
  * @param data event data.
  */
-static void
-gui_internal_cmd_pois_more(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_pois_more(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w=g_new0(struct widget,1);
     w->data=wm->data;
     w->c=wm->c;
@@ -444,8 +435,7 @@ gui_internal_cmd_pois_more(struct gui_priv *this, struct widget *wm, void *data)
  * @param wm called widget.
  * @param data event data (pointer to editor widget containg filter text).
  */
-static void
-gui_internal_cmd_pois_filter_do(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_pois_filter_do(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *w=data;
     struct poi_param *param;
 
@@ -477,8 +467,7 @@ gui_internal_cmd_pois_filter_do(struct gui_priv *this, struct widget *wm, void *
  *
  */
 
-static void
-gui_internal_cmd_pois_filter_changed(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_pois_filter_changed(struct gui_priv *this, struct widget *wm, void *data) {
     if (wm->text && wm->reason==gui_internal_reason_keypress_finish) {
         gui_internal_cmd_pois_filter_do(this, wm, wm);
     }
@@ -492,8 +481,7 @@ gui_internal_cmd_pois_filter_changed(struct gui_priv *this, struct widget *wm, v
  * @param wm called widget.
  * @param data event data.
  */
-void
-gui_internal_cmd_pois_filter(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_pois_filter(struct gui_priv *this, struct widget *wm, void *data) {
     struct widget *wb, *w, *wr, *wk, *we;
     int keyboard_mode;
     keyboard_mode = VKBD_FLAG_2 | gui_internal_keyboard_init_mode(getenv("LANG"));
@@ -544,8 +532,7 @@ gui_internal_cmd_pois_filter(struct gui_priv *this, struct widget *wm, void *dat
  * @param wm called widget.
  * @param data event data, reference to poi_param or NULL.
  */
-void
-gui_internal_cmd_pois(struct gui_priv *this, struct widget *wm, void *data) {
+void gui_internal_cmd_pois(struct gui_priv *this, struct widget *wm, void *data) {
     struct map_selection *sel,*selm;
     struct coord c,center;
     struct mapset_handle *h;

--- a/navit/gui/internal/gui_internal_search.c
+++ b/navit/gui/internal/gui_internal_search.c
@@ -22,14 +22,12 @@
 #include "gui_internal_keyboard.h"
 #include "gui_internal_search.h"
 
-static void
-gui_internal_search_country(struct gui_priv *this, struct widget *widget, void *data) {
+static void gui_internal_search_country(struct gui_priv *this, struct widget *widget, void *data) {
     gui_internal_prune_menu_count(this, 1, 0);
     gui_internal_search(this,_("Country"),"Country",0);
 }
 
-static void
-gui_internal_search_town(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_search_town(struct gui_priv *this, struct widget *wm, void *data) {
     if (this->sl)
         search_list_select(this->sl, attr_country_all, 0, 0);
     g_free(this->country_iso2);
@@ -37,20 +35,17 @@ gui_internal_search_town(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_search(this,_("Town"),"Town",0);
 }
 
-static void
-gui_internal_search_street(struct gui_priv *this, struct widget *widget, void *data) {
+static void gui_internal_search_street(struct gui_priv *this, struct widget *widget, void *data) {
     search_list_select(this->sl, attr_town_or_district_name, 0, 0);
     gui_internal_search(this,_("Street"),"Street",0);
 }
 
-static void
-gui_internal_search_house_number(struct gui_priv *this, struct widget *widget, void *data) {
+static void gui_internal_search_house_number(struct gui_priv *this, struct widget *widget, void *data) {
     search_list_select(this->sl, attr_street_name, 0, 0);
     gui_internal_search(this,_("House number"),"House number",0);
 }
 
-void
-gui_internal_search_idle_end(struct gui_priv *this) {
+void gui_internal_search_idle_end(struct gui_priv *this) {
     if (this->idle) {
         event_remove_idle(this->idle);
         this->idle=NULL;
@@ -61,8 +56,7 @@ gui_internal_search_idle_end(struct gui_priv *this) {
     }
 }
 
-static int
-gui_internal_search_cmp(gconstpointer _a, gconstpointer _b) {
+static int gui_internal_search_cmp(gconstpointer _a, gconstpointer _b) {
     struct widget *a=(struct widget *)_a, *b=(struct widget *)_b;
     char *sa,*sb;
     int r;
@@ -87,8 +81,7 @@ gui_internal_search_cmp(gconstpointer _a, gconstpointer _b) {
     return r;
 }
 
-static char *
-postal_str(struct search_list_result *res, int level) {
+static char *postal_str(struct search_list_result *res, int level) {
     char *ret=NULL;
     if (res->town->common.postal)
         ret=res->town->common.postal;
@@ -109,8 +102,7 @@ postal_str(struct search_list_result *res, int level) {
     return ret;
 }
 
-static char *
-get_string_from_attr_list(struct attr **attrs, enum attr_type type, char *dflt) {
+static char *get_string_from_attr_list(struct attr **attrs, enum attr_type type, char *dflt) {
     struct attr attr;
     if(attr_generic_get_attr(attrs,NULL,type,&attr,NULL))
         return attr.u.str;
@@ -118,8 +110,7 @@ get_string_from_attr_list(struct attr **attrs, enum attr_type type, char *dflt) 
         return dflt;
 }
 
-static char *
-district_str(struct search_list_result *res, int level, enum attr_type district, char *dflt) {
+static char *district_str(struct search_list_result *res, int level, enum attr_type district, char *dflt) {
     char *ret=dflt;
 
     ret=get_string_from_attr_list(res->town->common.attrs, district, ret);
@@ -136,8 +127,7 @@ district_str(struct search_list_result *res, int level, enum attr_type district,
     return ret;
 }
 
-static char *
-town_display_label(struct search_list_result *res, int level, int flags) {
+static char *town_display_label(struct search_list_result *res, int level, int flags) {
     char *town=district_str(res, level,attr_town_name,"");
     char *district=district_str(res, level,attr_district_name,NULL);
     char *postal=postal_str(res, level);
@@ -178,8 +168,8 @@ town_display_label(struct search_list_result *res, int level, int flags) {
                            county);
 }
 
-static void
-gui_internal_find_next_possible_key(char *search_text, char *wm_name, char *possible_keys, char *item_name) {
+static void gui_internal_find_next_possible_key(char *search_text, char *wm_name, char *possible_keys,
+        char *item_name) {
     gchar* trunk_name;
     if (item_name) {
 
@@ -205,8 +195,7 @@ gui_internal_find_next_possible_key(char *search_text, char *wm_name, char *poss
     }
 }
 
-static void
-gui_internal_highlight_possible_keys(struct gui_priv *this, char *possible_keys) {
+static void gui_internal_highlight_possible_keys(struct gui_priv *this, char *possible_keys) {
     struct menu_data *md;
     int first_available_key_found = 0;
 
@@ -259,8 +248,7 @@ gui_internal_highlight_possible_keys(struct gui_priv *this, char *possible_keys)
 
 }
 
-static int
-gui_internal_get_match_quality(char *item_name, char* search_text, int is_house_number_without_street) {
+static int gui_internal_get_match_quality(char *item_name, char* search_text, int is_house_number_without_street) {
     enum match_quality {
         full_string_match, word_match, substring_match, housenum_but_no_street_match
     }
@@ -299,9 +287,9 @@ gui_internal_get_match_quality(char *item_name, char* search_text, int is_house_
     return match_quality;
 }
 
-static struct widget*
-gui_internal_create_resultlist_entry(struct gui_priv *this, struct search_list_result *res, char *result_main_label,
-                                     char *result_sublabel, void *param, char *widget_name, struct item *item) {
+static struct widget* gui_internal_create_resultlist_entry(struct gui_priv *this, struct search_list_result *res,
+        char *result_main_label,
+        char *result_sublabel, void *param, char *widget_name, struct item *item) {
     struct widget *resultlist_entry;
     if(result_sublabel) {
         struct widget *entry_sublabel;
@@ -337,8 +325,7 @@ gui_internal_create_resultlist_entry(struct gui_priv *this, struct search_list_r
  */
 char possible_keys_incremental_search[256]="";
 
-static void
-gui_internal_search_idle(struct gui_priv *this, char *wm_name, struct widget *search_list, void *param) {
+static void gui_internal_search_idle(struct gui_priv *this, char *wm_name, struct widget *search_list, void *param) {
     char *result_main_label=NULL,*result_sublabel=NULL,*item_name=NULL, *widget_name=NULL, *search_text;
     struct search_list_result *res;
     struct item *item=NULL;
@@ -408,15 +395,14 @@ gui_internal_search_idle(struct gui_priv *this, char *wm_name, struct widget *se
     g_free(result_sublabel);
 }
 
-static void
-gui_internal_search_idle_start(struct gui_priv *this, char *wm_name, struct widget *search_list, void *param) {
+static void gui_internal_search_idle_start(struct gui_priv *this, char *wm_name, struct widget *search_list,
+        void *param) {
     this->idle_cb=callback_new_4(callback_cast(gui_internal_search_idle), this, wm_name, search_list, param);
     this->idle=event_add_idle(50,this->idle_cb);
     callback_call_0(this->idle_cb);
 }
 
-static void
-gui_internal_search_changed(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_search_changed(struct gui_priv *this, struct widget *wm, void *data) {
     GList *l;
     struct widget *search_list=gui_internal_menu_data(this)->search_list;
     void *param=(void *)3;
@@ -456,8 +442,7 @@ gui_internal_search_changed(struct gui_priv *this, struct widget *wm, void *data
     gui_internal_widget_render(this, l->data);
 }
 
-static void
-gui_internal_search_list_set_default_country(struct gui_priv *this) {
+static void gui_internal_search_list_set_default_country(struct gui_priv *this) {
     struct attr search_attr, country_name, country_iso2, *country_attr;
     struct item *item;
     struct country_search *cs;
@@ -497,8 +482,7 @@ gui_internal_search_list_set_default_country(struct gui_priv *this) {
     }
 }
 
-static void
-gui_internal_search_list_new(struct gui_priv *this) {
+static void gui_internal_search_list_new(struct gui_priv *this) {
     struct mapset *ms=navit_get_mapset(this->nav);
     if (! this->sl) {
         this->sl=search_list_new(ms);
@@ -506,16 +490,14 @@ gui_internal_search_list_new(struct gui_priv *this) {
     }
 }
 
-void
-gui_internal_search_list_destroy(struct gui_priv *this) {
+void gui_internal_search_list_destroy(struct gui_priv *this) {
     if (this->sl) {
         search_list_destroy(this->sl);
         this->sl=NULL;
     }
 }
 
-void
-gui_internal_search(struct gui_priv *this, const char *what, const char *type, int flags) {
+void gui_internal_search(struct gui_priv *this, const char *what, const char *type, int flags) {
     struct widget *wb,*wk,*w,*wr,*we,*wl,*wnext=NULL;
     char *country;
     int keyboard_mode;
@@ -584,24 +566,21 @@ gui_internal_search(struct gui_priv *this, const char *what, const char *type, i
     gui_internal_menu_render(this);
 }
 
-void
-gui_internal_search_house_number_in_street(struct gui_priv *this, struct widget *widget, void *data) {
+void gui_internal_search_house_number_in_street(struct gui_priv *this, struct widget *widget, void *data) {
     dbg(lvl_info,"id %d", widget->selection_id);
     search_list_select(this->sl, attr_street_name, 0, 0);
     search_list_select(this->sl, attr_street_name, widget->selection_id, 1);
     gui_internal_search(this,_("House number"),"House number",0);
 }
 
-void
-gui_internal_search_street_in_town(struct gui_priv *this, struct widget *widget, void *data) {
+void gui_internal_search_street_in_town(struct gui_priv *this, struct widget *widget, void *data) {
     dbg(lvl_info,"id %d", widget->selection_id);
     search_list_select(this->sl, attr_town_or_district_name, 0, 0);
     search_list_select(this->sl, attr_town_or_district_name, widget->selection_id, 1);
     gui_internal_search(this,_("Street"),"Street",0);
 }
 
-void
-gui_internal_search_town_in_country(struct gui_priv *this, struct widget *widget) {
+void gui_internal_search_town_in_country(struct gui_priv *this, struct widget *widget) {
     struct search_list_common *slc;
     dbg(lvl_info,"id %d", widget->selection_id);
     search_list_select(this->sl, attr_country_all, 0, 0);

--- a/navit/gui/internal/gui_internal_widget.c
+++ b/navit/gui/internal/gui_internal_widget.c
@@ -13,8 +13,7 @@
 
 static void gui_internal_scroll_buttons_init(struct gui_priv *this, struct widget *widget, struct scroll_buttons *sb);
 
-static void
-gui_internal_background_render(struct gui_priv *this, struct widget *w) {
+static void gui_internal_background_render(struct gui_priv *this, struct widget *w) {
     struct point pnt=w->p;
     if (w->state & STATE_HIGHLIGHTED)
         graphics_draw_rectangle(this->gra, this->highlight_background, &pnt, w->w, w->h);
@@ -89,8 +88,7 @@ gui_internal_image_new(struct gui_priv *this, struct graphics_image *image) {
     return widget;
 }
 
-static void
-gui_internal_image_render(struct gui_priv *this, struct widget *w) {
+static void gui_internal_image_render(struct gui_priv *this, struct widget *w) {
     struct point pnt;
 
     gui_internal_background_render(this, w);
@@ -108,8 +106,7 @@ gui_internal_image_render(struct gui_priv *this, struct widget *w) {
  * @param this The internal GUI instance
  * @param w The widget to render
  */
-static void
-gui_internal_label_render(struct gui_priv *this, struct widget *w) {
+static void gui_internal_label_render(struct gui_priv *this, struct widget *w) {
     struct point pnt=w->p;
     gui_internal_background_render(this, w);
     if (w->state & STATE_EDIT)
@@ -231,8 +228,7 @@ gui_internal_find_widget(struct widget *wi, struct point *p, int flags) {
 
 }
 
-void
-gui_internal_highlight_do(struct gui_priv *this, struct widget *found) {
+void gui_internal_highlight_do(struct gui_priv *this, struct widget *found) {
     if (found == this->highlighted)
         return;
 
@@ -258,8 +254,7 @@ gui_internal_highlight_do(struct gui_priv *this, struct widget *found) {
 //# Comment:
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
-void
-gui_internal_highlight(struct gui_priv *this) {
+void gui_internal_highlight(struct gui_priv *this) {
     struct widget *menu,*found=NULL;
     if (this->current.x > -1 && this->current.y > -1) {
         menu=g_list_last(this->root.children)->data;
@@ -604,8 +599,7 @@ static void gui_internal_box_pack(struct gui_priv *this, struct widget *w) {
     }
 }
 
-void
-gui_internal_widget_reset_pack(struct gui_priv *this, struct widget *w) {
+void gui_internal_widget_reset_pack(struct gui_priv *this, struct widget *w) {
     struct widget *wc;
     GList *l;
 
@@ -627,8 +621,7 @@ gui_internal_widget_reset_pack(struct gui_priv *this, struct widget *w) {
  * @param parent The parent widget
  * @param child The child widget
  */
-void
-gui_internal_widget_append(struct widget *parent, struct widget *child) {
+void gui_internal_widget_append(struct widget *parent, struct widget *child) {
     if (! child)
         return;
     if (! child->background)
@@ -643,8 +636,7 @@ gui_internal_widget_append(struct widget *parent, struct widget *child) {
  * @param parent The parent widget
  * @param child The child widget
  */
-void
-gui_internal_widget_prepend(struct widget *parent, struct widget *child) {
+void gui_internal_widget_prepend(struct widget *parent, struct widget *child) {
     if (! child->background)
         child->background=parent->background;
     parent->children=g_list_prepend(parent->children, child);
@@ -660,8 +652,7 @@ gui_internal_widget_prepend(struct widget *parent, struct widget *child) {
  * @param child The child widget
  * @param func The comparison function
  */
-void
-gui_internal_widget_insert_sorted(struct widget *parent, struct widget *child, GCompareFunc func) {
+void gui_internal_widget_insert_sorted(struct widget *parent, struct widget *child, GCompareFunc func) {
     if (! child->background)
         child->background=parent->background;
 
@@ -678,8 +669,7 @@ gui_internal_widget_insert_sorted(struct widget *parent, struct widget *child, G
  * @param this The internal GUI instance
  * @param w The widget whose children are to be destroyed
  */
-void
-gui_internal_widget_children_destroy(struct gui_priv *this, struct widget *w) {
+void gui_internal_widget_children_destroy(struct gui_priv *this, struct widget *w) {
     GList *l;
     struct widget *wc;
 
@@ -703,8 +693,7 @@ gui_internal_widget_children_destroy(struct gui_priv *this, struct widget *w) {
  * @param this The internal GUI instance
  * @param w The widget to destroy
  */
-void
-gui_internal_widget_destroy(struct gui_priv *this, struct widget *w) {
+void gui_internal_widget_destroy(struct gui_priv *this, struct widget *w) {
     gui_internal_widget_children_destroy(this, w);
     g_free(w->command);
     g_free(w->speech);
@@ -728,8 +717,7 @@ gui_internal_widget_destroy(struct gui_priv *this, struct widget *w) {
 }
 
 
-void
-gui_internal_widget_render(struct gui_priv *this, struct widget *w) {
+void gui_internal_widget_render(struct gui_priv *this, struct widget *w) {
     if(w->p.x > this->root.w || w->p.y > this->root.h || w->state & STATE_INVISIBLE)
         return;
 
@@ -751,8 +739,7 @@ gui_internal_widget_render(struct gui_priv *this, struct widget *w) {
     }
 }
 
-void
-gui_internal_widget_pack(struct gui_priv *this, struct widget *w) {
+void gui_internal_widget_pack(struct gui_priv *this, struct widget *w) {
     switch (w->type) {
     case widget_box:
         gui_internal_box_pack(this, w);
@@ -785,8 +772,7 @@ gui_internal_button_label(struct gui_priv *this, const char *label, int mode) {
     return wlb;
 }
 
-static void
-gui_internal_scroll_buttons_init(struct gui_priv *this, struct widget *widget, struct scroll_buttons *sb) {
+static void gui_internal_scroll_buttons_init(struct gui_priv *this, struct widget *widget, struct scroll_buttons *sb) {
     sb->next_button =  gui_internal_button_new_with_callback(this, _("Next"), image_new_xs(this, "gui_arrow_right"),
                        gravity_center|orientation_horizontal|flags_swap, gui_internal_table_button_next, widget);
     sb->prev_button =  gui_internal_button_new_with_callback(this, _("Prev"), image_new_xs(this, "gui_arrow_left"),
@@ -881,8 +867,7 @@ void gui_internal_widget_table_clear(struct gui_priv * this,struct widget * tabl
  *
  * @return GList pointer to the next row in the children list, or NULL if there are no any rows left.
  */
-GList *
-gui_internal_widget_table_next_row(GList * row) {
+GList *gui_internal_widget_table_next_row(GList * row) {
     while((row=g_list_next(row))!=NULL) {
         if(row->data && ((struct widget *)(row->data))->type == widget_table_row)
             break;
@@ -897,8 +882,7 @@ gui_internal_widget_table_next_row(GList * row) {
  *
  * @return GList pointer to the previous row in the children list, or NULL if there are no any rows left.
  */
-GList *
-gui_internal_widget_table_prev_row(GList * row) {
+GList *gui_internal_widget_table_prev_row(GList * row) {
     while((row=g_list_previous(row))!=NULL) {
         if(row->data && ((struct widget *)(row->data))->type == widget_table_row)
             break;
@@ -913,8 +897,7 @@ gui_internal_widget_table_prev_row(GList * row) {
  *
  * @return GList pointer to the first row in the children list, or NULL if table is empty.
  */
-GList *
-gui_internal_widget_table_first_row(GList * row) {
+GList *gui_internal_widget_table_first_row(GList * row) {
     if(!row)
         return NULL;
 
@@ -929,8 +912,7 @@ gui_internal_widget_table_first_row(GList * row) {
  *
  * @return GList pointer to the top row in the children list, or NULL.
  */
-GList *
-gui_internal_widget_table_top_row(struct gui_priv *this, struct widget * table) {
+GList *gui_internal_widget_table_top_row(struct gui_priv *this, struct widget * table) {
     if(table && table->type==widget_table) {
         struct table_data *d=table->data;
         return gui_internal_widget_table_first_row(d->top_row);
@@ -943,8 +925,7 @@ gui_internal_widget_table_top_row(struct gui_priv *this, struct widget * table) 
  *
  * @return GList pointer to the top row in the children list of the table.
  */
-GList *
-gui_internal_widget_table_set_top_row(struct gui_priv *this, struct widget * table, struct widget *row) {
+GList *gui_internal_widget_table_set_top_row(struct gui_priv *this, struct widget * table, struct widget *row) {
     if(table && table->type==widget_table) {
         struct table_data *d=table->data;
         d->top_row=table->children;
@@ -988,8 +969,7 @@ gui_internal_widget_table_row_new(struct gui_priv * this, enum flags flags) {
  *
  * The caller is responsible for freeing the returned list.
  */
-static GList *
-gui_internal_compute_table_dimensions(struct gui_priv * this,struct widget * w) {
+static GList *gui_internal_compute_table_dimensions(struct gui_priv * this,struct widget * w) {
 
     GList * column_desc = NULL;
     GList * current_desc=NULL;
@@ -1076,8 +1056,7 @@ gui_internal_compute_table_dimensions(struct gui_priv * this,struct widget * w) 
  * @param this The graphics context
  * @param w The widget to pack.
  */
-void
-gui_internal_table_pack(struct gui_priv * this, struct widget * w) {
+void gui_internal_table_pack(struct gui_priv * this, struct widget * w) {
 
     int height=0;
     int width=0;
@@ -1140,8 +1119,7 @@ gui_internal_table_pack(struct gui_priv * this, struct widget * w) {
  *
  * @param table_data Data from the table object.
  */
-void
-gui_internal_table_hide_rows(struct table_data * table_data) {
+void gui_internal_table_hide_rows(struct table_data * table_data) {
     GList*cur_row;
     for(cur_row=table_data->top_row; cur_row ; cur_row = g_list_next(cur_row)) {
         struct widget * cur_row_widget = (struct widget*)cur_row->data;
@@ -1163,8 +1141,7 @@ gui_internal_table_hide_rows(struct table_data * table_data) {
  * @param this The graphics context
  * @param w The table widget to render.
  */
-void
-gui_internal_table_render(struct gui_priv * this, struct widget * w) {
+void gui_internal_table_render(struct gui_priv * this, struct widget * w) {
 
     int x;
     int y;
@@ -1341,8 +1318,7 @@ gui_internal_table_render(struct gui_priv * this, struct widget * w) {
  * @param wm The button widget that was pressed.
  * @param data
  */
-void
-gui_internal_table_button_next(struct gui_priv * this, struct widget * wm, void *data) {
+void gui_internal_table_button_next(struct gui_priv * this, struct widget * wm, void *data) {
     struct widget * table_widget=NULL;
     struct table_data * table_data = NULL;
 
@@ -1379,8 +1355,7 @@ gui_internal_table_button_next(struct gui_priv * this, struct widget * wm, void 
  * @param this The graphics context.
  * @param wm The button widget that was pressed.
  */
-void
-gui_internal_table_button_prev(struct gui_priv * this, struct widget * wm, void *data) {
+void gui_internal_table_button_prev(struct gui_priv * this, struct widget * wm, void *data) {
     struct widget * table_widget = NULL;
     struct table_data * table_data = NULL;
 

--- a/navit/gui/qml/gui_qml.cpp
+++ b/navit/gui/qml/gui_qml.cpp
@@ -224,8 +224,7 @@ static void gui_qml_keypress(void *data, char *key) {
     return;
 }
 
-static void
-gui_qml_window_closed(struct gui_priv *data) {
+static void gui_qml_window_closed(struct gui_priv *data) {
     struct gui_priv *this_=(struct gui_priv*) data;
     this_->navitProxy->quit();
 }
@@ -328,8 +327,7 @@ static int gui_qml_set_graphics(struct gui_priv *this_, struct graphics *gra) {
     return 0;
 }
 
-static int
-gui_qml_get_attr(struct gui_priv *this_, enum attr_type type, struct attr *attr) {
+static int gui_qml_get_attr(struct gui_priv *this_, enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_fullscreen:
         attr->u.num=this_->fullscreen;
@@ -350,8 +348,7 @@ gui_qml_get_attr(struct gui_priv *this_, enum attr_type type, struct attr *attr)
     return 1;
 }
 
-static int
-gui_qml_set_attr(struct gui_priv *this_, struct attr *attr) {
+static int gui_qml_set_attr(struct gui_priv *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_fullscreen:
         if (!(this_->fullscreen) && (attr->u.num)) {
@@ -387,8 +384,7 @@ struct gui_methods gui_qml_methods = {
     gui_qml_set_attr,
 };
 
-static void
-gui_qml_command(struct gui_priv *this_, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void gui_qml_command(struct gui_priv *this_, char *function, struct attr **in, struct attr ***out, int *valid) {
     this_->guiProxy->processCommand(function);
 }
 

--- a/navit/gui/qt5_qml/gui_qt5_qml.cpp
+++ b/navit/gui/qt5_qml/gui_qt5_qml.cpp
@@ -95,8 +95,7 @@ struct gui_priv {
 
 #include "backend.h"
 
-static void
-gui_qt5_qml_button(void* data, int pressed, int button, struct point* p) {
+static void gui_qt5_qml_button(void* data, int pressed, int button, struct point* p) {
     struct gui_priv* gui_priv = (struct gui_priv*)data;
 
     /* check if navit wants to handle this */
@@ -114,24 +113,21 @@ gui_qt5_qml_button(void* data, int pressed, int button, struct point* p) {
     }
 }
 
-static void
-gui_qt5_qml_motion(void* data, struct point* p) {
+static void gui_qt5_qml_motion(void* data, struct point* p) {
     struct gui_priv* gui_priv = (struct gui_priv*)data;
     dbg(lvl_debug, "enter (%d, %d)", p->x, p->y);
     /* forward this to navit  */
     navit_handle_motion(gui_priv->nav, p);
 }
 
-static void
-gui_qt5_qml_resize(void* data, int w, int h) {
+static void gui_qt5_qml_resize(void* data, int w, int h) {
     struct gui_priv* gui_priv = (struct gui_priv*)data;
     dbg(lvl_debug, "enter");
     /* forward this to navit */
     navit_handle_resize(gui_priv->nav, w, h);
 }
 
-static void
-gui_qml_keypress(void* data, char* key) {
+static void gui_qml_keypress(void* data, char* key) {
     struct gui_priv* this_ = (struct gui_priv*)data;
     int w, h;
     struct point p;
@@ -175,8 +171,7 @@ gui_qml_keypress(void* data, char* key) {
     return;
 }
 
-static int
-gui_qt5_qml_set_graphics(struct gui_priv* gui_priv, struct graphics* gra) {
+static int gui_qt5_qml_set_graphics(struct gui_priv* gui_priv, struct graphics* gra) {
     struct transformation* trans;
     dbg(lvl_debug, "enter");
 
@@ -246,14 +241,12 @@ gui_qt5_qml_set_graphics(struct gui_priv* gui_priv, struct graphics* gra) {
     return 0;
 }
 
-static int
-gui_qt5_qml_get_attr(struct gui_priv* gui_priv, enum attr_type type, struct attr* attr) {
+static int gui_qt5_qml_get_attr(struct gui_priv* gui_priv, enum attr_type type, struct attr* attr) {
     dbg(lvl_debug, "enter");
     return 1;
 }
 
-static int
-gui_qt5_qml_set_attr(struct gui_priv* gui_priv, struct attr* attr) {
+static int gui_qt5_qml_set_attr(struct gui_priv* gui_priv, struct attr* attr) {
     dbg(lvl_debug, "enter");
     return 1;
 }
@@ -271,8 +264,8 @@ struct gui_methods gui_qt5_qml_methods = {
     gui_qt5_qml_set_attr,
 };
 
-static struct gui_priv*
-gui_qt5_qml_new(struct navit* nav, struct gui_methods* meth, struct attr** attrs, struct gui* gui) {
+static struct gui_priv* gui_qt5_qml_new(struct navit* nav, struct gui_methods* meth, struct attr** attrs,
+                                        struct gui* gui) {
     struct gui_priv* gui_priv;
     struct attr* attr;
 

--- a/navit/item.c
+++ b/navit/item.c
@@ -93,8 +93,7 @@ static GHashTable *default_flags_hash;
 
 static GHashTable *item_hash;
 
-void
-item_create_hash(void) {
+void item_create_hash(void) {
     int i;
     item_hash=g_hash_table_new(g_str_hash, g_str_equal);
     for (i=0 ; i < sizeof(item_names)/sizeof(struct item_name) ; i++) {
@@ -102,14 +101,12 @@ item_create_hash(void) {
     }
 }
 
-void
-item_destroy_hash(void) {
+void item_destroy_hash(void) {
     g_hash_table_destroy(item_hash);
     item_hash=NULL;
 }
 
-int *
-item_get_default_flags(enum item_type type) {
+int *item_get_default_flags(enum item_type type) {
     if (!default_flags_hash) {
         int i;
         default_flags_hash=g_hash_table_new(NULL, NULL);
@@ -120,8 +117,7 @@ item_get_default_flags(enum item_type type) {
     return g_hash_table_lookup(default_flags_hash, (void *)(long)type);
 }
 
-void
-item_cleanup(void) {
+void item_cleanup(void) {
     if (default_flags_hash)
         g_hash_table_destroy(default_flags_hash);
 }
@@ -138,8 +134,7 @@ item_cleanup(void) {
  * @param it The map item whose pointer is to be reset. This must be the active item, i.e. the last one retrieved from the
  * {@code map_rect}. There can only be one active item per {@code map_rect}.
  */
-void
-item_coord_rewind(struct item *it) {
+void item_coord_rewind(struct item *it) {
     it->meth->item_coord_rewind(it->priv_data);
 }
 
@@ -165,8 +160,7 @@ item_coord_rewind(struct item *it) {
  *
  * @return The number of coordinates actually retrieved and stored in {@code c}
  */
-int
-item_coord_get(struct item *it, struct coord *c, int count) {
+int item_coord_get(struct item *it, struct coord *c, int count) {
     return it->meth->item_coord_get(it->priv_data, c, count);
 }
 
@@ -195,15 +189,13 @@ item_coord_get(struct item *it, struct coord *c, int count) {
  * @param count TODO number of coordinates to add, delete or modify?
  * @param mode The change mode, see description
  */
-int
-item_coord_set(struct item *it, struct coord *c, int count, enum change_mode mode) {
+int item_coord_set(struct item *it, struct coord *c, int count, enum change_mode mode) {
     if (!it->meth->item_coord_set)
         return 0;
     return it->meth->item_coord_set(it->priv_data, c, count, mode);
 }
 
-int
-item_coord_get_within_selection(struct item *it, struct coord *c, int count, struct map_selection *sel) {
+int item_coord_get_within_selection(struct item *it, struct coord *c, int count, struct map_selection *sel) {
     int i,ret=it->meth->item_coord_get(it->priv_data, c, count);
     struct coord_rect r;
     struct map_selection *curr;
@@ -249,8 +241,7 @@ item_coord_get_within_selection(struct item *it, struct coord *c, int count, str
  *
  * @return The number of coordinates actually retrieved and stored in {@code c}
  */
-int
-item_coord_get_pro(struct item *it, struct coord *c, int count, enum projection to) {
+int item_coord_get_pro(struct item *it, struct coord *c, int count, enum projection to) {
     int ret=item_coord_get(it, c, count);
     int i;
     enum projection from=map_projection(it->map);
@@ -272,8 +263,7 @@ item_coord_get_pro(struct item *it, struct coord *c, int count, enum projection 
  *
  * @return True on success, false on failure
  */
-int
-item_coord_is_node(struct item *it) {
+int item_coord_is_node(struct item *it) {
     if (it->meth->item_coord_is_node)
         return it->meth->item_coord_is_node(it->priv_data);
     return 0;
@@ -291,8 +281,7 @@ item_coord_is_node(struct item *it) {
  * @param it The map item whose pointer is to be reset. This must be the active item, i.e. the last one retrieved from the
  * {@code map_rect}. There can only be one active item per {@code map_rect}.
  */
-void
-item_attr_rewind(struct item *it) {
+void item_attr_rewind(struct item *it) {
     it->meth->item_attr_rewind(it->priv_data);
 }
 
@@ -312,8 +301,7 @@ item_attr_rewind(struct item *it) {
  *
  * @return True on success, false on failure
  */
-int
-item_attr_get(struct item *it, enum attr_type attr_type, struct attr *attr) {
+int item_attr_get(struct item *it, enum attr_type attr_type, struct attr *attr) {
     return it->meth->item_attr_get(it->priv_data, attr_type, attr);
 }
 
@@ -339,8 +327,7 @@ item_attr_get(struct item *it, enum attr_type attr_type, struct attr *attr) {
  * @param attr TODO new attr, also store for old attr (delete/modify)? Required in delete mode (type of attr to delete)?
  * @param mode The change mode, see description
  */
-int
-item_attr_set(struct item *it, struct attr *attr, enum change_mode mode) {
+int item_attr_set(struct item *it, struct attr *attr, enum change_mode mode) {
     if (!it->meth->item_attr_set)
         return 0;
     return it->meth->item_attr_set(it->priv_data, attr, mode);
@@ -354,8 +341,7 @@ item_attr_set(struct item *it, struct attr *attr, enum change_mode mode) {
  *
  * @return Non-zero if this action is supported by the map and type is set successfully, 0 on error.
  */
-int
-item_type_set(struct item *it, enum item_type type) {
+int item_type_set(struct item *it, enum item_type type) {
     if (!it->meth->item_type_set)
         return 0;
     return it->meth->item_type_set(it->priv_data, type);
@@ -371,8 +357,7 @@ struct item * item_new(char *type, int zoom) {
     return it;
 }
 
-enum item_type
-item_from_name(const char *name) {
+enum item_type item_from_name(const char *name) {
     int i;
 
     if (item_hash)
@@ -385,8 +370,7 @@ item_from_name(const char *name) {
     return type_none;
 }
 
-char *
-item_to_name(enum item_type item) {
+char *item_to_name(enum item_type item) {
     int i;
 
     for (i=0 ; i < sizeof(item_names)/sizeof(struct item_name) ; i++) {
@@ -400,15 +384,13 @@ struct item_hash {
     GHashTable *h;
 };
 
-static guint
-item_hash_hash(gconstpointer key) {
+static guint item_hash_hash(gconstpointer key) {
     const struct item *itm=key;
     gconstpointer hashkey=(gconstpointer)GINT_TO_POINTER(itm->id_hi^itm->id_lo^(GPOINTER_TO_INT(itm->map)));
     return g_direct_hash(hashkey);
 }
 
-static gboolean
-item_hash_equal(gconstpointer a, gconstpointer b) {
+static gboolean item_hash_equal(gconstpointer a, gconstpointer b) {
     const struct item *itm_a=a;
     const struct item *itm_b=b;
     if (item_is_equal(*itm_a, *itm_b))
@@ -416,14 +398,12 @@ item_hash_equal(gconstpointer a, gconstpointer b) {
     return FALSE;
 }
 
-unsigned int
-item_id_hash(const void *key) {
+unsigned int item_id_hash(const void *key) {
     const struct item_id *id=key;
     return id->id_hi^id->id_lo;
 }
 
-int
-item_id_equal(const void *a, const void *b) {
+int item_id_equal(const void *a, const void *b) {
     const struct item_id *id_a=a;
     const struct item_id *id_b=b;
     return (id_a->id_hi == id_b->id_hi && id_a->id_lo == id_b->id_lo);
@@ -436,8 +416,7 @@ item_id_equal(const void *a, const void *b) {
  * @param id pointer to derive item id from.
  * @return  Nothing.
  */
-void
-item_id_from_ptr(struct item *item, void *id) {
+void item_id_from_ptr(struct item *item, void *id) {
 #if !defined(__LP64__) && !defined(__LLP64__) && !defined(WIN64)
     item->id_lo=(int) id;
     item->id_hi=0;
@@ -460,16 +439,14 @@ item_hash_new(void) {
     return ret;
 }
 
-void
-item_hash_insert(struct item_hash *h, struct item *item, void *val) {
+void item_hash_insert(struct item_hash *h, struct item *item, void *val) {
     struct item *hitem=g_new(struct item, 1);
     *hitem=*item;
     dbg(lvl_info,"inserting (0x%x,0x%x) into %p", item->id_hi, item->id_lo, h->h);
     g_hash_table_insert(h->h, hitem, val);
 }
 
-int
-item_hash_remove(struct item_hash *h, struct item *item) {
+int item_hash_remove(struct item_hash *h, struct item *item) {
     int ret;
 
     dbg(lvl_info,"removing (0x%x,0x%x) from %p", item->id_hi, item->id_lo, h->h);
@@ -479,43 +456,37 @@ item_hash_remove(struct item_hash *h, struct item *item) {
     return ret;
 }
 
-void *
-item_hash_lookup(struct item_hash *h, struct item *item) {
+void *item_hash_lookup(struct item_hash *h, struct item *item) {
     return g_hash_table_lookup(h->h, item);
 }
 
 
-void
-item_hash_destroy(struct item_hash *h) {
+void item_hash_destroy(struct item_hash *h) {
     g_hash_table_destroy(h->h);
     g_free(h);
 }
 
-int
-item_range_intersects_range(struct item_range *range1, struct item_range *range2) {
+int item_range_intersects_range(struct item_range *range1, struct item_range *range2) {
     if (range1->max < range2->min)
         return 0;
     if (range1->min > range2->max)
         return 0;
     return 1;
 }
-int
-item_range_contains_item(struct item_range *range, enum item_type type) {
+int item_range_contains_item(struct item_range *range, enum item_type type) {
     if (type >= range->min && type <= range->max)
         return 1;
     return 0;
 }
 
-void
-item_dump_attr(struct item *item, struct map *map, FILE *out) {
+void item_dump_attr(struct item *item, struct map *map, FILE *out) {
     struct attr attr;
     fprintf(out,"type=%s", item_to_name(item->type));
     while (item_attr_get(item, attr_any, &attr))
         fprintf(out," %s='%s'", attr_to_name(attr.type), attr_to_text(&attr, map, 1));
 }
 
-void
-item_dump_filedesc(struct item *item, struct map *map, FILE *out) {
+void item_dump_filedesc(struct item *item, struct map *map, FILE *out) {
 
     int i,count,max=16384;
     struct coord *ca=g_alloca(sizeof(struct coord)*max);

--- a/navit/layout.c
+++ b/navit/layout.c
@@ -69,13 +69,11 @@ layout_attr_iter_new(void) {
     return g_new0(struct attr_iter, 1);
 }
 
-void
-layout_attr_iter_destroy(struct attr_iter *iter) {
+void layout_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
-int
-layout_get_attr(struct layout *layout, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int layout_get_attr(struct layout *layout, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     GList *cursor,*layer;
     attr->type=type;
     switch (type) {
@@ -122,8 +120,7 @@ layout_get_attr(struct layout *layout, enum attr_type type, struct attr *attr, s
 }
 
 
-int
-layout_add_attr(struct layout *layout, struct attr *attr) {
+int layout_add_attr(struct layout *layout, struct attr *attr) {
     switch (attr->type) {
     case attr_cursor:
         layout->cursors = g_list_append(layout->cursors, attr->u.cursor);
@@ -198,8 +195,7 @@ cursor_new(struct attr *parent, struct attr **attrs) {
     return this;
 }
 
-void
-cursor_destroy(struct cursor *this_) {
+void cursor_destroy(struct cursor *this_) {
     if (this_->sequence_range)
         g_free(this_->sequence_range);
     if (this_->name) {
@@ -208,8 +204,7 @@ cursor_destroy(struct cursor *this_) {
     g_free(this_);
 }
 
-int
-cursor_add_attr(struct cursor *this_, struct attr *attr) {
+int cursor_add_attr(struct cursor *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_itemgra:
         this_->attrs=attr_generic_add_attr(this_->attrs, attr);
@@ -220,8 +215,7 @@ cursor_add_attr(struct cursor *this_, struct attr *attr) {
     return 0;
 }
 
-static int
-layer_set_attr_do(struct layer *l, struct attr *attr, int init) {
+static int layer_set_attr_do(struct layer *l, struct attr *attr, int init) {
     struct attr_iter *iter;
     struct navit_object *obj;
     struct attr layer;
@@ -282,8 +276,7 @@ struct layer * layer_new(struct attr *parent, struct attr **attrs) {
     return l;
 }
 
-int
-layer_get_attr(struct layer *layer, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int layer_get_attr(struct layer *layer, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     attr->type=type;
     switch(type) {
     case attr_active:
@@ -304,8 +297,7 @@ layer_get_attr(struct layer *layer, enum attr_type type, struct attr *attr, stru
     return 0;
 }
 
-int
-layer_add_attr(struct layer *layer, struct attr *attr) {
+int layer_add_attr(struct layer *layer, struct attr *attr) {
     switch (attr->type) {
     case attr_itemgra:
         layer->itemgras = g_list_append(layer->itemgras, attr->u.itemgra);
@@ -315,13 +307,11 @@ layer_add_attr(struct layer *layer, struct attr *attr) {
     }
 }
 
-int
-layer_set_attr(struct layer *layer, struct attr *attr) {
+int layer_set_attr(struct layer *layer, struct attr *attr) {
     return layer_set_attr_do(layer, attr, 0);
 }
 
-static void
-layer_destroy(struct layer *layer) {
+static void layer_destroy(struct layer *layer) {
     attr_list_free(layer->attrs);
     g_free(layer->name);
     g_free(layer);
@@ -366,8 +356,7 @@ struct itemgra * itemgra_new(struct attr *parent, struct attr **attrs) {
     }
     return itm;
 }
-int
-itemgra_add_attr(struct itemgra *itemgra, struct attr *attr) {
+int itemgra_add_attr(struct itemgra *itemgra, struct attr *attr) {
     switch (attr->type) {
     case attr_polygon:
     case attr_polyline:
@@ -384,8 +373,7 @@ itemgra_add_attr(struct itemgra *itemgra, struct attr *attr) {
     }
 }
 
-static void
-element_set_color(struct element *e, struct attr **attrs) {
+static void element_set_color(struct element *e, struct attr **attrs) {
     struct attr *color;
     color=attr_search(attrs, NULL, attr_color);
     if (color)
@@ -393,8 +381,7 @@ element_set_color(struct element *e, struct attr **attrs) {
 }
 
 
-static void
-element_set_background_color(struct color *c, struct attr **attrs) {
+static void element_set_background_color(struct color *c, struct attr **attrs) {
     struct attr *color;
     color=attr_search(attrs, NULL, attr_background_color);
     if (color)
@@ -402,32 +389,28 @@ element_set_background_color(struct color *c, struct attr **attrs) {
 }
 
 
-static void
-element_set_text_size(struct element *e, struct attr **attrs) {
+static void element_set_text_size(struct element *e, struct attr **attrs) {
     struct attr *text_size;
     text_size=attr_search(attrs, NULL, attr_text_size);
     if (text_size)
         e->text_size=text_size->u.num;
 }
 
-static void
-element_set_polyline_width(struct element *e, struct attr **attrs) {
+static void element_set_polyline_width(struct element *e, struct attr **attrs) {
     struct attr *width;
     width=attr_search(attrs, NULL, attr_width);
     if (width)
         e->u.polyline.width=width->u.num;
 }
 
-static void
-element_set_polyline_directed(struct element *e, struct attr **attrs) {
+static void element_set_polyline_directed(struct element *e, struct attr **attrs) {
     struct attr *directed;
     directed=attr_search(attrs, NULL, attr_directed);
     if (directed)
         e->u.polyline.directed=directed->u.num;
 }
 
-static void
-element_set_polyline_dash(struct element *e, struct attr **attrs) {
+static void element_set_polyline_dash(struct element *e, struct attr **attrs) {
     struct attr *dash;
     int i;
 
@@ -442,24 +425,21 @@ element_set_polyline_dash(struct element *e, struct attr **attrs) {
     }
 }
 
-static void
-element_set_polyline_offset(struct element *e, struct attr **attrs) {
+static void element_set_polyline_offset(struct element *e, struct attr **attrs) {
     struct attr *offset;
     offset=attr_search(attrs, NULL, attr_offset);
     if (offset)
         e->u.polyline.offset=offset->u.num;
 }
 
-static void
-element_set_circle_width(struct element *e, struct attr **attrs) {
+static void element_set_circle_width(struct element *e, struct attr **attrs) {
     struct attr *width;
     width=attr_search(attrs, NULL, attr_width);
     if (width)
         e->u.circle.width=width->u.num;
 }
 
-static void
-element_set_circle_radius(struct element *e, struct attr **attrs) {
+static void element_set_circle_radius(struct element *e, struct attr **attrs) {
     struct attr *radius;
     radius=attr_search(attrs, NULL, attr_radius);
     if (radius)
@@ -579,8 +559,7 @@ arrows_new(struct attr *parent, struct attr **attrs) {
     return (struct arrows *)e;
 }
 
-int
-element_add_attr(struct element *e, struct attr *attr) {
+int element_add_attr(struct element *e, struct attr *attr) {
     switch (attr->type) {
     case attr_coord:
         e->coord=g_realloc(e->coord,(e->coord_count+1)*sizeof(struct coord));

--- a/navit/linguistics.c
+++ b/navit/linguistics.c
@@ -285,8 +285,7 @@ static GHashTable *casefold_hash, *special_hash;
  * @param in String to prepeare.
  * @return String prepared for case insensitive search. Result shoud be g_free()d after use.
  */
-char*
-linguistics_casefold(const char *in) {
+char* linguistics_casefold(const char *in) {
     int len=strlen(in);
     const char *src=in;
     char *ret=g_new(char,len+1);
@@ -320,8 +319,7 @@ linguistics_casefold(const char *in) {
     return ret;
 }
 
-static char**
-linguistics_get_special(const char *str, const char *end) {
+static char** linguistics_get_special(const char *str, const char *end) {
     char *buf;
     int len;
     if(!end)
@@ -384,8 +382,7 @@ int linguistics_compare(const char *s1, const char *s2, enum linguistics_cmp_mod
  * replacement has multitple letter (e.g. a-umlaut -> ae)
  * @returns copy of string, with characters replaced
  */
-char *
-linguistics_expand_special(const char *str, int mode) {
+char *linguistics_expand_special(const char *str, int mode) {
     const char *in=str;
     char *out,*ret;
     int found=0;
@@ -442,16 +439,14 @@ linguistics_expand_special(const char *str, int mode) {
     return ret;
 }
 
-char *
-linguistics_next_word(char *str) {
+char *linguistics_next_word(char *str) {
     int len=strcspn(str, LINGUISTICS_WORD_SEPARATORS_ASCII);
     if (!str[len] || !str[len+1])
         return NULL;
     return str+len+1;
 }
 
-int
-linguistics_search(const char *str) {
+int linguistics_search(const char *str) {
     if (!g_ascii_strcasecmp(str,"str"))
         return 0;
     if (!g_ascii_strcasecmp(str,"str."))
@@ -478,8 +473,7 @@ static char
     return ret;
 }
 
-void
-linguistics_init(void) {
+void linguistics_init(void) {
     int i;
 
     casefold_hash=g_hash_table_new_full(g_str_hash, g_str_equal,g_free,g_free);
@@ -501,8 +495,7 @@ linguistics_init(void) {
 
 }
 
-void
-linguistics_free(void) {
+void linguistics_free(void) {
     g_hash_table_destroy(casefold_hash);
     g_hash_table_destroy(special_hash);
     casefold_hash=NULL;

--- a/navit/log.c
+++ b/navit/log.c
@@ -87,8 +87,7 @@ struct log {
  * @param fmt The format string
  * @return Nothing
  */
-static void
-strftime_localtime(char *buffer, int size, char *fmt) {
+static void strftime_localtime(char *buffer, int size, char *fmt) {
     time_t t;
     struct tm *tm;
 
@@ -107,8 +106,7 @@ strftime_localtime(char *buffer, int size, char *fmt) {
  *
  * @param this_ The log object.
  */
-static void
-expand_filenames(struct log *this_) {
+static void expand_filenames(struct log *this_) {
     char *pos,buffer[4096];
     int i;
 
@@ -137,8 +135,7 @@ expand_filenames(struct log *this_) {
  *
  * @param this_ The log object.
  */
-static void
-log_set_last_flush(struct log *this_) {
+static void log_set_last_flush(struct log *this_) {
 #ifdef HAVE_SYS_TIME_H
     gettimeofday(&this_->last_flush, NULL);
 #endif
@@ -162,8 +159,7 @@ log_set_last_flush(struct log *this_) {
  *
  * @param this_ The log object.
  */
-static void
-log_open(struct log *this_) {
+static void log_open(struct log *this_) {
     char *mode;
     if (this_->overwrite)
         mode="w";
@@ -189,8 +185,7 @@ log_open(struct log *this_) {
  *
  * @param this_ The log object.
  */
-static void
-log_close(struct log *this_) {
+static void log_close(struct log *this_) {
     if (! this_->f)
         return;
     if (this_->trailer.len)
@@ -225,8 +220,7 @@ log_close(struct log *this_) {
  * <br>
  * {@code log_flag_truncate}: truncates the log file at the current position. On the Win32 Base API, this flag has no effect.
  */
-static void
-log_flush(struct log *this_, enum log_flags flags) {
+static void log_flush(struct log *this_, enum log_flags flags) {
     long pos;
     if (this_->lazy && !this_->f) {
         if (!this_->data.len)
@@ -275,8 +269,7 @@ log_flush(struct log *this_, enum log_flags flags) {
  * @param this_ The log object.
  * @return True if the cache needs to be flushed, false otherwise.
  */
-static int
-log_flush_required(struct log *this_) {
+static int log_flush_required(struct log *this_) {
     return this_->data.len > this_->flush_size;
 }
 
@@ -298,8 +291,7 @@ log_flush_required(struct log *this_) {
  *
  * @param this_ The log object.
  */
-static void
-log_change(struct log *this_) {
+static void log_change(struct log *this_) {
     log_flush(this_,0);
     log_close(this_);
     expand_filenames(this_);
@@ -316,8 +308,7 @@ log_change(struct log *this_) {
  * @param this_ The log object.
  * @return True if the date/time-dependent part of the filename has changed, false otherwise.
  */
-static int
-log_change_required(struct log *this_) {
+static int log_change_required(struct log *this_) {
     char buffer[4096];
 
     strftime_localtime(buffer, 4096, this_->filename);
@@ -332,8 +323,7 @@ log_change_required(struct log *this_) {
  *
  * @param this_ The log object.
  */
-static void
-log_timer(struct log *this_) {
+static void log_timer(struct log *this_) {
 #ifdef HAVE_SYS_TIME_H
     struct timeval tv;
     int delta;
@@ -354,8 +344,7 @@ log_timer(struct log *this_) {
  * @param iter An attribute iterator
  * @return True for success, false for failure
  */
-int
-log_get_attr(struct log *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int log_get_attr(struct log *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     return attr_generic_get_attr(this_->attrs, NULL, type, attr, iter);
 }
 
@@ -429,8 +418,7 @@ log_new(struct attr * parent,struct attr **attrs) {
  * @param data The header data.
  * @param len Size of the header data to be copied, in bytes.
  */
-void
-log_set_header(struct log *this_, char *data, int len) {
+void log_set_header(struct log *this_, char *data, int len) {
     this_->header.data=g_malloc(len);
     this_->header.max_len=this_->header.len=len;
     memcpy(this_->header.data, data, len);
@@ -446,8 +434,7 @@ log_set_header(struct log *this_, char *data, int len) {
  * @param data The trailer data.
  * @param len Size of the trailer data to be copied, in bytes.
  */
-void
-log_set_trailer(struct log *this_, char *data, int len) {
+void log_set_trailer(struct log *this_, char *data, int len) {
     this_->trailer.data=g_malloc(len);
     this_->trailer.max_len=this_->trailer.len=len;
     memcpy(this_->trailer.data, data, len);
@@ -475,8 +462,7 @@ log_set_trailer(struct log *this_, char *data, int len) {
  * <br>
  * {@code log_flag_truncate}: ignored
  */
-void
-log_write(struct log *this_, char *data, int len, enum log_flags flags) {
+void log_write(struct log *this_, char *data, int len, enum log_flags flags) {
     dbg(lvl_debug,"enter");
     if (log_change_required(this_)) {
         dbg(lvl_debug,"log_change");
@@ -503,8 +489,7 @@ log_write(struct log *this_, char *data, int len, enum log_flags flags) {
  * This can be NULL, in which case no information on buffer length will be stored.
  * @return Pointer to the data buffer.
  */
-void *
-log_get_buffer(struct log *this_, int *len) {
+void *log_get_buffer(struct log *this_, int *len) {
     if (len)
         *len=this_->data.len;
     return this_->data.data;
@@ -521,8 +506,7 @@ log_get_buffer(struct log *this_, int *len) {
  * @param fmt The format string.
  * @param ... Additional arguments must be specified for each placeholder in the format string.
  */
-void
-log_printf(struct log *this_, char *fmt, ...) {
+void log_printf(struct log *this_, char *fmt, ...) {
     char buffer[LOG_BUFFER_SIZE];
     int size;
     va_list ap;
@@ -541,8 +525,7 @@ log_printf(struct log *this_, char *fmt, ...) {
  *
  * @param this_ The log object.
  */
-void
-log_destroy(struct log *this_) {
+void log_destroy(struct log *this_) {
     dbg(lvl_debug,"enter");
     attr_list_free(this_->attrs);
     callback_destroy(this_->timer_callback);

--- a/navit/main.c
+++ b/navit/main.c
@@ -64,8 +64,7 @@ struct map_data *map_data_default;
 struct callback_list *cbl;
 
 #ifdef HAVE_API_WIN32
-void
-setenv(char *var, char *val, int overwrite) {
+void setenv(char *var, char *val, int overwrite) {
     char *str=g_strdup_printf("%s=%s",var,val);
     if (overwrite || !getenv(var))
         putenv(str);
@@ -89,8 +88,7 @@ static char *environment_vars[][5]= {
     {NULL,                NULL,         NULL,            NULL,          NULL},
 };
 
-static void
-main_setup_environment(int mode) {
+static void main_setup_environment(int mode) {
     int i=0;
     char *var,*val,*homedir;
     while ((var=environment_vars[i][0])) {
@@ -295,8 +293,7 @@ char *nls_table[][3]= {
     {NULL,NULL,NULL},		// Default - Can't find the language / Language not listed above
 };
 
-static void
-win_set_nls(void) {
+static void win_set_nls(void) {
     char country[32],lang[32];
     int i=0;
 
@@ -322,8 +319,7 @@ win_set_nls(void) {
 }
 #endif
 
-void
-main_init(const char *program) {
+void main_init(const char *program) {
     char *s;
 #ifdef _UNICODE		/* currently for wince */
     wchar_t wfilename[MAX_PATH + 1];

--- a/navit/map.c
+++ b/navit/map.c
@@ -126,8 +126,7 @@ map_new(struct attr *parent, struct attr **attrs) {
  * @param iter (NOT IMPLEMENTED) Used to iterate through all attributes of a type. Set this to NULL to get the first attribute, set this to an attr_iter to get the next attribute
  * @return True if the attribute type was found, false if not
  */
-int
-map_get_attr(struct map *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int map_get_attr(struct map *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     int ret=0;
     if (this_->meth.map_get_attr)
         ret=this_->meth.map_get_attr(this_->priv, type, attr);
@@ -152,8 +151,7 @@ map_get_attr(struct map *this_, enum attr_type type, struct attr *attr, struct a
  * @param attr The attribute to set
  * @return True if the attr could be set, false otherwise
  */
-int
-map_set_attr(struct map *this_, struct attr *attr) {
+int map_set_attr(struct map *this_, struct attr *attr) {
     this_->attrs=attr_generic_set_attr(this_->attrs, attr);
     if (this_->meth.map_set_attr)
         this_->meth.map_set_attr(this_->priv, attr);
@@ -170,8 +168,7 @@ map_set_attr(struct map *this_, struct attr *attr) {
  * @param this_ The map to associate the callback with
  * @param cb The callback to add
  */
-void
-map_add_callback(struct map *this_, struct callback *cb) {
+void map_add_callback(struct map *this_, struct callback *cb) {
     callback_list_add(this_->attr_cbl, cb);
 }
 
@@ -184,8 +181,7 @@ map_add_callback(struct map *this_, struct callback *cb) {
  * @param this_ The map to remove the callback from
  * @param cb The callback to remove
  */
-void
-map_remove_callback(struct map *this_, struct callback *cb) {
+void map_remove_callback(struct map *this_, struct callback *cb) {
     callback_list_remove(this_->attr_cbl, cb);
 }
 
@@ -196,8 +192,7 @@ map_remove_callback(struct map *this_, struct callback *cb) {
  * @param this_ Map to be checked for the need to convert strings
  * @return True if strings from the map have to be converted, false otherwise
  */
-int
-map_requires_conversion(struct map *this_) {
+int map_requires_conversion(struct map *this_) {
     return (this_->meth.charset != NULL && strcmp(this_->meth.charset, "utf-8"));
 }
 
@@ -211,8 +206,7 @@ char *map_converted_string_tmp=NULL;
  * @param str The string to be converted
  * @return The converted string. Don't care about it after use.
  */
-char *
-map_convert_string_tmp(struct map *this_, char *str) {
+char *map_convert_string_tmp(struct map *this_, char *str) {
     if(map_converted_string_tmp!=NULL)
         g_free(map_converted_string_tmp);
     map_converted_string_tmp=NULL;
@@ -233,14 +227,12 @@ map_convert_string_tmp(struct map *this_, char *str) {
  * @param str The string to be converted
  * @return The converted string. It has to be map_convert_free()d after use.
  */
-char *
-map_convert_string(struct map *this_, char *str) {
+char *map_convert_string(struct map *this_, char *str) {
     return map_convert_dup(map_convert_string_tmp(this_,str));
 }
 
 
-char *
-map_convert_dup(char *str) {
+char *map_convert_dup(char *str) {
     if(map_converted_string_tmp==str) {
         map_converted_string_tmp=NULL;
         return str;
@@ -253,8 +245,7 @@ map_convert_dup(char *str) {
  *
  * @param str The string to be freed
  */
-void
-map_convert_free(char *str) {
+void map_convert_free(char *str) {
     g_free(str);
 }
 
@@ -264,8 +255,7 @@ map_convert_free(char *str) {
  * @param this_ The map to return the projection of
  * @return The projection of the map
  */
-enum projection
-map_projection(struct map *this_) {
+enum projection map_projection(struct map *this_) {
     return this_->meth.pro;
 }
 
@@ -275,8 +265,7 @@ map_projection(struct map *this_) {
  * @param this_ The map to set the projection of
  * @param pro The projection to be set
  */
-void
-map_set_projection(struct map *this_, enum projection pro) {
+void map_set_projection(struct map *this_, enum projection pro) {
     this_->meth.pro=pro;
 }
 
@@ -286,8 +275,7 @@ map_set_projection(struct map *this_, enum projection pro) {
  * @param m The map to be destroyed
  */
 
-void
-map_destroy(struct map *m) {
+void map_destroy(struct map *m) {
     if (!m)
         return;
     if (m->priv)
@@ -372,8 +360,7 @@ map_rect_get_item_byid(struct map_rect *mr, int id_hi, int id_lo) {
  *
  * @param mr The map rect to be destroyed
  */
-void
-map_rect_destroy(struct map_rect *mr) {
+void map_rect_destroy(struct map_rect *mr) {
     if (mr) {
         mr->m->meth.map_rect_destroy(mr->priv);
         g_free(mr);
@@ -479,8 +466,7 @@ map_search_get_item(struct map_search *this_) {
  *
  * @param this_ The map search struct to be destroyed
  */
-void
-map_search_destroy(struct map_search *this_) {
+void map_search_destroy(struct map_search *this_) {
     if (! this_)
         return;
     if (this_->search_attr.type >= attr_country_all && this_->search_attr.type <= attr_country_name)
@@ -559,8 +545,7 @@ map_selection_dup(struct map_selection *sel) {
  *
  * @param sel The map selection to be destroyed
  */
-void
-map_selection_destroy(struct map_selection *sel) {
+void map_selection_destroy(struct map_selection *sel) {
     struct map_selection *next;
     while (sel) {
         next = sel->next;
@@ -579,8 +564,7 @@ map_selection_destroy(struct map_selection *sel) {
  * @param item The item that the rectangle should be built around
  * @return True if the rectangle is within the selection, false otherwise
  */
-int
-map_selection_contains_item_rect(struct map_selection *sel, struct item *item) {
+int map_selection_contains_item_rect(struct map_selection *sel, struct item *item) {
     struct coord c;
     struct coord_rect r;
     int count=0;
@@ -611,8 +595,7 @@ map_selection_contains_item_rect(struct map_selection *sel, struct item *item) {
  * @return True if there is a match, false otherwise
  */
 
-int
-map_selection_contains_item_range(struct map_selection *sel, int follow, struct item_range *range, int count) {
+int map_selection_contains_item_range(struct map_selection *sel, int follow, struct item_range *range, int count) {
     int i;
     if (! sel)
         return 1;
@@ -638,8 +621,7 @@ map_selection_contains_item_range(struct map_selection *sel, int follow, struct 
  * @return True if there is a match, false otherwise
  */
 
-int
-map_selection_contains_item(struct map_selection *sel, int follow, enum item_type type) {
+int map_selection_contains_item(struct map_selection *sel, int follow, enum item_type type) {
     if (! sel)
         return 1;
     while (sel) {
@@ -661,13 +643,11 @@ map_selection_contains_item(struct map_selection *sel, int follow, enum item_typ
  * @param priv The private data that should be checked.
  * @return True if priv is the private data of map
  */
-int
-map_priv_is(struct map *map, struct map_priv *priv) {
+int map_priv_is(struct map *map, struct map_priv *priv) {
     return (map->priv == priv);
 }
 
-void
-map_dump_filedesc(struct map *map, FILE *out) {
+void map_dump_filedesc(struct map *map, FILE *out) {
     struct map_rect *mr=map_rect_new(map, NULL);
     struct item *item;
 
@@ -676,8 +656,7 @@ map_dump_filedesc(struct map *map, FILE *out) {
     map_rect_destroy(mr);
 }
 
-void
-map_dump_file(struct map *map, const char *file) {
+void map_dump_file(struct map *map, const char *file) {
     FILE *f;
     f=fopen(file,"w");
     if (f) {
@@ -687,8 +666,7 @@ map_dump_file(struct map *map, const char *file) {
         dbg(lvl_error,"failed to open file '%s'",file);
 }
 
-void
-map_dump(struct map *map) {
+void map_dump(struct map *map) {
     map_dump_filedesc(map, stdout);
 }
 

--- a/navit/map/binfile/binfile.c
+++ b/navit/map/binfile/binfile.c
@@ -233,8 +233,7 @@ static void eoc_to_cpu(struct zip_eoc *eoc) {
 
 static void binfile_check_version(struct map_priv *m);
 
-static struct zip_eoc *
-binfile_read_eoc(struct file *fi) {
+static struct zip_eoc *binfile_read_eoc(struct file *fi) {
     struct zip_eoc *eoc;
     eoc=(struct zip_eoc *)file_data_read(fi,fi->size-sizeof(struct zip_eoc), sizeof(struct zip_eoc));
     if (eoc) {
@@ -249,8 +248,7 @@ binfile_read_eoc(struct file *fi) {
     return eoc;
 }
 
-static struct zip64_eoc *
-binfile_read_eoc64(struct file *fi) {
+static struct zip64_eoc *binfile_read_eoc64(struct file *fi) {
     struct zip64_eocl *eocl;
     struct zip64_eoc *eoc;
     eocl=(struct zip64_eocl *)file_data_read(fi,fi->size-sizeof(struct zip_eoc)-sizeof(struct zip64_eocl),
@@ -276,13 +274,11 @@ binfile_read_eoc64(struct file *fi) {
     return eoc;
 }
 
-static int
-binfile_cd_extra(struct zip_cd *cd) {
+static int binfile_cd_extra(struct zip_cd *cd) {
     return cd->zipcfnl+cd->zipcxtl;
 }
 
-static struct zip_cd *
-binfile_read_cd(struct map_priv *m, int offset, int len) {
+static struct zip_cd *binfile_read_cd(struct map_priv *m, int offset, int len) {
     struct zip_cd *cd;
     long long cdoffset=m->eoc64?m->eoc64->zip64eofst:m->eoc->zipeofst;
     if (len == -1) {
@@ -311,8 +307,7 @@ binfile_read_cd(struct map_priv *m, int offset, int len) {
  * @param cd pointer to zip central directory structure
  * @return pointer to ZIP64 extra field, or NULL if not available
  */
-static struct zip_cd_ext *
-binfile_cd_ext(struct zip_cd *cd) {
+static struct zip_cd_ext *binfile_cd_ext(struct zip_cd *cd) {
     struct zip_cd_ext *ext;
     if (cd->zipofst != zip_size_64bit_placeholder)
         return NULL;
@@ -329,8 +324,7 @@ binfile_cd_ext(struct zip_cd *cd) {
  * @return Offset of local file header in zip file.
  * Will use ZIP64 data if present.
  */
-static long long
-binfile_cd_offset(struct zip_cd *cd) {
+static long long binfile_cd_offset(struct zip_cd *cd) {
     struct zip_cd_ext *ext=binfile_cd_ext(cd);
     if (ext)
         return ext->zipofst;
@@ -338,8 +332,7 @@ binfile_cd_offset(struct zip_cd *cd) {
         return cd->zipofst;
 }
 
-static struct zip_lfh *
-binfile_read_lfh(struct file *fi, long long offset) {
+static struct zip_lfh *binfile_read_lfh(struct file *fi, long long offset) {
     struct zip_lfh *lfh;
 
     lfh=(struct zip_lfh *)(file_data_read(fi,offset,sizeof(struct zip_lfh)));
@@ -353,8 +346,7 @@ binfile_read_lfh(struct file *fi, long long offset) {
     return lfh;
 }
 
-static unsigned char *
-binfile_read_content(struct map_priv *m, struct file *fi, long long offset, struct zip_lfh *lfh) {
+static unsigned char *binfile_read_content(struct map_priv *m, struct file *fi, long long offset, struct zip_lfh *lfh) {
     unsigned char *ret=NULL;
 
     offset+=sizeof(struct zip_lfh)+lfh->zipfnln;
@@ -373,8 +365,7 @@ binfile_read_content(struct map_priv *m, struct file *fi, long long offset, stru
     return ret;
 }
 
-static int
-binfile_search_cd(struct map_priv *m, int offset, char *name, int partial, int skip) {
+static int binfile_search_cd(struct map_priv *m, int offset, char *name, int partial, int skip) {
     int size=4096;
     int end=m->eoc64?m->eoc64->zip64ecsz:m->eoc->zipecsz;
     int len=strlen(name);
@@ -418,30 +409,26 @@ binfile_search_cd(struct map_priv *m, int offset, char *name, int partial, int s
     return -1;
 }
 
-static void
-map_destroy_binfile(struct map_priv *m) {
+static void map_destroy_binfile(struct map_priv *m) {
     dbg(lvl_debug,"map_destroy_binfile");
     if (m->fi)
         map_binfile_close(m);
     map_binfile_destroy(m);
 }
 
-static void
-binfile_coord_rewind(void *priv_data) {
+static void binfile_coord_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t;
     t->pos_coord=t->pos_coord_start;
 }
 
-static inline int
-binfile_coord_left(void *priv_data) {
+static inline int binfile_coord_left(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t;
     return (t->pos_attr_start-t->pos_coord)/2;
 }
 
-static int
-binfile_coord_get(void *priv_data, struct coord *c, int count) {
+static int binfile_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t;
     int max,ret=0;
@@ -471,8 +458,7 @@ binfile_coord_get(void *priv_data, struct coord *c, int count) {
  * @param
  * @return
  */
-static void
-binfile_attr_rewind(void *priv_data) {
+static void binfile_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t;
     t->pos_attr=t->pos_attr_start;
@@ -481,8 +467,7 @@ binfile_attr_rewind(void *priv_data) {
 
 }
 
-static char *
-binfile_extract(struct map_priv *m, char *dir, char *filename, int partial) {
+static char *binfile_extract(struct map_priv *m, char *dir, char *filename, int partial) {
     char *full,*fulld,*sep;
     unsigned char *start;
     int len,offset=m->index_offset;
@@ -527,8 +512,7 @@ binfile_extract(struct map_priv *m, char *dir, char *filename, int partial) {
     return g_strdup_printf("%s/%s",dir,filename);
 }
 
-static int
-binfile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int binfile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t;
     enum attr_type type;
@@ -610,20 +594,17 @@ struct binfile_hash_entry {
     int data[0];
 };
 
-static guint
-binfile_hash_entry_hash(gconstpointer key) {
+static guint binfile_hash_entry_hash(gconstpointer key) {
     const struct binfile_hash_entry *entry=key;
     return (entry->id.id_hi ^ entry->id.id_lo);
 }
 
-static gboolean
-binfile_hash_entry_equal(gconstpointer a, gconstpointer b) {
+static gboolean binfile_hash_entry_equal(gconstpointer a, gconstpointer b) {
     const struct binfile_hash_entry *entry1=a,*entry2=b;
     return (entry1->id.id_hi==entry2->id.id_hi && entry1->id.id_lo == entry2->id.id_lo);
 }
 
-static int *
-binfile_item_dup(struct map_priv *m, struct item *item, struct tile *t, int extend) {
+static int *binfile_item_dup(struct map_priv *m, struct item *item, struct tile *t, int extend) {
     int size=le32_to_cpu(t->pos[0]);
     struct binfile_hash_entry *entry=g_malloc(sizeof(struct binfile_hash_entry)+(size+1+extend)*sizeof(int));
     void *ret=entry->data;
@@ -640,8 +621,7 @@ binfile_item_dup(struct map_priv *m, struct item *item, struct tile *t, int exte
     return ret;
 }
 
-static int
-binfile_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode) {
+static int binfile_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t,*tn,new;
     int i,delta,move_len;
@@ -735,8 +715,7 @@ binfile_coord_set(void *priv_data, struct coord *c, int count, enum change_mode 
     return 1;
 }
 
-static int
-binfile_attr_set(void *priv_data, struct attr *attr, enum change_mode mode) {
+static int binfile_attr_set(void *priv_data, struct attr *attr, enum change_mode mode) {
     struct map_rect_priv *mr=priv_data;
     struct tile *t=mr->t,*tn,new;
     int offset,delta,move_len;
@@ -852,8 +831,7 @@ static struct item_methods methods_binfile = {
     binfile_coord_set,
 };
 
-static void
-push_tile(struct map_rect_priv *mr, struct tile *t, int offset, int length) {
+static void push_tile(struct map_rect_priv *mr, struct tile *t, int offset, int length) {
     dbg_assert(mr->tile_depth < 8);
     mr->t=&mr->tiles[mr->tile_depth++];
     *(mr->t)=*t;
@@ -864,8 +842,7 @@ push_tile(struct map_rect_priv *mr, struct tile *t, int offset, int length) {
         mr->t->end=mr->t->pos+length;
 }
 
-static int
-pop_tile(struct map_rect_priv *mr) {
+static int pop_tile(struct map_rect_priv *mr) {
     if (mr->tile_depth <= 1)
         return 0;
     if (mr->t->mode < 2)
@@ -880,8 +857,7 @@ pop_tile(struct map_rect_priv *mr) {
 }
 
 
-static int
-zipfile_to_tile(struct map_priv *m, struct zip_cd *cd, struct tile *t) {
+static int zipfile_to_tile(struct map_priv *m, struct zip_cd *cd, struct tile *t) {
     char buffer[1024];
     struct zip_lfh *lfh;
     char *zipfn;
@@ -907,8 +883,7 @@ zipfile_to_tile(struct map_priv *m, struct zip_cd *cd, struct tile *t) {
 }
 
 
-static int
-map_binfile_handle_redirect(struct map_priv *m) {
+static int map_binfile_handle_redirect(struct map_priv *m) {
     char *location=file_http_header(m->http, "location");
     if (!location) {
         m->redirect=0;
@@ -926,8 +901,7 @@ map_binfile_handle_redirect(struct map_priv *m) {
     return 1;
 }
 
-static int
-map_binfile_http_request(struct map_priv *m, struct attr **attrs) {
+static int map_binfile_http_request(struct map_priv *m, struct attr **attrs) {
     if (!m->http) {
         m->http=file_create(NULL, attrs);
     } else {
@@ -937,8 +911,7 @@ map_binfile_http_request(struct map_priv *m, struct attr **attrs) {
 }
 
 
-static long long
-map_binfile_download_size(struct map_priv *m) {
+static long long map_binfile_download_size(struct map_priv *m) {
     struct attr url= {attr_url};
     struct attr http_method= {attr_http_method};
     struct attr persistent= {attr_persistent};
@@ -969,8 +942,7 @@ map_binfile_download_size(struct map_priv *m) {
 }
 
 
-static int
-map_binfile_http_close(struct map_priv *m) {
+static int map_binfile_http_close(struct map_priv *m) {
     if (m->http) {
         file_destroy(m->http);
         m->http=NULL;
@@ -979,8 +951,7 @@ map_binfile_http_close(struct map_priv *m) {
 }
 
 
-static struct file *
-map_binfile_http_range(struct map_priv *m, long long offset, int size) {
+static struct file *map_binfile_http_range(struct map_priv *m, long long offset, int size) {
     struct attr *attrs[4];
     struct attr url= {attr_url};
     struct attr http_header= {attr_http_header};
@@ -999,8 +970,7 @@ map_binfile_http_range(struct map_priv *m, long long offset, int size) {
     return m->http;
 }
 
-static unsigned char *
-map_binfile_download_range(struct map_priv *m, long long offset, int size) {
+static unsigned char *map_binfile_download_range(struct map_priv *m, long long offset, int size) {
     unsigned char *ret;
     int size_ret;
     struct file *http=map_binfile_http_range(m, offset, size);
@@ -1014,8 +984,7 @@ map_binfile_download_range(struct map_priv *m, long long offset, int size) {
     return ret;
 }
 
-static struct zip_cd *
-download_cd(struct map_download *download) {
+static struct zip_cd *download_cd(struct map_download *download) {
     struct map_priv *m=download->m;
     struct zip64_eoc *zip64_eoc=(struct zip64_eoc *)file_data_read(m->fi, 0, sizeof(*zip64_eoc));
     struct zip_cd *cd=(struct zip_cd *)map_binfile_download_range(m, zip64_eoc->zip64eofst+download->zipfile*m->cde_size,
@@ -1025,8 +994,7 @@ download_cd(struct map_download *download) {
     return cd;
 }
 
-static int
-download_request(struct map_download *download) {
+static int download_request(struct map_download *download) {
     struct attr url= {attr_url};
     struct attr http_header= {attr_http_header};
     struct attr persistent= {attr_persistent};
@@ -1061,8 +1029,7 @@ download_request(struct map_download *download) {
 }
 
 
-static int
-download_start(struct map_download *download) {
+static int download_start(struct map_download *download) {
     long long offset;
     struct zip_eoc *eoc;
 
@@ -1084,8 +1051,7 @@ download_start(struct map_download *download) {
     return download_request(download);
 }
 
-static int
-download_download(struct map_download *download) {
+static int download_download(struct map_download *download) {
     int size=64*1024,size_ret;
     unsigned char *data;
     if (download->dl_size != -1 && size > download->dl_size)
@@ -1113,8 +1079,7 @@ download_download(struct map_download *download) {
     return 0;
 }
 
-static int
-download_finish(struct map_download *download) {
+static int download_finish(struct map_download *download) {
     struct zip_lfh *lfh;
     char *lfh_filename;
     struct zip_cd_ext *ext;
@@ -1147,8 +1112,7 @@ download_finish(struct map_download *download) {
     return 1;
 }
 
-static int
-download_planet_size(struct map_download *download) {
+static int download_planet_size(struct map_download *download) {
     download->size=map_binfile_download_size(download->m);
     dbg(lvl_debug,"Planet size "LONGLONG_FMT"",download->size);
     if (!download->size)
@@ -1156,8 +1120,7 @@ download_planet_size(struct map_download *download) {
     return 1;
 }
 
-static int
-download_eoc(struct map_download *download) {
+static int download_eoc(struct map_download *download) {
     download->zip64_eoc=(struct zip64_eoc *)map_binfile_download_range(download->m, download->size-98, 98);
     if (!download->zip64_eoc)
         return 0;
@@ -1172,16 +1135,14 @@ download_eoc(struct map_download *download) {
     return 1;
 }
 
-static int
-download_directory_start(struct map_download *download) {
+static int download_directory_start(struct map_download *download) {
     download->http=map_binfile_http_range(download->m, download->zip64_eoc->zip64eofst, download->zip64_eoc->zip64ecsz);
     if (!download->http)
         return 0;
     return 1;
 }
 
-static int
-download_directory_do(struct map_download *download) {
+static int download_directory_do(struct map_download *download) {
     int count;
 
     for (count = 0 ; count < 100 ; count++) {
@@ -1213,14 +1174,12 @@ download_directory_do(struct map_download *download) {
     return 1;
 }
 
-static int
-download_directory_finish(struct map_download *download) {
+static int download_directory_finish(struct map_download *download) {
     download->http=NULL;
     return 1;
 }
 
-static int
-download_initial_finish(struct map_download *download) {
+static int download_initial_finish(struct map_download *download) {
     download->zip64_eoc->zip64eofst=download->cd1offset;
     download->zip64_eocl->zip64lofst=download->offset;
     download->zip_eoc->zipeofst=download->cd1offset;
@@ -1237,8 +1196,7 @@ download_initial_finish(struct map_download *download) {
     return 1;
 }
 
-static void
-push_zipfile_tile_do(struct map_rect_priv *mr, struct zip_cd *cd, int zipfile, int offset, int length)
+static void push_zipfile_tile_do(struct map_rect_priv *mr, struct zip_cd *cd, int zipfile, int offset, int length)
 
 {
     struct tile t;
@@ -1264,9 +1222,9 @@ push_zipfile_tile_do(struct map_rect_priv *mr, struct zip_cd *cd, int zipfile, i
 }
 
 
-static struct zip_cd *
-download(struct map_priv *m, struct map_rect_priv *mr, struct zip_cd *cd, int zipfile, int offset, int length,
-         int async) {
+static struct zip_cd *download(struct map_priv *m, struct map_rect_priv *mr, struct zip_cd *cd, int zipfile, int offset,
+                               int length,
+                               int async) {
     struct map_download *download;
 
     if(!m->download_enabled)
@@ -1403,8 +1361,7 @@ download(struct map_priv *m, struct map_rect_priv *mr, struct zip_cd *cd, int zi
     }
 }
 
-static int
-push_zipfile_tile(struct map_rect_priv *mr, int zipfile, int offset, int length, int async) {
+static int push_zipfile_tile(struct map_rect_priv *mr, int zipfile, int offset, int length, int async) {
     struct map_priv *m=mr->m;
     struct file *f=m->fi;
     long long cdoffset=m->eoc64?m->eoc64->zip64eofst:m->eoc->zipeofst;
@@ -1420,8 +1377,7 @@ push_zipfile_tile(struct map_rect_priv *mr, int zipfile, int offset, int length,
     return 0;
 }
 
-static struct map_rect_priv *
-map_rect_new_binfile_int(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *map_rect_new_binfile_int(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr;
 
     binfile_check_version(map);
@@ -1439,8 +1395,7 @@ map_rect_new_binfile_int(struct map_priv *map, struct map_selection *sel) {
     return mr;
 }
 
-static void
-tile_bbox(char *tile, int len, struct coord_rect *r) {
+static void tile_bbox(char *tile, int len, struct coord_rect *r) {
     struct coord c;
     int overlap=1;
     int xo,yo;
@@ -1479,8 +1434,7 @@ tile_bbox(char *tile, int len, struct coord_rect *r) {
     }
 }
 
-static int
-map_download_selection_check(struct zip_cd *cd, struct map_selection *sel) {
+static int map_download_selection_check(struct zip_cd *cd, struct map_selection *sel) {
     struct coord_rect cd_rect;
     if (cd->zipcunc)
         return 0;
@@ -1493,8 +1447,7 @@ map_download_selection_check(struct zip_cd *cd, struct map_selection *sel) {
     return 0;
 }
 
-static void
-map_download_selection(struct map_priv *m, struct map_rect_priv *mr, struct map_selection *sel) {
+static void map_download_selection(struct map_priv *m, struct map_rect_priv *mr, struct map_selection *sel) {
     int i;
     struct zip_cd *cd;
     for (i = 0 ; i < m->zip_members ; i++) {
@@ -1505,8 +1458,7 @@ map_download_selection(struct map_priv *m, struct map_rect_priv *mr, struct map_
     }
 }
 
-static struct map_rect_priv *
-map_rect_new_binfile(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *map_rect_new_binfile(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr=map_rect_new_binfile_int(map, sel);
     struct tile t;
     dbg(lvl_debug,"zip_members=%d", map->zip_members);
@@ -1533,8 +1485,7 @@ map_rect_new_binfile(struct map_priv *map, struct map_selection *sel) {
     return mr;
 }
 
-static void
-write_changes_do(gpointer key, gpointer value, gpointer user_data) {
+static void write_changes_do(gpointer key, gpointer value, gpointer user_data) {
     struct binfile_hash_entry *entry=key;
     FILE *out=user_data;
     if (entry->flags) {
@@ -1544,8 +1495,7 @@ write_changes_do(gpointer key, gpointer value, gpointer user_data) {
     }
 }
 
-static void
-write_changes(struct map_priv *m) {
+static void write_changes(struct map_priv *m) {
     FILE *changes;
     char *changes_file;
     if (!m->changes)
@@ -1557,8 +1507,7 @@ write_changes(struct map_priv *m) {
     g_free(changes_file);
 }
 
-static void
-load_changes(struct map_priv *m) {
+static void load_changes(struct map_priv *m) {
     FILE *changes;
     char *changes_file;
     struct binfile_hash_entry entry,*e;
@@ -1585,8 +1534,7 @@ load_changes(struct map_priv *m) {
 }
 
 
-static void
-map_rect_destroy_binfile(struct map_rect_priv *mr) {
+static void map_rect_destroy_binfile(struct map_rect_priv *mr) {
     write_changes(mr->m);
     while (pop_tile(mr));
 #ifdef DEBUG_SIZE
@@ -1599,8 +1547,7 @@ map_rect_destroy_binfile(struct map_rect_priv *mr) {
     g_free(mr);
 }
 
-static void
-setup_pos(struct map_rect_priv *mr) {
+static void setup_pos(struct map_rect_priv *mr) {
     int size,coord_size;
     struct tile *t=mr->t;
     size=le32_to_cpu(t->pos[0]);
@@ -1618,8 +1565,7 @@ setup_pos(struct map_rect_priv *mr) {
     t->pos_attr_start=t->pos_coord_start+coord_size;
 }
 
-static int
-selection_contains(struct map_selection *sel, struct coord_rect *r, struct range *mima) {
+static int selection_contains(struct map_selection *sel, struct coord_rect *r, struct range *mima) {
     int order;
     if (! sel)
         return 1;
@@ -1637,8 +1583,7 @@ selection_contains(struct map_selection *sel, struct coord_rect *r, struct range
     return 0;
 }
 
-static void
-map_parse_country_binfile(struct map_rect_priv *mr) {
+static void map_parse_country_binfile(struct map_rect_priv *mr) {
     struct attr at;
 
     if (!binfile_attr_get(mr->item.priv_data, attr_country_id, &at))
@@ -1672,8 +1617,7 @@ map_parse_country_binfile(struct map_rect_priv *mr) {
     push_zipfile_tile(mr, at.u.num, 0, 0, 0);
 }
 
-static int
-map_parse_submap(struct map_rect_priv *mr, int async) {
+static int map_parse_submap(struct map_rect_priv *mr, int async) {
     struct coord_rect r;
     struct coord c[2];
     struct attr at;
@@ -1700,8 +1644,7 @@ map_parse_submap(struct map_rect_priv *mr, int async) {
     return push_zipfile_tile(mr, at.u.num, 0, 0, async);
 }
 
-static int
-push_modified_item(struct map_rect_priv *mr) {
+static int push_modified_item(struct map_rect_priv *mr) {
     struct item_id id;
     struct binfile_hash_entry *entry;
     id.id_hi=mr->item.id_hi;
@@ -1719,8 +1662,7 @@ push_modified_item(struct map_rect_priv *mr) {
     return 0;
 }
 
-static struct item *
-map_rect_get_item_binfile(struct map_rect_priv *mr) {
+static struct item *map_rect_get_item_binfile(struct map_rect_priv *mr) {
     struct tile *t;
     struct map_priv *m=mr->m;
     if (m->download) {
@@ -1770,8 +1712,7 @@ map_rect_get_item_binfile(struct map_rect_priv *mr) {
     }
 }
 
-static struct item *
-map_rect_get_item_byid_binfile(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_rect_get_item_byid_binfile(struct map_rect_priv *mr, int id_hi, int id_lo) {
     struct tile *t;
     if (mr->m->eoc) {
         while (pop_tile(mr));
@@ -1789,8 +1730,7 @@ map_rect_get_item_byid_binfile(struct map_rect_priv *mr, int id_hi, int id_lo) {
     return &mr->item;
 }
 
-static int
-binmap_search_by_index(struct map_priv *map, struct item *item, struct map_rect_priv **ret) {
+static int binmap_search_by_index(struct map_priv *map, struct item *item, struct map_rect_priv **ret) {
     struct attr zipfile_ref;
     int *data;
 
@@ -1819,9 +1759,9 @@ binmap_search_by_index(struct map_priv *map, struct item *item, struct map_rect_
     return 0;
 }
 
-static struct map_rect_priv *
-binmap_search_street_by_place(struct map_priv *map, struct item *town, struct coord *c, struct map_selection *sel,
-                              GList **boundaries) {
+static struct map_rect_priv *binmap_search_street_by_place(struct map_priv *map, struct item *town, struct coord *c,
+        struct map_selection *sel,
+        GList **boundaries) {
     struct attr town_name, poly_town_name;
     struct map_rect_priv *map_rec2;
     struct item *place;
@@ -1861,8 +1801,7 @@ binmap_search_street_by_place(struct map_priv *map, struct item *town, struct co
     return NULL;
 }
 
-static int
-binmap_get_estimated_town_size(struct item *town) {
+static int binmap_get_estimated_town_size(struct item *town) {
     int size = 10000;
     switch (town->type) {
     case type_town_label_1e5:
@@ -1911,8 +1850,8 @@ binmap_get_estimated_town_size(struct item *town) {
     return size;
 }
 
-static struct map_rect_priv *
-binmap_search_street_by_estimate(struct map_priv *map, struct item *town, struct coord *c, struct map_selection *sel) {
+static struct map_rect_priv *binmap_search_street_by_estimate(struct map_priv *map, struct item *town, struct coord *c,
+        struct map_selection *sel) {
     int size = binmap_get_estimated_town_size(town);
 
     sel->u.c_rect.lu.x = c->x-size;
@@ -1922,8 +1861,8 @@ binmap_search_street_by_estimate(struct map_priv *map, struct item *town, struct
     return map_rect_new_binfile(map, sel);
 }
 
-static struct map_rect_priv *
-binmap_search_housenumber_by_estimate(struct map_priv *map, struct coord *c, struct map_selection *sel) {
+static struct map_rect_priv *binmap_search_housenumber_by_estimate(struct map_priv *map, struct coord *c,
+        struct map_selection *sel) {
     int size = 400;
     sel->u.c_rect.lu.x = c->x-size;
     sel->u.c_rect.lu.y = c->y+size;
@@ -1937,8 +1876,7 @@ binmap_search_housenumber_by_estimate(struct map_priv *map, struct coord *c, str
 }
 
 
-static int
-binmap_get_estimated_boundaries (struct item *town, GList **boundaries) {
+static int binmap_get_estimated_boundaries (struct item *town, GList **boundaries) {
     int size = binmap_get_estimated_town_size(town);
     struct coord tc;
 
@@ -1966,8 +1904,8 @@ binmap_get_estimated_boundaries (struct item *town, GList **boundaries) {
     return 0;
 }
 
-static struct map_search_priv *
-binmap_search_new(struct map_priv *map, struct item *item, struct attr *search, int partial) {
+static struct map_search_priv *binmap_search_new(struct map_priv *map, struct item *item, struct attr *search,
+        int partial) {
     struct map_rect_priv *map_rec;
     struct map_search_priv *msp=g_new0(struct map_search_priv, 1);
     struct item *town;
@@ -2087,14 +2025,12 @@ struct duplicate {
     char str[0];
 };
 
-static guint
-duplicate_hash(gconstpointer key) {
+static guint duplicate_hash(gconstpointer key) {
     const struct duplicate *d=key;
     return d->c.x^d->c.y^g_str_hash(d->str);
 }
 
-static gboolean
-duplicate_equal(gconstpointer a, gconstpointer b) {
+static gboolean duplicate_equal(gconstpointer a, gconstpointer b) {
     const struct duplicate *da=a;
     const struct duplicate *db=b;
     return (da->c.x == db->c.x && da->c.y == db->c.y && g_str_equal(da->str,db->str));
@@ -2109,8 +2045,8 @@ duplicate_equal(gconstpointer a, gconstpointer b) {
  * returns - pointer to new struct duplicate, if this item is not already exist in hash
  *         - NULL if this item already exists in duplicate hash or doesnt have an attr_type attr;
  */
-static struct duplicate*
-duplicate_test(struct map_search_priv *msp, struct item *item, enum attr_type attr_type, enum attr_type attr_type2) {
+static struct duplicate* duplicate_test(struct map_search_priv *msp, struct item *item, enum attr_type attr_type,
+                                        enum attr_type attr_type2) {
     struct attr attr;
     struct attr attr2;
     int len;
@@ -2152,8 +2088,7 @@ duplicate_test(struct map_search_priv *msp, struct item *item, enum attr_type at
  * @param msp pointer to private map search data
  * @param duplicate Duplicate info to insert
  */
-static void
-duplicate_insert(struct map_search_priv *msp, struct duplicate *d) {
+static void duplicate_insert(struct map_search_priv *msp, struct duplicate *d) {
     g_hash_table_insert(msp->search_results, d, GINT_TO_POINTER(1));
 }
 
@@ -2166,8 +2101,8 @@ duplicate_insert(struct map_search_priv *msp, struct duplicate *d) {
  * @returns 0 if item is not a duplicate
  * 	    1 if item is duplicate or doesn't have required attr_type attribute
  */
-static int
-duplicate(struct map_search_priv *msp, struct item *item, enum attr_type attr_type, enum attr_type attr_type2) {
+static int duplicate(struct map_search_priv *msp, struct item *item, enum attr_type attr_type,
+                     enum attr_type attr_type2) {
     struct duplicate *d=duplicate_test(msp, item, attr_type, attr_type2);
     if(!d)
         return 1;
@@ -2175,8 +2110,7 @@ duplicate(struct map_search_priv *msp, struct item *item, enum attr_type attr_ty
     return 0;
 }
 
-static int
-item_inside_poly_list(struct item *it, GList *l) {
+static int item_inside_poly_list(struct item *it, GList *l) {
 
     while(l) {
         struct geom_poly_segment *p=l->data;
@@ -2208,8 +2142,7 @@ item_inside_poly_list(struct item *it, GList *l) {
     return 0;
 }
 
-static struct item *
-binmap_search_get_item(struct map_search_priv *map_search) {
+static struct item *binmap_search_get_item(struct map_search_priv *map_search) {
     struct item* it;
     struct attr at;
     enum linguistics_cmp_mode mode=(map_search->partial?linguistics_cmp_partial:0);
@@ -2370,8 +2303,7 @@ binmap_search_get_item(struct map_search_priv *map_search) {
 }
 
 
-static void
-binmap_search_destroy(struct map_search_priv *ms) {
+static void binmap_search_destroy(struct map_search_priv *ms) {
     if (ms->search_results)
         g_hash_table_destroy(ms->search_results);
     if(ATTR_IS_STRING(ms->search.type))
@@ -2389,8 +2321,7 @@ binmap_search_destroy(struct map_search_priv *ms) {
     g_free(ms);
 }
 
-static int
-binmap_get_attr(struct map_priv *m, enum attr_type type, struct attr *attr) {
+static int binmap_get_attr(struct map_priv *m, enum attr_type type, struct attr *attr) {
     attr->type=type;
     switch (type) {
     case attr_map_release:
@@ -2410,8 +2341,7 @@ binmap_get_attr(struct map_priv *m, enum attr_type type, struct attr *attr) {
     return 0;
 }
 
-static int
-binmap_set_attr(struct map_priv *map, struct attr *attr) {
+static int binmap_set_attr(struct map_priv *map, struct attr *attr) {
     switch (attr->type) {
     case attr_update:
         map->download_enabled = attr->u.num;
@@ -2438,8 +2368,7 @@ static struct map_methods map_methods_binfile = {
     binmap_set_attr,
 };
 
-static int
-binfile_get_index(struct map_priv *m) {
+static int binfile_get_index(struct map_priv *m) {
     int len;
     int cde_index_size;
     int offset;
@@ -2479,8 +2408,7 @@ binfile_get_index(struct map_priv *m) {
     return 1;
 }
 
-static int
-map_binfile_zip_setup(struct map_priv *m, char *filename, int mmap) {
+static int map_binfile_zip_setup(struct map_priv *m, char *filename, int mmap) {
     struct zip_cd *first_cd;
     int i;
     if (!(m->eoc=binfile_read_eoc(m->fi))) {
@@ -2522,8 +2450,7 @@ map_binfile_zip_setup(struct map_priv *m, char *filename, int mmap) {
 
 
 #if 0
-static int
-map_binfile_download_initial(struct map_priv *m) {
+static int map_binfile_download_initial(struct map_priv *m) {
     struct attr readwrite= {attr_readwrite,{(void *)1}};
     struct attr create= {attr_create,{(void *)1}};
     struct attr *attrs[4];
@@ -2601,8 +2528,7 @@ map_binfile_download_initial(struct map_priv *m) {
 }
 #endif
 
-static int
-map_binfile_open(struct map_priv *m) {
+static int map_binfile_open(struct map_priv *m) {
     int *magic;
     struct map_rect_priv *mr;
     struct item *item;
@@ -2671,8 +2597,7 @@ map_binfile_open(struct map_priv *m) {
     return 1;
 }
 
-static void
-map_binfile_close(struct map_priv *m) {
+static void map_binfile_close(struct map_priv *m) {
     int i;
     file_data_free(m->fi, (unsigned char *)m->index_cd);
     file_data_free(m->fi, (unsigned char *)m->eoc);
@@ -2687,8 +2612,7 @@ map_binfile_close(struct map_priv *m) {
         file_destroy(m->fi);
 }
 
-static void
-map_binfile_destroy(struct map_priv *m) {
+static void map_binfile_destroy(struct map_priv *m) {
     g_free(m->filename);
     g_free(m->url);
     g_free(m->progress);
@@ -2696,8 +2620,7 @@ map_binfile_destroy(struct map_priv *m) {
 }
 
 
-static void
-binfile_check_version(struct map_priv *m) {
+static void binfile_check_version(struct map_priv *m) {
     int version=-1;
     if (!m->check_version)
         return;
@@ -2711,8 +2634,7 @@ binfile_check_version(struct map_priv *m) {
 }
 
 
-static struct map_priv *
-map_new_binfile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *map_new_binfile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m;
     struct attr *data=attr_search(attrs, NULL, attr_data);
     struct attr *check_version,*flags,*url,*download_enabled;
@@ -2753,8 +2675,7 @@ map_new_binfile(struct map_methods *meth, struct attr **attrs, struct callback_l
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug,"binfile: plugin_init");
     if (sizeof(struct zip_cd) != 46) {
         dbg(lvl_error,"error: sizeof(struct zip_cd)=%zu",sizeof(struct zip_cd));

--- a/navit/map/csv/csv.c
+++ b/navit/map/csv/csv.c
@@ -45,8 +45,7 @@
 static int map_id;
 
 /*prototypes*/
-static int
-csv_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode);
+static int csv_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode);
 static struct item * csv_create_item(struct map_rect_priv *mr, enum item_type it_type);
 static void quadtree_item_free(void *mr, struct quadtree_item *qitem);
 static void quadtree_item_free_do(void *qitem);
@@ -73,8 +72,7 @@ struct quadtree_data *quadtree_data_dup(struct quadtree_data *qdata) {
     return ret;
 }
 
-static void
-save_map_csv(struct map_priv *m) {
+static void save_map_csv(struct map_priv *m) {
     if(m->filename && m->dirty) {
         char* filename = g_strdup_printf("%s.tmp",m->filename);
         FILE* fp;
@@ -176,8 +174,7 @@ save_map_csv(struct map_priv *m) {
 
 static const int zoom_max = 18;
 
-static void
-map_destroy_csv(struct map_priv *m) {
+static void map_destroy_csv(struct map_priv *m) {
     dbg(lvl_debug,"map_destroy_csv");
     /*save if changed */
     save_map_csv(m);
@@ -189,12 +186,10 @@ map_destroy_csv(struct map_priv *m) {
     g_free(m);
 }
 
-static void
-csv_coord_rewind(void *priv_data) {
+static void csv_coord_rewind(void *priv_data) {
 }
 
-static int
-csv_coord_get(void *priv_data, struct coord *c, int count) {
+static int csv_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     if(mr) {
         *c = mr->c;
@@ -204,13 +199,11 @@ csv_coord_get(void *priv_data, struct coord *c, int count) {
     }
 }
 
-static void
-csv_attr_rewind(void *priv_data) {
+static void csv_attr_rewind(void *priv_data) {
     /*TODO implement if needed*/
 }
 
-static int
-csv_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int csv_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     int i, bAttrFound = 0;
     GList* attr_list;
     struct map_rect_priv *mr=priv_data;
@@ -267,8 +260,7 @@ csv_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     return 0;
 }
 
-static int
-csv_attr_set(void *priv_data, struct attr *attr, enum change_mode mode) {
+static int csv_attr_set(void *priv_data, struct attr *attr, enum change_mode mode) {
     struct map_rect_priv* mr;
     struct map_priv* m;
     int i, bFound;
@@ -342,8 +334,7 @@ csv_attr_set(void *priv_data, struct attr *attr, enum change_mode mode) {
     return 0;
 }
 
-static int
-csv_type_set(void *priv_data, enum item_type type) {
+static int csv_type_set(void *priv_data, enum item_type type) {
     struct map_rect_priv* mr = (struct map_rect_priv*)priv_data;
     dbg(lvl_debug,"Enter %d", type);
 
@@ -376,8 +367,7 @@ static struct item_methods methods_csv = {
 /*
  * Sets coordinate of an existing item (either on the new list or an item with coord )
  */
-static int
-csv_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode) {
+static int csv_coord_set(void *priv_data, struct coord *c, int count, enum change_mode mode) {
     struct quadtree_item query_item, *insert_item, *query_res;
     struct coord_geo cg;
     struct map_rect_priv* mr;
@@ -496,8 +486,7 @@ static void map_csv_debug_dump(struct map_priv *map) {
 }
 
 
-static struct map_rect_priv *
-map_rect_new_csv(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *map_rect_new_csv(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr;
     struct coord_geo lu;
     struct coord_geo rl;
@@ -533,8 +522,7 @@ map_rect_new_csv(struct map_priv *map, struct map_selection *sel) {
     return mr;
 }
 
-static void
-map_rect_destroy_csv(struct map_rect_priv *mr) {
+static void map_rect_destroy_csv(struct map_rect_priv *mr) {
     if(mr->qitem)
         mr->qitem->ref_count--;
 
@@ -544,8 +532,7 @@ map_rect_destroy_csv(struct map_rect_priv *mr) {
     g_free(mr);
 }
 
-static struct item *
-map_rect_get_item_csv(struct map_rect_priv *mr) {
+static struct item *map_rect_get_item_csv(struct map_rect_priv *mr) {
 
     if(mr->qitem)
         mr->qitem->ref_count--;
@@ -566,8 +553,7 @@ map_rect_get_item_csv(struct map_rect_priv *mr) {
     return NULL;
 }
 
-static struct item *
-map_rect_get_item_byid_csv(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_rect_get_item_byid_csv(struct map_rect_priv *mr, int id_hi, int id_lo) {
     /*currently id_hi is ignored*/
 
     struct quadtree_item *qit = g_hash_table_lookup(mr->m->qitem_hash,&id_lo);
@@ -587,13 +573,11 @@ map_rect_get_item_byid_csv(struct map_rect_priv *mr, int id_hi, int id_lo) {
     }
 }
 
-static int
-csv_get_attr(struct map_priv *m, enum attr_type type, struct attr *attr) {
+static int csv_get_attr(struct map_priv *m, enum attr_type type, struct attr *attr) {
     return 0;
 }
 
-static struct item *
-csv_create_item(struct map_rect_priv *mr, enum item_type it_type) {
+static struct item *csv_create_item(struct map_rect_priv *mr, enum item_type it_type) {
     struct map_priv* m;
     struct quadtree_data* qd;
     struct quadtree_item* qi;
@@ -660,8 +644,7 @@ static struct map_methods map_methods_csv = {
     csv_get_attr,
 };
 
-static struct map_priv *
-map_new_csv(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *map_new_csv(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m = NULL;
     struct attr *attr_types;
     struct attr *item_type_attr;
@@ -845,8 +828,7 @@ map_new_csv(struct map_methods *meth, struct attr **attrs, struct callback_list 
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug,"csv: plugin_init");
     plugin_register_category_map("csv", map_new_csv);
 }

--- a/navit/map/csv/quadtree.c
+++ b/navit/map/csv/quadtree.c
@@ -58,8 +58,7 @@ struct quadtree_iter_node {
 };
 
 
-static double
-dist_sq(double x1,double y1,double x2,double y2) {
+static double dist_sq(double x1,double y1,double x2,double y2) {
     return (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1);
 }
 
@@ -78,9 +77,8 @@ quadtree_node_new(struct quadtree_node* parent, double xmin, double xmax, double
 /*
  * searches all four subnodes recursively for the list of items within a rectangle
  */
-void
-quadtree_find_rect_items(struct quadtree_node* this_, double dXMin, double dXMax, double dYMin, double dYMax,
-                         GList**out) {
+void quadtree_find_rect_items(struct quadtree_node* this_, double dXMin, double dXMax, double dYMin, double dYMax,
+                              GList**out) {
 
     struct quadtree_node* nodes[4] = { this_->aa, this_->ab, this_->ba, this_->bb };
     if( this_->is_leaf ) {
@@ -386,8 +384,7 @@ void quadtree_node_drop_garbage(struct quadtree_node* node, struct quadtree_iter
  * @param iter Quadtree iteration context. Can be NULL if no garbage collection is needed.
  * @return nothing
  */
-void
-quadtree_add(struct quadtree_node* this_, struct quadtree_item* item, struct quadtree_iter *iter) {
+void quadtree_add(struct quadtree_node* this_, struct quadtree_item* item, struct quadtree_iter *iter) {
     if( this_->is_leaf ) {
         int bSame = 1;
         int i;
@@ -457,8 +454,7 @@ quadtree_add(struct quadtree_node* this_, struct quadtree_item* item, struct qua
     }
 }
 
-void
-quadtree_split(struct quadtree_node* this_) {
+void quadtree_split(struct quadtree_node* this_) {
     int i;
     this_->is_leaf = 0;
     for(i=0; i<this_->node_num; ++i) {
@@ -504,8 +500,7 @@ quadtree_split(struct quadtree_node* this_) {
     this_->node_num = 0;
 }
 
-void
-quadtree_destroy(struct quadtree_node* this_) {
+void quadtree_destroy(struct quadtree_node* this_) {
     if(this_->aa) {
         quadtree_destroy(this_->aa);
         this_->aa = NULL;

--- a/navit/map/filter/filter.c
+++ b/navit/map/filter/filter.c
@@ -64,8 +64,7 @@ struct map_search_priv {
     struct map_rect_priv *mr;
 };
 
-static enum item_type
-filter_type(struct map_priv *m, struct item *item) {
+static enum item_type filter_type(struct map_priv *m, struct item *item) {
     GList *filters=m->filters;
     struct filter_entry *entry;
     while (filters) {
@@ -125,14 +124,12 @@ filter_type(struct map_priv *m, struct item *item) {
     return item->type;
 }
 
-static void
-free_filter_entry(struct filter_entry *filter) {
+static void free_filter_entry(struct filter_entry *filter) {
     g_free(filter->cond_str);
     g_free(filter);
 }
 
-static void
-free_filter(struct filter *filter) {
+static void free_filter(struct filter *filter) {
     g_list_foreach(filter->old, (GFunc)free_filter_entry, NULL);
     g_list_free(filter->old);
     filter->old=NULL;
@@ -141,15 +138,13 @@ free_filter(struct filter *filter) {
     filter->new=NULL;
 }
 
-static void
-free_filters(struct map_priv *m) {
+static void free_filters(struct map_priv *m) {
     g_list_foreach(m->filters, (GFunc)free_filter, NULL);
     g_list_free(m->filters);
     m->filters=NULL;
 }
 
-static GList *
-parse_filter(char *filter) {
+static GList *parse_filter(char *filter) {
     GList *ret=NULL;
     for (;;) {
         char *condition,*range,*next=strchr(filter,',');
@@ -197,8 +192,7 @@ parse_filter(char *filter) {
     return ret;
 }
 
-static void
-parse_filters(struct map_priv *m, char *filter) {
+static void parse_filters(struct map_priv *m, char *filter) {
     char *filter_copy=g_strdup(filter);
     char *str=filter_copy;
 
@@ -239,26 +233,22 @@ parse_filters(struct map_priv *m, char *filter) {
     g_free(filter_copy);
 }
 
-static void
-map_filter_coord_rewind(void *priv_data) {
+static void map_filter_coord_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     item_coord_rewind(mr->parent_item);
 }
 
-static int
-map_filter_coord_get(void *priv_data, struct coord *c, int count) {
+static int map_filter_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     return item_coord_get(mr->parent_item, c, count);
 }
 
-static void
-map_filter_attr_rewind(void *priv_data) {
+static void map_filter_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     item_attr_rewind(mr->parent_item);
 }
 
-static int
-map_filter_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int map_filter_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     return item_attr_get(mr->parent_item, attr_type, attr);
 }
@@ -270,8 +260,7 @@ static struct item_methods methods_filter = {
     map_filter_attr_get,
 };
 
-static struct map_rect_priv *
-map_filter_rect_new(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *map_filter_rect_new(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr=NULL;
     struct map_rect *parent;
     parent=map_rect_new(map->parent, sel);
@@ -286,14 +275,12 @@ map_filter_rect_new(struct map_priv *map, struct map_selection *sel) {
     return mr;
 }
 
-static void
-map_filter_rect_destroy(struct map_rect_priv *mr) {
+static void map_filter_rect_destroy(struct map_rect_priv *mr) {
     map_rect_destroy(mr->parent);
     g_free(mr);
 }
 
-static struct item *
-map_filter_rect_get_item(struct map_rect_priv *mr) {
+static struct item *map_filter_rect_get_item(struct map_rect_priv *mr) {
     mr->parent_item=map_rect_get_item(mr->parent);
     if (!mr->parent_item)
         return NULL;
@@ -303,8 +290,7 @@ map_filter_rect_get_item(struct map_rect_priv *mr) {
     return &mr->item;
 }
 
-static struct item *
-map_filter_rect_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_filter_rect_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     dbg(lvl_debug,"enter");
     mr->parent_item=map_rect_get_item_byid(mr->parent, id_hi, id_lo);
     if (!mr->parent_item)
@@ -315,31 +301,27 @@ map_filter_rect_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     return &mr->item;
 }
 
-static struct map_search_priv *
-map_filter_search_new(struct map_priv *map, struct item *item, struct attr *search, int partial) {
+static struct map_search_priv *map_filter_search_new(struct map_priv *map, struct item *item, struct attr *search,
+        int partial) {
     dbg(lvl_debug,"enter");
     return NULL;
 }
 
-static struct item *
-map_filter_search_get_item(struct map_search_priv *map_search) {
+static struct item *map_filter_search_get_item(struct map_search_priv *map_search) {
     dbg(lvl_debug,"enter");
     return NULL;
 }
 
-static void
-map_filter_search_destroy(struct map_search_priv *ms) {
+static void map_filter_search_destroy(struct map_search_priv *ms) {
     dbg(lvl_debug,"enter");
 }
 
-static void
-map_filter_destroy(struct map_priv *m) {
+static void map_filter_destroy(struct map_priv *m) {
     map_destroy(m->parent);
     g_free(m);
 }
 
-static int
-map_filter_set_attr(struct map_priv *m, struct attr *attr) {
+static int map_filter_set_attr(struct map_priv *m, struct attr *attr) {
     switch (attr->type) {
     case attr_filter:
         parse_filters(m,attr->u.str);
@@ -368,8 +350,7 @@ static struct map_methods map_methods_filter = {
 
 
 
-static struct map_priv *
-map_filter_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *map_filter_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m=NULL;
     struct attr **parent_attrs,type,*subtype=attr_search(attrs, NULL, attr_subtype),*filter=attr_search(attrs, NULL,
             attr_filter);
@@ -407,8 +388,7 @@ map_filter_new(struct map_methods *meth, struct attr **attrs, struct callback_li
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug,"filter: plugin_init");
     plugin_register_category_map("filter", map_filter_new);
 }

--- a/navit/map/garmin/garmin.c
+++ b/navit/map/garmin/garmin.c
@@ -76,8 +76,7 @@ struct map_rect_priv {
 
 int garmin_debug = 10;
 
-void
-logfn(char *file, int line, int level, char *fmt, ...) {
+void logfn(char *file, int line, int level, char *fmt, ...) {
     va_list ap;
     char fileline[256];
     int sz;
@@ -136,8 +135,7 @@ static struct gscale mapscales[] = {
 };
 
 
-static int
-garmin_object_label(struct gobject *o, struct attr *attr) {
+static int garmin_object_label(struct gobject *o, struct attr *attr) {
     struct map_rect_priv *mr = o->priv_data;
     char *codepage;
     char *label;
@@ -172,8 +170,7 @@ garmin_object_label(struct gobject *o, struct attr *attr) {
     return 0;
 }
 
-static int
-garmin_object_debug(struct gobject *o, struct attr *attr) {
+static int garmin_object_debug(struct gobject *o, struct attr *attr) {
     struct map_rect_priv *mr = o->priv_data;
     if (!mr) {
         dlog(1, "Error object do not have priv_data!!\n");
@@ -190,8 +187,8 @@ garmin_object_debug(struct gobject *o, struct attr *attr) {
 }
 
 
-static struct map_search_priv *
-gmap_search_new(struct map_priv *map, struct item *item, struct attr *search, int partial) {
+static struct map_search_priv *gmap_search_new(struct map_priv *map, struct item *item, struct attr *search,
+        int partial) {
     struct map_rect_priv *mr=g_new0(struct map_rect_priv, 1);
     struct gar_search *gs;
     int rc;
@@ -252,22 +249,19 @@ out_err:
 }
 
 /* Assumes that only one item will be itterated at time! */
-static void
-coord_rewind(void *priv_data) {
+static void coord_rewind(void *priv_data) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     mr->last_coord = 0;
 };
 
-static void
-attr_rewind(void *priv_data) {
+static void attr_rewind(void *priv_data) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     mr->last_attr = 0;
 };
 
-static int
-point_coord_get(void *priv_data, struct coord *c, int count) {
+static int point_coord_get(void *priv_data, struct coord *c, int count) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     struct gcoord gc;
@@ -290,16 +284,14 @@ point_coord_get(void *priv_data, struct coord *c, int count) {
     return 1;
 }
 
-static int
-coord_is_node(void *priv_data) {
+static int coord_is_node(void *priv_data) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
 
     return gar_is_object_dcoord_node(mr->gmap, g, mr->last_coord);
 }
 
-static int
-poly_coord_get(void *priv_data, struct coord *c, int count) {
+static int poly_coord_get(void *priv_data, struct coord *c, int count) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     int ndeltas = 0, total = 0;
@@ -340,8 +332,7 @@ poly_coord_get(void *priv_data, struct coord *c, int count) {
 }
 
 // for _any we must return one by one
-static int
-point_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int point_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     int rc;
@@ -429,8 +420,7 @@ static struct item_methods methods_garmin_poly = {
     coord_is_node,
 };
 
-static int
-search_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int search_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     int rc;
@@ -563,8 +553,7 @@ search_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     return 0;
 }
 
-static int
-search_coord_get(void *priv_data, struct coord *c, int count) {
+static int search_coord_get(void *priv_data, struct coord *c, int count) {
     struct gobject *g = priv_data;
     struct map_rect_priv *mr = g->priv_data;
     struct gcoord gc;
@@ -595,8 +584,7 @@ static struct item_methods methods_garmin_search = {
 };
 
 
-static struct item *
-garmin_poi2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
+static struct item *garmin_poi2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
     if (mr->mpriv->conv) {
         int mask = gar_object_group(o) << G2N_KIND_SHIFT;
         mr->item.type = g2n_get_type(mr->mpriv->conv, G2N_POINT|mask, otype);
@@ -605,8 +593,7 @@ garmin_poi2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otyp
     return &mr->item;
 }
 
-static struct item *
-garmin_pl2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
+static struct item *garmin_pl2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
     if (mr->mpriv->conv) {
         int mask = gar_object_group(o) << G2N_KIND_SHIFT;
         mr->item.type = g2n_get_type(mr->mpriv->conv, G2N_POLYLINE|mask, otype);
@@ -615,8 +602,7 @@ garmin_pl2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype
     return &mr->item;
 }
 
-static struct item *
-garmin_pg2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
+static struct item *garmin_pg2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
     if (mr->mpriv->conv) {
         int mask = gar_object_group(o) << G2N_KIND_SHIFT;
         mr->item.type = g2n_get_type(mr->mpriv->conv, G2N_POLYGONE|mask, otype);
@@ -625,15 +611,13 @@ garmin_pg2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype
     return &mr->item;
 }
 
-static struct item *
-garmin_srch2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
+static struct item *garmin_srch2item(struct map_rect_priv *mr, struct gobject *o, unsigned short otype) {
     mr->item.type = type_country_label;
     mr->item.meth = &methods_garmin_search;
     return &mr->item;
 }
 
-static struct item *
-garmin_obj2item(struct map_rect_priv *mr, struct gobject *o) {
+static struct item *garmin_obj2item(struct map_rect_priv *mr, struct gobject *o) {
     unsigned short otype;
     otype = gar_obj_type(o);
     mr->item.type = type_none;
@@ -657,8 +641,7 @@ garmin_obj2item(struct map_rect_priv *mr, struct gobject *o) {
     return NULL;
 }
 
-static struct item *
-gmap_rect_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *gmap_rect_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     struct gobject *o;
     o = mr->objs = gar_get_object_by_id(mr->mpriv->g, id_hi, id_lo);
     if (!o) {
@@ -676,8 +659,7 @@ gmap_rect_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     return &mr->item;
 }
 
-static struct item *
-gmap_rect_get_item(struct map_rect_priv *mr) {
+static struct item *gmap_rect_get_item(struct map_rect_priv *mr) {
     struct gobject *o;
     if (!mr->objs)
         return NULL;
@@ -751,13 +733,11 @@ struct nl2gl_t nl2gl[] = {
     { /* 18 */ .g = 0, .descr = "0-120m", },
 };
 
-static int
-get_level(struct map_selection *sel) {
+static int get_level(struct map_selection *sel) {
     return sel->order;
 }
 
-static int
-garmin_get_selection(struct map_rect_priv *map, struct map_selection *sel) {
+static int garmin_get_selection(struct map_rect_priv *map, struct map_selection *sel) {
     struct gar_rect r;
     struct gmap *gm;
     struct gobject **glast = NULL;
@@ -820,8 +800,7 @@ garmin_get_selection(struct map_rect_priv *map, struct map_selection *sel) {
     return rc;
 }
 // Can not return NULL, navit segfaults
-static struct map_rect_priv *
-gmap_rect_new(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *gmap_rect_new(struct map_priv *map, struct map_selection *sel) {
     struct map_selection *ms = sel;
     struct map_rect_priv *mr;
 
@@ -846,8 +825,7 @@ gmap_rect_new(struct map_priv *map, struct map_selection *sel) {
     return mr;
 }
 
-static void
-gmap_rect_destroy(struct map_rect_priv *mr) {
+static void gmap_rect_destroy(struct map_rect_priv *mr) {
     dlog(11,"destroy maprect\n");
     if (mr->gmap)
         gar_free_gmap(mr->gmap);
@@ -858,13 +836,11 @@ gmap_rect_destroy(struct map_rect_priv *mr) {
     free(mr);
 }
 
-static void
-gmap_search_destroy(struct map_search_priv *ms) {
+static void gmap_search_destroy(struct map_search_priv *ms) {
     gmap_rect_destroy((struct map_rect_priv *)ms);
 }
 
-static void
-gmap_destroy(struct map_priv *m) {
+static void gmap_destroy(struct map_priv *m) {
     dlog(5, "garmin_map_destroy\n");
     if (m->g)
         gar_free(m->g);
@@ -886,8 +862,7 @@ static struct map_methods map_methods = {
     NULL,
 };
 
-static struct map_priv *
-gmap_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *gmap_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m;
     struct attr *data;
     struct attr *debug;
@@ -953,7 +928,6 @@ gmap_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cb
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_map("garmin", gmap_new);
 }

--- a/navit/map/garmin_img/garmin_img.c
+++ b/navit/map/garmin_img/garmin_img.c
@@ -46,8 +46,7 @@ int shift=5;
 int subdiv_next=0x10;
 
 
-static void *
-file_read(struct file *f, int offset, int size) {
+static void *file_read(struct file *f, int offset, int size) {
     void *ptr;
     int ret;
 
@@ -63,8 +62,7 @@ file_read(struct file *f, int offset, int size) {
     return ptr;
 }
 
-static void
-file_free(void *ptr) {
+static void file_free(void *ptr) {
     free(ptr);
 }
 
@@ -73,8 +71,7 @@ struct offset_len {
     int length;
 } __attribute ((packed));
 
-static void
-dump_offset_len(struct offset_len *off_len) {
+static void dump_offset_len(struct offset_len *off_len) {
     printf("offset: 0x%x(%d) length 0x%x(%d)\n", off_len->offset, off_len->offset, off_len->length, off_len->length);
 }
 
@@ -120,15 +117,13 @@ struct img_header {
     char unknown11[480];
 } __attribute__((packed));
 
-static void
-dump_ts(struct timestamp *ts) {
+static void dump_ts(struct timestamp *ts) {
     printf("%d-%02d-%02d %02d:%02d:%02d\n", ts->creation_year, ts->creation_month, ts->creation_day, ts->creation_hour,
            ts->creation_minute, ts->creation_second);
 }
 
 #if 0
-static void
-dump_img(struct img_header *img_hdr) {
+static void dump_img(struct img_header *img_hdr) {
     printf("signature: '%s'\n", img_hdr->signature);
     printf("creation: ");
     dump_ts(&img_hdr->ts);
@@ -153,8 +148,7 @@ struct fat_block {
 } __attribute__((packed));
 
 #if 0
-static void
-dump_fat_block(struct fat_block *fat_blk) {
+static void dump_fat_block(struct fat_block *fat_blk) {
     int i=0;
     char name[9];
     char type[4];
@@ -186,8 +180,7 @@ struct file_header {
     struct timestamp ts;
 } __attribute__((packed));
 
-static void
-dump_file(struct file_header *fil_hdr) {
+static void dump_file(struct file_header *fil_hdr) {
     printf("header_len: %d\n", fil_hdr->header_len);
     printf("type: '%s'\n", fil_hdr->type);
     printf("unknown1: 0x%x(%d)\n", fil_hdr->unknown1, fil_hdr->unknown1);
@@ -203,8 +196,7 @@ struct region_header {
 } __attribute__((packed));
 
 #if 0
-static void
-dump_region(struct region_header *rgn_hdr) {
+static void dump_region(struct region_header *rgn_hdr) {
     dump_offset_len(&rgn_hdr->offset_len);
 }
 #endif
@@ -266,15 +258,13 @@ struct map_rect_priv {
 
 static int map_id;
 
-static int
-contains_coord(char *line) {
+static int contains_coord(char *line) {
     return g_ascii_isdigit(line[0]);
 }
 
 static int debug=1;
 
-static int
-get_tag(char *line, char *name, int *pos, char *ret) {
+static int get_tag(char *line, char *name, int *pos, char *ret) {
     int len,quoted;
     char *p,*e,*n;
 
@@ -323,26 +313,22 @@ get_tag(char *line, char *name, int *pos, char *ret) {
     return 0;
 }
 
-static void
-get_line(struct map_rect_priv *mr) {
+static void get_line(struct map_rect_priv *mr) {
     mr->pos=ftell(mr->f);
     fgets(mr->line, 256, mr->f);
 }
 
-static void
-map_destroy_garmin_img(struct map_priv *m) {
+static void map_destroy_garmin_img(struct map_priv *m) {
     if (debug)
         printf("map_destroy_garmin_img\n");
     g_free(m);
 }
 
-static char *
-map_charset_garmin_img(struct map_priv *m) {
+static char *map_charset_garmin_img(struct map_priv *m) {
     return "iso8859-1";
 }
 
-static enum projection
-map_projection_garmin_img(struct map_priv *m) {
+static enum projection map_projection_garmin_img(struct map_priv *m) {
     return projection_garmin;
 }
 
@@ -353,8 +339,7 @@ struct label_data_offset {
 } __attribute ((packed));
 
 #if 0
-static void
-dump_label_data_offset(struct label_data_offset *lbl_dat) {
+static void dump_label_data_offset(struct label_data_offset *lbl_dat) {
     dump_offset_len(&lbl_dat->offset_len);
     printf("multiplier 0x%x(%d)\n", lbl_dat->multiplier, lbl_dat->multiplier);
     printf("data 0x%x(%d)\n", lbl_dat->data, lbl_dat->data);
@@ -367,8 +352,7 @@ struct label_data {
     int zero;
 } __attribute ((packed));
 
-static void
-dump_label_data(struct label_data *lbl_dat) {
+static void dump_label_data(struct label_data *lbl_dat) {
     dump_offset_len(&lbl_dat->offset_len);
     printf("size 0x%x(%d)\n", lbl_dat->size, lbl_dat->size);
 }
@@ -388,8 +372,7 @@ struct tree_header {
     int mapid;
 };
 
-static void
-dump_tree_header(struct tree_header *tre_hdr) {
+static void dump_tree_header(struct tree_header *tre_hdr) {
     printf("tree_header:\n");
     dump_file(&tre_hdr->fil_hdr);
     printf("level: ");
@@ -430,8 +413,7 @@ struct label_header {
 } __attribute((packed));
 
 #if 0
-static void
-dump_label(struct label_header *lbl_hdr) {
+static void dump_label(struct label_header *lbl_hdr) {
     dump_file(&lbl_hdr->fil_hdr);
     printf("label:\n");
     dump_label_data_offset(&lbl_hdr->label);
@@ -467,21 +449,18 @@ struct triple {
     unsigned char data[3];
 } __attribute((packed));
 
-static unsigned int
-triple_u(struct triple *t) {
+static unsigned int triple_u(struct triple *t) {
     return t->data[0] | (t->data[1] << 8)  | (t->data[2] << 16);
 }
 
-static int
-triple(struct triple *t) {
+static int triple(struct triple *t) {
     int ret=t->data[0] | (t->data[1] << 8)  | (t->data[2] << 16);
     if (ret > 1<<23)
         ret=ret-(1<<24);
     return ret;
 }
 
-static void
-dump_triple_u(struct triple *t) {
+static void dump_triple_u(struct triple *t) {
     int val=triple_u(t);
     printf("0x%x(%d)\n", val, val);
 }
@@ -490,8 +469,7 @@ struct tcoord {
     struct triple lng,lat;
 } __attribute((packed));
 
-static void
-dump_tcoord(struct tcoord *t) {
+static void dump_tcoord(struct tcoord *t) {
     printf ("0x%x(%d),0x%x(%d)\n", triple_u(&t->lng), triple_u(&t->lng), triple_u(&t->lat), triple_u(&t->lat));
 }
 
@@ -501,8 +479,7 @@ struct level {
     unsigned short subdivisions;
 } __attribute((packed));
 
-static void
-dump_level(struct level *lvl) {
+static void dump_level(struct level *lvl) {
     printf("level:\n");
     printf("\tzoom 0x%x(%d)\n", lvl->zoom, lvl->zoom);
     printf("\tbits_per_coord 0x%x(%d)\n", lvl->bits_per_coord, lvl->bits_per_coord);
@@ -518,8 +495,7 @@ struct subdivision {
     unsigned short next;
 } __attribute((packed));
 
-static void
-dump_subdivision(struct subdivision *sub) {
+static void dump_subdivision(struct subdivision *sub) {
     printf("subdivision:\n");
     printf("\trgn_offset: ");
     dump_triple_u(&sub->rgn_offset);
@@ -541,8 +517,7 @@ struct rgn_point {
     unsigned char subtype;
 } __attribute((packed));
 
-static void
-dump_point(struct rgn_point *pnt) {
+static void dump_point(struct rgn_point *pnt) {
     printf("point:\n");
     printf("\tinfo 0x%x(%d)\n", pnt->info, pnt->info);
     printf("\tlbl_offset 0x%x(%d)\n", triple_u(&pnt->lbl_offset), triple_u(&pnt->lbl_offset));
@@ -569,8 +544,7 @@ struct rgn_poly {
     } __attribute((packed)) u;
 } __attribute((packed));
 
-static void
-dump_poly(struct rgn_poly *ply) {
+static void dump_poly(struct rgn_poly *ply) {
     printf("poly:\n");
     printf("\tinfo 0x%x(%d)\n", ply->info, ply->info);
     printf("\tlbl_offset 0x%x(%d)\n", triple_u(&ply->lbl_offset), triple_u(&ply->lbl_offset));
@@ -586,8 +560,7 @@ dump_poly(struct rgn_poly *ply) {
     printf("\tlen: 0x%x(%d)\n", sizeof(*ply), sizeof(*ply));
 }
 
-static void
-dump_hex(void *ptr, int len) {
+static void dump_hex(void *ptr, int len) {
     unsigned char *c=ptr;
     while (len--) {
         printf("%02x ", *c++);
@@ -595,8 +568,7 @@ dump_hex(void *ptr, int len) {
     printf("\n");
 }
 
-static void
-dump_hex_r(void *ptr, int len, int rec) {
+static void dump_hex_r(void *ptr, int len, int rec) {
     unsigned char *c=ptr;
     int l=rec;
     while (len--) {
@@ -610,8 +582,7 @@ dump_hex_r(void *ptr, int len, int rec) {
 }
 
 #if 0
-static void
-dump_label_offset(struct map_rect_priv *mr, int offset) {
+static void dump_label_offset(struct map_rect_priv *mr, int offset) {
     void *p;
     p=file_read(&mr->lbl, mr->lbl_hdr->label.offset_len.offset+offset, 128);
     printf("%s\n", (char *)p);
@@ -620,8 +591,7 @@ dump_label_offset(struct map_rect_priv *mr, int offset) {
 
 
 #if 0
-static void
-dump_region_item(struct subdivision *sub, struct file *rgn, struct map_rect_priv *mr) {
+static void dump_region_item(struct subdivision *sub, struct file *rgn, struct map_rect_priv *mr) {
     int offset,item_offset,i,j;
     unsigned short count=0;
     unsigned short *offsets[4];
@@ -697,8 +667,7 @@ dump_region_item(struct subdivision *sub, struct file *rgn, struct map_rect_priv
 
 #endif
 
-static void
-dump_levels(struct map_rect_priv *mr) {
+static void dump_levels(struct map_rect_priv *mr) {
     int i,offset;
     struct level *lvl;
 
@@ -711,8 +680,7 @@ dump_levels(struct map_rect_priv *mr) {
 }
 
 #if 0
-static void
-dump_tree(struct file *f, struct file *rgn, struct map_rect_priv *mr) {
+static void dump_tree(struct file *f, struct file *rgn, struct map_rect_priv *mr) {
     struct tree_header *tre_hdr;
     struct subdivision *sub;
     int i,offset;
@@ -737,8 +705,7 @@ dump_tree(struct file *f, struct file *rgn, struct map_rect_priv *mr) {
 #endif
 
 #if 0
-static void
-dump_labels(struct file *f) {
+static void dump_labels(struct file *f) {
     struct label_header *lbl_hdr;
 
     lbl_hdr=file_read(f, 0, sizeof(*lbl_hdr));
@@ -758,12 +725,10 @@ dump_labels(struct file *f) {
 }
 #endif
 
-static void
-garmin_img_coord_rewind(void *priv_data) {
+static void garmin_img_coord_rewind(void *priv_data) {
 }
 
-static void
-parse_line(struct map_rect_priv *mr) {
+static void parse_line(struct map_rect_priv *mr) {
     int pos=0;
     sscanf(mr->line,"%lf %c %lf %c %n",&mr->lat,&mr->lat_c,&mr->lng,&mr->lng_c,&pos);
     if (pos < strlen(mr->line)) {
@@ -771,8 +736,7 @@ parse_line(struct map_rect_priv *mr) {
     }
 }
 
-static int
-get_bits(struct map_rect_priv *mr, int bits) {
+static int get_bits(struct map_rect_priv *mr, int bits) {
     unsigned long ret;
     ret=L(*((unsigned long *)(mr->ply_data+mr->ply_bitpos/8)));
     ret >>= (mr->ply_bitpos & 7);
@@ -781,8 +745,7 @@ get_bits(struct map_rect_priv *mr, int bits) {
     return ret;
 }
 
-static int
-garmin_img_coord_get(void *priv_data, struct coord *c, int count) {
+static int garmin_img_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     struct subdivision *sub=(struct subdivision *)(mr->subdiv+mr->subdiv_pos);
     int ret=0;
@@ -896,18 +859,15 @@ garmin_img_coord_get(void *priv_data, struct coord *c, int count) {
     return ret;
 }
 
-static char *
-get_label_offset(struct map_rect_priv *mr, int offset) {
+static char *get_label_offset(struct map_rect_priv *mr, int offset) {
     g_assert(offset < mr->lbl_hdr->label.offset_len.length);
     return file_read(&mr->lbl, mr->lbl_hdr->label.offset_len.offset+offset, 128);
 }
 
-static void
-garmin_img_attr_rewind(void *priv_data) {
+static void garmin_img_attr_rewind(void *priv_data) {
 }
 
-static int
-garmin_img_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int garmin_img_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     int debug=0;
 
@@ -949,8 +909,7 @@ static int rgn_next_type(struct map_rect_priv *mr) {
     return 1;
 }
 
-static int
-sub_next(struct map_rect_priv *mr, int next) {
+static int sub_next(struct map_rect_priv *mr, int next) {
     int i,offset,first=-1,last=-1,count=-1;
     int end;
     unsigned short *offsets;
@@ -1038,8 +997,8 @@ sub_next(struct map_rect_priv *mr, int next) {
 
 int item_count;
 
-static struct map_rect_priv *
-map_rect_new_garmin_img(struct map_priv *map, struct coord_rect *r, struct layer *layers, int limit) {
+static struct map_rect_priv *map_rect_new_garmin_img(struct map_priv *map, struct coord_rect *r, struct layer *layers,
+        int limit) {
     struct map_rect_priv *mr;
     struct img_header img;
 
@@ -1163,15 +1122,13 @@ map_rect_new_garmin_img(struct map_priv *map, struct coord_rect *r, struct layer
 }
 
 
-static void
-map_rect_destroy_garmin_img(struct map_rect_priv *mr) {
+static void map_rect_destroy_garmin_img(struct map_rect_priv *mr) {
     fclose(mr->f);
     g_free(mr);
 }
 
 
-static struct item *
-map_rect_get_item_garmin_img(struct map_rect_priv *mr) {
+static struct item *map_rect_get_item_garmin_img(struct map_rect_priv *mr) {
     char *p,type[256];
     int ptype;
     int debug=0;
@@ -1433,8 +1390,7 @@ map_rect_get_item_garmin_img(struct map_rect_priv *mr) {
     }
 }
 
-static struct item *
-map_rect_get_item_byid_garmin_img(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_rect_get_item_byid_garmin_img(struct map_rect_priv *mr, int id_hi, int id_lo) {
     fseek(mr->f, id_lo, SEEK_SET);
     get_line(mr);
     mr->item.id_hi=id_hi;
@@ -1453,8 +1409,7 @@ static struct map_methods map_methods_garmin_img = {
     map_rect_get_item_byid_garmin_img,
 };
 
-static struct map_priv *
-map_new_garmin_img(struct map_methods *meth, struct attr **attrs) {
+static struct map_priv *map_new_garmin_img(struct map_methods *meth, struct attr **attrs) {
     struct map_priv *m;
     struct attr *data=attr_search(attrs, NULL, attr_data);
     if (! data)
@@ -1467,8 +1422,7 @@ map_new_garmin_img(struct map_methods *meth, struct attr **attrs) {
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_map("garmin_img", map_new_garmin_img);
 }
 

--- a/navit/map/mg/block.c
+++ b/navit/map/mg/block.c
@@ -62,16 +62,14 @@ static inline struct block_index_item * block_index_get_list(struct block_index 
     return (struct block_index_item *)(blk->p+12);
 }
 
-static struct block *
-block_get(unsigned char **p) {
+static struct block *block_get(unsigned char **p) {
     struct block *ret=(struct block *)(*p);
     *p += sizeof(*ret);
     return ret;
 }
 
 
-static struct block *
-block_get_byid(struct file *file, int id, unsigned char **p_ret) {
+static struct block *block_get_byid(struct file *file, int id, unsigned char **p_ret) {
     struct block_index *blk_idx;
     int blk_num,max;
 
@@ -89,8 +87,7 @@ block_get_byid(struct file *file, int id, unsigned char **p_ret) {
     return block_get(p_ret);
 }
 
-int
-block_get_byindex(struct file *file, int idx, struct block_priv *blk) {
+int block_get_byindex(struct file *file, int idx, struct block_priv *blk) {
     dbg(lvl_debug,"idx=%d", idx);
     blk->b=block_get_byid(file, idx, &blk->p);
     blk->block_start=(unsigned char *)(blk->b);
@@ -100,8 +97,7 @@ block_get_byindex(struct file *file, int idx, struct block_priv *blk) {
     return 1;
 }
 
-static void
-block_setup_tags(struct map_rect_priv *mr) {
+static void block_setup_tags(struct map_rect_priv *mr) {
     int len;
     unsigned char *p,*t;
     char *str;
@@ -143,22 +139,19 @@ block_setup_tags(struct map_rect_priv *mr) {
 }
 
 #if 0
-static void
-block_rect_print(struct coord_rect *r) {
+static void block_rect_print(struct coord_rect *r) {
     printf ("0x%x,0x%x-0x%x,0x%x (0x%x,0x%x)", r->lu.x, r->lu.y, r->rl.x, r->rl.y, r->lu.x/2+r->rl.x/2,r->lu.y/2+r->rl.y/2);
 }
 #endif
 
-static void
-block_rect_same(struct coord_rect *r1, struct coord_rect *r2) {
+static void block_rect_same(struct coord_rect *r1, struct coord_rect *r2) {
     dbg_assert(r1->lu.x==r2->lu.x);
     dbg_assert(r1->lu.y==r2->lu.y);
     dbg_assert(r1->rl.x==r2->rl.x);
     dbg_assert(r1->rl.y==r2->rl.y);
 }
 
-int
-block_init(struct map_rect_priv *mr) {
+int block_init(struct map_rect_priv *mr) {
     mr->b.block_num=-1;
     mr->b.bt.b=NULL;
     mr->b.bt.next=0;
@@ -174,8 +167,7 @@ block_init(struct map_rect_priv *mr) {
 }
 
 
-int
-block_next_lin(struct map_rect_priv *mr) {
+int block_next_lin(struct map_rect_priv *mr) {
     struct coord_rect r;
     for (;;) {
         block_lin_count++;
@@ -208,8 +200,7 @@ block_next_lin(struct map_rect_priv *mr) {
     }
 }
 
-int
-block_next(struct map_rect_priv *mr) {
+int block_next(struct map_rect_priv *mr) {
     int blk_num,coord,r_h,r_w;
     struct block_bt_priv *bt=&mr->b.bt;
     struct coord_rect r;

--- a/navit/map/mg/map.c
+++ b/navit/map/mg/map.c
@@ -169,8 +169,7 @@ struct item_range poly_ranges[]= {
 };
 
 
-static int
-file_next(struct map_rect_priv *mr) {
+static int file_next(struct map_rect_priv *mr) {
     int debug=0;
 
     for (;;) {
@@ -207,8 +206,7 @@ file_next(struct map_rect_priv *mr) {
     }
 }
 
-static void
-map_destroy_mg(struct map_priv *m) {
+static void map_destroy_mg(struct map_priv *m) {
     int i;
 
     printf("mg_map_destroy\n");
@@ -242,8 +240,7 @@ map_rect_new_mg(struct map_priv *map, struct map_selection *sel) {
 }
 
 
-static struct item *
-map_rect_get_item_mg(struct map_rect_priv *mr) {
+static struct item *map_rect_get_item_mg(struct map_rect_priv *mr) {
     for (;;) {
         switch (mr->current_file) {
         case file_town_twn:
@@ -315,8 +312,7 @@ map_rect_get_item_byid_mg(struct map_rect_priv *mr, int id_hi, int id_lo) {
 }
 
 
-void
-map_rect_destroy_mg(struct map_rect_priv *mr) {
+void map_rect_destroy_mg(struct map_rect_priv *mr) {
     int i;
     for (i=0 ; i < file_end ; i++)
         if (mr->block_hash[i])
@@ -324,8 +320,7 @@ map_rect_destroy_mg(struct map_rect_priv *mr) {
     g_free(mr);
 }
 
-static char *
-map_search_mg_convert_special(char *str) {
+static char *map_search_mg_convert_special(char *str) {
     char *ret,*c=g_malloc(strlen(str)*2+1);
 
     ret=c;
@@ -364,8 +359,7 @@ map_search_mg_convert_special(char *str) {
     }
 }
 
-static int
-map_search_setup(struct map_rect_priv *mr) {
+static int map_search_setup(struct map_rect_priv *mr) {
     char *prefix;
     dbg(lvl_debug,"%s", attr_to_name(mr->search_type));
     switch (mr->search_type) {
@@ -456,8 +450,8 @@ static void map_search_cleanup(struct map_rect_priv *mr);
 
 static struct item * map_search_get_item_mg(struct map_search_priv *ms);
 
-static struct map_search_priv *
-map_search_new_mg(struct map_priv *map, struct item *item, struct attr *search, int partial) {
+static struct map_search_priv *map_search_new_mg(struct map_priv *map, struct item *item, struct attr *search,
+        int partial) {
     struct map_rect_priv *mr=g_new0(struct map_rect_priv, 1);
     dbg(lvl_debug,"searching for %s '%s'", attr_to_name(search->type), search->u.str);
     dbg(lvl_debug,"id_lo=0x%x", item->id_lo);
@@ -481,8 +475,7 @@ map_search_new_mg(struct map_priv *map, struct item *item, struct attr *search, 
     return (struct map_search_priv *)mr;
 }
 
-static void
-map_search_cleanup(struct map_rect_priv *mr) {
+static void map_search_cleanup(struct map_rect_priv *mr) {
     g_free(mr->search_str);
     mr->search_str=NULL;
     tree_search_free(&mr->ts);
@@ -493,8 +486,7 @@ map_search_cleanup(struct map_rect_priv *mr) {
     mr->search_block=0;
 }
 
-static void
-map_search_destroy_mg(struct map_search_priv *ms) {
+static void map_search_destroy_mg(struct map_search_priv *ms) {
     struct map_rect_priv *mr=(struct map_rect_priv *)ms;
 
     dbg(lvl_debug,"mr=%p", mr);
@@ -507,8 +499,7 @@ map_search_destroy_mg(struct map_search_priv *ms) {
     g_free(mr);
 }
 
-static struct item *
-map_search_get_item_mg(struct map_search_priv *ms) {
+static struct item *map_search_get_item_mg(struct map_search_priv *ms) {
     struct map_rect_priv *mr=(struct map_rect_priv *)ms;
     struct item *ret=NULL;
 
@@ -594,7 +585,6 @@ map_new_mg(struct map_methods *meth, struct attr **attrs, struct callback_list *
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_map("mg", map_new_mg);
 }

--- a/navit/map/mg/poly.c
+++ b/navit/map/mg/poly.c
@@ -21,16 +21,14 @@
 #include "debug.h"
 #include "mg.h"
 
-static void
-poly_coord_rewind(void *priv_data) {
+static void poly_coord_rewind(void *priv_data) {
     struct poly_priv *poly=priv_data;
 
     poly->p=poly->subpoly_start;
 
 }
 
-static int
-poly_coord_get(void *priv_data, struct coord *c, int count) {
+static int poly_coord_get(void *priv_data, struct coord *c, int count) {
     struct poly_priv *poly=priv_data;
     int ret=0;
 
@@ -45,15 +43,13 @@ poly_coord_get(void *priv_data, struct coord *c, int count) {
     return ret;
 }
 
-static void
-poly_attr_rewind(void *priv_data) {
+static void poly_attr_rewind(void *priv_data) {
     struct poly_priv *poly=priv_data;
 
     poly->aidx=0;
 }
 
-static int
-poly_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int poly_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct poly_priv *poly=priv_data;
 
     attr->type=attr_type;
@@ -83,8 +79,7 @@ static struct item_methods poly_meth = {
     poly_attr_get,
 };
 
-static void
-poly_get_data(struct poly_priv *poly, unsigned char **p) {
+static void poly_get_data(struct poly_priv *poly, unsigned char **p) {
     poly->c[0].x=get_u32_unal(p);
     poly->c[0].y=get_u32_unal(p);
     poly->c[1].x=get_u32_unal(p);
@@ -103,8 +98,7 @@ poly_get_data(struct poly_priv *poly, unsigned char **p) {
     poly->count_sum=get_u32_unal(p);
 }
 
-int
-poly_get(struct map_rect_priv *mr, struct poly_priv *poly, struct item *item) {
+int poly_get(struct map_rect_priv *mr, struct poly_priv *poly, struct item *item) {
     struct coord_rect r;
 
     for (;;) {
@@ -246,8 +240,7 @@ poly_get(struct map_rect_priv *mr, struct poly_priv *poly, struct item *item) {
     }
 }
 
-int
-poly_get_byid(struct map_rect_priv *mr, struct poly_priv *poly, int id_hi, int id_lo, struct item *item) {
+int poly_get_byid(struct map_rect_priv *mr, struct poly_priv *poly, int id_hi, int id_lo, struct item *item) {
     int count=id_lo & 0xffff;
     int ret=0;
     block_get_byindex(mr->m->file[mr->current_file], id_lo >> 16, &mr->b);

--- a/navit/map/mg/street.c
+++ b/navit/map/mg/street.c
@@ -30,8 +30,7 @@ int coord_debug;
 static void street_name_numbers_get(struct street_name_numbers *name_numbers, unsigned char **p);
 static void street_name_number_get(struct street_name_number *name_number, unsigned char **p);
 
-static void
-street_name_debug(struct street_name *sn, FILE *out) {
+static void street_name_debug(struct street_name *sn, FILE *out) {
     struct street_name_numbers nns;
     unsigned char *p=sn->aux_data;
     unsigned char *end=p+sn->aux_len;
@@ -59,8 +58,7 @@ street_name_debug(struct street_name *sn, FILE *out) {
 }
 #endif
 
-static void
-street_name_get(struct street_name *name, unsigned char **p) {
+static void street_name_get(struct street_name *name, unsigned char **p) {
     unsigned char *start=*p;
     name->len=get_u16_unal(p);
     name->country=get_u16_unal(p);
@@ -77,13 +75,11 @@ street_name_get(struct street_name *name, unsigned char **p) {
     *p=start+name->len;
 }
 
-static int
-street_name_eod(struct street_name *name) {
+static int street_name_eod(struct street_name *name) {
     return (name->tmp_data >= name->aux_data+name->aux_len);
 }
 
-static void
-street_name_numbers_get(struct street_name_numbers *name_numbers, unsigned char **p) {
+static void street_name_numbers_get(struct street_name_numbers *name_numbers, unsigned char **p) {
     unsigned char *start=*p;
     name_numbers->len=get_u16_unal(p);
     name_numbers->tag=get_u8(p);
@@ -104,13 +100,11 @@ street_name_numbers_get(struct street_name_numbers *name_numbers, unsigned char 
     *p=start+name_numbers->len;
 }
 
-static int
-street_name_numbers_eod(struct street_name_numbers *name_numbers) {
+static int street_name_numbers_eod(struct street_name_numbers *name_numbers) {
     return (name_numbers->tmp_data >= name_numbers->aux_data+name_numbers->aux_len);
 }
 
-static void
-street_name_number_get(struct street_name_number *name_number, unsigned char **p) {
+static void street_name_number_get(struct street_name_number *name_number, unsigned char **p) {
     unsigned char *start=*p;
     name_number->len=get_u16_unal(p);
     name_number->tag=get_u8(p);
@@ -123,8 +117,7 @@ street_name_number_get(struct street_name_number *name_number, unsigned char **p
     *p=start+name_number->len;
 }
 
-static void
-street_name_get_by_id(struct street_name *name, struct file *file, unsigned long id) {
+static void street_name_get_by_id(struct street_name *name, struct file *file, unsigned long id) {
     unsigned char *p;
     if (id) {
         p=file->begin+id+0x2000;
@@ -190,8 +183,7 @@ static int street_get_coord(unsigned char **pos, int bytes, struct coord_rect *r
     return flags;
 }
 
-static void
-street_coord_get_begin(unsigned char **p) {
+static void street_coord_get_begin(unsigned char **p) {
     struct street_str *str;
 
     str=(struct street_str *)(*p);
@@ -203,16 +195,14 @@ street_coord_get_begin(unsigned char **p) {
 }
 
 
-static void
-street_coord_rewind(void *priv_data) {
+static void street_coord_rewind(void *priv_data) {
     struct street_priv *street=priv_data;
 
     street->p=street->next=NULL;
     street->status=street->status_rewind;
 }
 
-static int
-street_coord_get_helper(struct street_priv *street, struct coord *c) {
+static int street_coord_get_helper(struct street_priv *street, struct coord *c) {
     unsigned char *n;
     if (street->p+street->bytes*2 >= street->end)
         return 0;
@@ -229,8 +219,7 @@ street_coord_get_helper(struct street_priv *street, struct coord *c) {
     return 1;
 }
 
-static int
-street_coord_get(void *priv_data, struct coord *c, int count) {
+static int street_coord_get(void *priv_data, struct coord *c, int count) {
     struct street_priv *street=priv_data;
     int ret=0,i,scount;
 #ifdef DEBUG_COORD_GET
@@ -275,14 +264,12 @@ street_coord_get(void *priv_data, struct coord *c, int count) {
     return ret;
 }
 
-static void
-street_attr_rewind(void *priv_data) {
+static void street_attr_rewind(void *priv_data) {
     /* struct street_priv *street=priv_data; */
 
 }
 
-static int
-street_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int street_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct street_priv *street=priv_data;
     int nameid;
 
@@ -365,8 +352,7 @@ static struct item_methods street_meth = {
     street_attr_get,
 };
 
-static void
-street_get_data(struct street_priv *street, unsigned char **p) {
+static void street_get_data(struct street_priv *street, unsigned char **p) {
     street->header=(struct street_header *)(*p);
     (*p)+=sizeof(struct street_header);
     street->type_count=street_header_get_count(street->header);
@@ -377,8 +363,7 @@ street_get_data(struct street_priv *street, unsigned char **p) {
 /*0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 */
 static unsigned char limit[]= {0,0,1,1,1,2,2,4,6,6,12,13,14,20,20,20,20,20,20};
 
-int
-street_get(struct map_rect_priv *mr, struct street_priv *street, struct item *item) {
+int street_get(struct map_rect_priv *mr, struct street_priv *street, struct item *item) {
     int *flags;
     struct coord_rect r;
     for (;;) {
@@ -504,8 +489,7 @@ street_get(struct map_rect_priv *mr, struct street_priv *street, struct item *it
     }
 }
 
-int
-street_get_byid(struct map_rect_priv *mr, struct street_priv *street, int id_hi, int id_lo, struct item *item) {
+int street_get_byid(struct map_rect_priv *mr, struct street_priv *street, int id_hi, int id_lo, struct item *item) {
     int country=id_hi & 0xffff;
     int res;
     struct coord_rect r;
@@ -541,8 +525,7 @@ struct street_name_index {
     char name[0];
 } __attribute__((packed));
 
-static unsigned char
-latin1_tolower(unsigned char c) {
+static unsigned char latin1_tolower(unsigned char c) {
     if (c >= 'A' && c <= 'Z')
         return c - 'A' + 'a';
     if (c == 0xc4 || c == 0xc9 || c == 0xd6 || c == 0xdc)
@@ -550,8 +533,7 @@ latin1_tolower(unsigned char c) {
     return c;
 }
 
-static unsigned char
-latin1_tolower_ascii(unsigned char c) {
+static unsigned char latin1_tolower_ascii(unsigned char c) {
     unsigned char ret=latin1_tolower(c);
     switch (ret) {
     case 0xe4:
@@ -569,8 +551,7 @@ latin1_tolower_ascii(unsigned char c) {
     }
 }
 
-static int
-strncasecmp_latin1(char *str1, char *str2, int len) {
+static int strncasecmp_latin1(char *str1, char *str2, int len) {
     int d;
     while (len--) {
         d=latin1_tolower((unsigned char)(*str1))-latin1_tolower((unsigned char)(*str2));
@@ -584,8 +565,7 @@ strncasecmp_latin1(char *str1, char *str2, int len) {
     return 0;
 }
 
-static int
-strncasecmp_latin1_ascii(char *str1, char *str2, int len) {
+static int strncasecmp_latin1_ascii(char *str1, char *str2, int len) {
     int d;
     while (len--) {
         d=latin1_tolower_ascii((unsigned char)(*str1))-latin1_tolower_ascii((unsigned char)(*str2));
@@ -599,8 +579,7 @@ strncasecmp_latin1_ascii(char *str1, char *str2, int len) {
     return 0;
 }
 
-static int
-street_search_compare_do(struct map_rect_priv *mr, int country, int town_assoc, char *name) {
+static int street_search_compare_do(struct map_rect_priv *mr, int country, int town_assoc, char *name) {
     int d,len;
 
     dbg(lvl_debug,"enter");
@@ -627,8 +606,7 @@ street_search_compare_do(struct map_rect_priv *mr, int country, int town_assoc, 
     return d;
 }
 
-static int
-street_search_compare(unsigned char **p, struct map_rect_priv *mr) {
+static int street_search_compare(unsigned char **p, struct map_rect_priv *mr) {
     struct street_name_index *i;
     int ret;
 
@@ -644,20 +622,17 @@ street_search_compare(unsigned char **p, struct map_rect_priv *mr) {
     return ret;
 }
 
-static void
-street_name_coord_rewind(void *priv_data) {
+static void street_name_coord_rewind(void *priv_data) {
     /* struct street_priv *street=priv_data; */
 
 }
 
-static void
-street_name_attr_rewind(void *priv_data) {
+static void street_name_attr_rewind(void *priv_data) {
     /* struct street_priv *street=priv_data; */
 
 }
 
-static int
-street_name_coord_get(void *priv_data, struct coord *c, int count) {
+static int street_name_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     struct street_name_numbers snns;
     unsigned char *p=mr->street.name.aux_data;
@@ -673,8 +648,7 @@ street_name_coord_get(void *priv_data, struct coord *c, int count) {
 }
 
 #if 0
-static void
-debug(struct map_rect_priv *mr) {
+static void debug(struct map_rect_priv *mr) {
     int i;
     struct street_name_numbers nns;
     unsigned char *p=mr->street.name.aux_data;
@@ -715,8 +689,7 @@ debug(struct map_rect_priv *mr) {
 }
 #endif
 
-static int
-street_name_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int street_name_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
 
     attr->type=attr_type;
@@ -754,8 +727,8 @@ static struct item_methods street_name_meth = {
 };
 
 
-int
-street_name_get_byid(struct map_rect_priv *mr, struct street_priv *street, int id_hi, int id_lo, struct item *item) {
+int street_name_get_byid(struct map_rect_priv *mr, struct street_priv *street, int id_hi, int id_lo,
+                         struct item *item) {
     mr->current_file=id_hi >> 16;
     street->name_file=mr->m->file[mr->current_file];
     item->type=type_street_name;
@@ -771,8 +744,7 @@ street_name_get_byid(struct map_rect_priv *mr, struct street_priv *street, int i
     return 1;
 }
 
-static struct item *
-street_search_get_item_street_name(struct map_rect_priv *mr) {
+static struct item *street_search_get_item_street_name(struct map_rect_priv *mr) {
     int dir=1,leaf;
     unsigned char *last;
 
@@ -853,8 +825,7 @@ street_search_get_item(struct map_rect_priv *mr) {
     }
 }
 
-static int
-street_name_numbers_next(struct map_rect_priv *mr) {
+static int street_name_numbers_next(struct map_rect_priv *mr) {
     if (street_name_eod(&mr->street.name))
         return 0;
     dbg(lvl_debug,"%p vs %p",mr->street.name.tmp_data, mr->street.name.aux_data);
@@ -862,8 +833,7 @@ street_name_numbers_next(struct map_rect_priv *mr) {
     return 1;
 }
 
-static int
-street_name_number_next(struct map_rect_priv *mr) {
+static int street_name_number_next(struct map_rect_priv *mr) {
     if (street_name_numbers_eod(&mr->street.name_numbers))
         return 0;
     street_name_number_get(&mr->street.name_number, &mr->street.name_numbers.tmp_data);
@@ -873,25 +843,21 @@ street_name_number_next(struct map_rect_priv *mr) {
     return 1;
 }
 
-static void
-housenumber_coord_rewind(void *priv_data) {
+static void housenumber_coord_rewind(void *priv_data) {
     /* struct street_priv *street=priv_data; */
 
 }
 
-static void
-housenumber_attr_rewind(void *priv_data) {
+static void housenumber_attr_rewind(void *priv_data) {
     /* struct street_priv *street=priv_data; */
 
 }
 
-static int
-housenumber_coord_get(void *priv_data, struct coord *c, int count) {
+static int housenumber_coord_get(void *priv_data, struct coord *c, int count) {
     return 0;
 }
 
-static int
-housenumber_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int housenumber_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     attr->type=attr_type;
     switch (attr_type) {
@@ -921,8 +887,7 @@ static struct item_methods housenumber_meth = {
     housenumber_attr_get,
 };
 
-int
-housenumber_search_setup(struct map_rect_priv *mr) {
+int housenumber_search_setup(struct map_rect_priv *mr) {
     dbg(lvl_debug,"enter (0x%x,0x%x)",mr->search_item.id_hi,mr->search_item.id_lo);
     int id=mr->search_item.id_hi & 0xff;
     mr->current_file=file_strname_stn;
@@ -953,8 +918,7 @@ housenumber_search_setup(struct map_rect_priv *mr) {
     return 1;
 }
 
-static int
-house_number_next(char *number, char *first, char *last, int interpolation, int *percentage) {
+static int house_number_next(char *number, char *first, char *last, int interpolation, int *percentage) {
     int firstn=atoi(first);
     int lastn=atoi(last);
     int current,delta,len=lastn-firstn;

--- a/navit/map/mg/town.c
+++ b/navit/map/mg/town.c
@@ -24,15 +24,13 @@
 
 
 
-static void
-town_coord_rewind(void *priv_data) {
+static void town_coord_rewind(void *priv_data) {
     struct town_priv *twn=priv_data;
 
     twn->cidx=0;
 }
 
-static int
-town_coord_get(void *priv_data, struct coord *c, int count) {
+static int town_coord_get(void *priv_data, struct coord *c, int count) {
     struct town_priv *twn=priv_data;
 
     if (twn->cidx || count <= 0)
@@ -42,16 +40,14 @@ town_coord_get(void *priv_data, struct coord *c, int count) {
     return 1;
 }
 
-static void
-town_attr_rewind(void *priv_data) {
+static void town_attr_rewind(void *priv_data) {
     struct town_priv *twn=priv_data;
 
     twn->aidx=0;
     twn->attr_next=attr_label;
 }
 
-static int
-town_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int town_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct town_priv *twn=priv_data;
     int len;
 
@@ -115,8 +111,7 @@ static struct item_methods town_meth = {
     town_attr_get,
 };
 
-static void
-town_get_data(struct town_priv *twn, unsigned char **p) {
+static void town_get_data(struct town_priv *twn, unsigned char **p) {
     twn->id=get_u32_unal(p);
     twn->c.x=get_u32_unal(p);
     twn->c.y=get_u32_unal(p);
@@ -138,8 +133,7 @@ static unsigned char limit[]= {0,1,2,2,4,6,8,10,11,13,14,14,14,20,20,20,20,20,20
 
 static enum item_type town_item[]= {type_town_label_5e1, type_town_label_1e2, type_town_label_2e2, type_town_label_5e2, type_town_label_1e3, type_town_label_1e3, type_town_label_2e3, type_town_label_5e3, type_town_label_1e4, type_town_label_2e4, type_town_label_5e4, type_town_label_1e5, type_town_label_1e5, type_town_label_2e5, type_town_label_5e5, type_town_label_1e6, type_town_label_2e6};
 static enum item_type district_item[]= {type_district_label_5e1, type_district_label_1e2, type_district_label_2e2, type_district_label_5e2, type_district_label_1e3, type_district_label_1e3, type_district_label_2e3, type_district_label_5e3, type_district_label_1e4, type_district_label_2e4, type_district_label_5e4, type_district_label_1e5, type_district_label_1e5, type_district_label_2e5, type_district_label_5e5, type_district_label_1e6, type_district_label_2e6};
-int
-town_get(struct map_rect_priv *mr, struct town_priv *twn, struct item *item) {
+int town_get(struct map_rect_priv *mr, struct town_priv *twn, struct item *item) {
     int size;
     for (;;) {
         if (mr->b.p >= mr->b.end)
@@ -187,8 +181,7 @@ town_get(struct map_rect_priv *mr, struct town_priv *twn, struct item *item) {
     }
 }
 
-int
-town_get_byid(struct map_rect_priv *mr, struct town_priv *twn, int id_hi, int id_lo, struct item *item) {
+int town_get_byid(struct map_rect_priv *mr, struct town_priv *twn, int id_hi, int id_lo, struct item *item) {
     int country=id_hi & 0xffff;
     int res;
     if (!tree_search_hv(mr->m->dirname, "town", (id_lo >> 8) | (country << 24), id_lo & 0xff, &res))
@@ -198,8 +191,7 @@ town_get_byid(struct map_rect_priv *mr, struct town_priv *twn, int id_hi, int id
     return town_get(mr, twn, item);
 }
 
-static int
-town_search_compare(unsigned char **p, struct map_rect_priv *mr) {
+static int town_search_compare(unsigned char **p, struct map_rect_priv *mr) {
     int country, d;
     char *name;
 

--- a/navit/map/mg/tree.c
+++ b/navit/map/mg/tree.c
@@ -109,8 +109,7 @@ static inline int tree_leaf_v_get_value(struct tree_leaf_v * tree) {
     return get_u32_unal(&p);
 }
 
-static int
-tree_search_h(struct file *file, unsigned int search) {
+static int tree_search_h(struct file *file, unsigned int search) {
     unsigned char *p=file->begin,*end;
     int last,i=0,value,lower;
     struct tree_hdr_h *thdr;
@@ -147,8 +146,7 @@ tree_search_h(struct file *file, unsigned int search) {
     return 0;
 }
 
-static int
-tree_search_v(struct file *file, int offset, int search) {
+static int tree_search_v(struct file *file, int offset, int search) {
     unsigned char *p=file->begin+offset;
     int i=0,count,next;
     struct tree_hdr_v *thdr;
@@ -173,8 +171,7 @@ tree_search_v(struct file *file, int offset, int search) {
     return 0;
 }
 
-int
-tree_search_hv(char *dirname, char *filename, unsigned int search_h, unsigned int search_v, int *result) {
+int tree_search_hv(char *dirname, char *filename, unsigned int search_h, unsigned int search_v, int *result) {
     struct file *f_idx_h, *f_idx_v;
     char buffer[4096];
     int h,v;
@@ -208,8 +205,7 @@ tree_search_hv(char *dirname, char *filename, unsigned int search_h, unsigned in
     return 0;
 }
 
-static struct tree_search_node *
-tree_search_enter(struct tree_search *ts, int offset) {
+static struct tree_search_node *tree_search_enter(struct tree_search *ts, int offset) {
     struct tree_search_node *tsn=&ts->nodes[++ts->curr_node];
     unsigned char *p;
     p=ts->f->begin+offset;
@@ -294,8 +290,7 @@ int tree_search_next_lin(struct tree_search *ts, unsigned char **p) {
     return 0;
 }
 
-void
-tree_search_init(char *dirname, char *filename, struct tree_search *ts, int offset) {
+void tree_search_init(char *dirname, char *filename, struct tree_search *ts, int offset) {
     char buffer[4096];
     sprintf(buffer, "%s/%s", dirname, filename);
     ts->f=file_create_caseinsensitive(buffer, 0);
@@ -306,8 +301,7 @@ tree_search_init(char *dirname, char *filename, struct tree_search *ts, int offs
     }
 }
 
-void
-tree_search_free(struct tree_search *ts) {
+void tree_search_free(struct tree_search *ts) {
     if (ts->f)
         file_destroy(ts->f);
 }

--- a/navit/map/shapefile/shapefile.c
+++ b/navit/map/shapefile/shapefile.c
@@ -73,21 +73,18 @@ struct map_rect_priv {
     struct attr *attr;
 };
 
-static void
-map_destroy_shapefile(struct map_priv *m) {
+static void map_destroy_shapefile(struct map_priv *m) {
     dbg(lvl_debug,"map_destroy_shapefile");
     g_free(m);
 }
 
-static void
-shapefile_coord_rewind(void *priv_data) {
+static void shapefile_coord_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     mr->cidx=mr->cidx_rewind;
     mr->part=mr->part_rewind;
 }
 
-static void
-shapefile_coord(struct map_rect_priv *mr, int idx, struct coord *c) {
+static void shapefile_coord(struct map_rect_priv *mr, int idx, struct coord *c) {
     SHPObject *psShape=mr->psShape;
     struct coord cs;
     struct coord_geo g;
@@ -103,8 +100,7 @@ shapefile_coord(struct map_rect_priv *mr, int idx, struct coord *c) {
     }
 }
 
-static int
-shapefile_coord_get(void *priv_data, struct coord *c, int count) {
+static int shapefile_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     int ret=0;
     int idx;
@@ -134,8 +130,7 @@ shapefile_coord_get(void *priv_data, struct coord *c, int count) {
     return ret;
 }
 
-static void
-shapefile_attr_rewind(void *priv_data) {
+static void shapefile_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     mr->aidx=0;
     mr->attr_pos=0;
@@ -165,8 +160,7 @@ struct longest_match {
     int longest_match_list_count;
 };
 
-static void
-longest_match_add_match(struct longest_match *lm, struct longest_match_list_item *lmi, char *match) {
+static void longest_match_add_match(struct longest_match *lm, struct longest_match_list_item *lmi, char *match) {
     int idx;
     if (!(idx=(int)(long)g_hash_table_lookup(lm->match_hash, match))) {
         idx=lm->match_present_count++;
@@ -177,8 +171,7 @@ longest_match_add_match(struct longest_match *lm, struct longest_match_list_item
     lmi->match_idx[lmi->match_idx_count++]=idx;
 }
 
-static void
-longest_match_item_destroy(struct longest_match_list_item *lmi, long flags) {
+static void longest_match_item_destroy(struct longest_match_list_item *lmi, long flags) {
     if (!lmi)
         return;
     if (flags & 2) {
@@ -188,8 +181,7 @@ longest_match_item_destroy(struct longest_match_list_item *lmi, long flags) {
     g_free(lmi);
 }
 
-static struct longest_match_list_item *
-longest_match_item_new(struct longest_match_list *lml, void *data) {
+static struct longest_match_list_item *longest_match_item_new(struct longest_match_list *lml, void *data) {
     struct longest_match_list_item *ret=g_new0(struct longest_match_list_item,1);
     lml->longest_match_list_items=g_list_append(lml->longest_match_list_items, ret);
     ret->data=data;
@@ -197,15 +189,13 @@ longest_match_item_new(struct longest_match_list *lml, void *data) {
     return ret;
 }
 
-static struct longest_match_list *
-longest_match_list_new(struct longest_match *lm) {
+static struct longest_match_list *longest_match_list_new(struct longest_match *lm) {
     struct longest_match_list *ret=g_new0(struct longest_match_list,1);
     lm->longest_match_lists=g_list_append(lm->longest_match_lists, ret);
     return ret;
 }
 
-static void
-longest_match_list_destroy(struct longest_match_list *lml, long flags) {
+static void longest_match_list_destroy(struct longest_match_list *lml, long flags) {
     if (!lml)
         return;
     if (flags & 1) {
@@ -215,8 +205,7 @@ longest_match_list_destroy(struct longest_match_list *lml, long flags) {
     g_free(lml);
 }
 
-static struct longest_match_list *
-longest_match_get_list(struct longest_match *lm, int list) {
+static struct longest_match_list *longest_match_get_list(struct longest_match *lm, int list) {
     GList *l=lm->longest_match_lists;
     while (l && list > 0) {
         l=g_list_next(l);
@@ -227,16 +216,14 @@ longest_match_get_list(struct longest_match *lm, int list) {
     return NULL;
 }
 
-static struct longest_match *
-longest_match_new(void) {
+static struct longest_match *longest_match_new(void) {
     struct longest_match *ret=g_new0(struct longest_match,1);
     ret->match_hash=g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
     ret->match_present_count=1;
     return ret;
 }
 
-static void
-longest_match_destroy(struct longest_match *lm, long flags) {
+static void longest_match_destroy(struct longest_match *lm, long flags) {
     if (!lm)
         return;
     if (flags & 1) {
@@ -248,14 +235,12 @@ longest_match_destroy(struct longest_match *lm, long flags) {
     g_free(lm);
 }
 
-static void
-longest_match_clear(struct longest_match *lm) {
+static void longest_match_clear(struct longest_match *lm) {
     if (lm->match_present)
         memset(lm->match_present, 0, lm->match_present_count);
 }
 
-static void
-longest_match_add_key_value(struct longest_match *lm, char *k, char *v) {
+static void longest_match_add_key_value(struct longest_match *lm, char *k, char *v) {
     char* buffer=g_alloca(strlen(k)+strlen(v)+2);
     int idx;
 
@@ -276,8 +261,8 @@ longest_match_add_key_value(struct longest_match *lm, char *k, char *v) {
         lm->match_present[idx]=4;
 }
 
-static int
-longest_match_list_find(struct longest_match *lm, struct longest_match_list *lml, void **list, int max_list_len) {
+static int longest_match_list_find(struct longest_match *lm, struct longest_match_list *lml, void **list,
+                                   int max_list_len) {
     int j,longest=0,ret=0,sum,val;
     struct longest_match_list_item *curr;
     GList *l=lml->longest_match_list_items;
@@ -307,8 +292,7 @@ longest_match_list_find(struct longest_match *lm, struct longest_match_list *lml
 }
 
 
-static void
-build_match(struct longest_match *lm, struct longest_match_list *lml, char *line) {
+static void build_match(struct longest_match *lm, struct longest_match_list *lml, char *line) {
     struct longest_match_list_item *lmli;
     char *kvl=NULL,*i=NULL,*p,*kv;
     dbg(lvl_debug,"line=%s",line);
@@ -326,8 +310,7 @@ build_match(struct longest_match *lm, struct longest_match_list *lml, char *line
     }
 }
 
-static void
-build_matches(struct map_priv *m,char *matches) {
+static void build_matches(struct map_priv *m,char *matches) {
     char *matches2=g_strdup(matches);
     char *l=matches2,*p;
     struct longest_match_list *lml;
@@ -345,8 +328,7 @@ build_matches(struct map_priv *m,char *matches) {
     g_free(matches2);
 }
 
-static void
-process_fields(struct map_priv *m, int id) {
+static void process_fields(struct map_priv *m, int id) {
     int i;
     char szTitle[12],*str;
     int nWidth, nDecimals;
@@ -373,8 +355,7 @@ process_fields(struct map_priv *m, int id) {
     }
 }
 
-static int
-attr_resolve(struct map_rect_priv *mr, enum attr_type attr_type, struct attr *attr) {
+static int attr_resolve(struct map_rect_priv *mr, enum attr_type attr_type, struct attr *attr) {
     char name[1024];
     char value[1024];
     char szTitle[12];
@@ -416,8 +397,7 @@ attr_resolve(struct map_rect_priv *mr, enum attr_type attr_type, struct attr *at
     return 0;
 }
 
-static int
-shapefile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int shapefile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     struct map_priv *m=mr->m;
     char szTitle[12],*pszTypeName, *str;
@@ -479,8 +459,7 @@ static struct item_methods methods_shapefile = {
     shapefile_attr_get,
 };
 
-static struct map_rect_priv *
-map_rect_new_shapefile(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *map_rect_new_shapefile(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr;
     char *dbfmapfile=g_strdup_printf("%s.dbfmap", map->filename);
     void *data;
@@ -530,8 +509,7 @@ map_rect_new_shapefile(struct map_priv *map, struct map_selection *sel) {
 }
 
 
-static void
-map_rect_destroy_shapefile(struct map_rect_priv *mr) {
+static void map_rect_destroy_shapefile(struct map_rect_priv *mr) {
     if (mr->psShape)
         SHPDestroyObject(mr->psShape);
     attr_free(mr->attr);
@@ -539,8 +517,7 @@ map_rect_destroy_shapefile(struct map_rect_priv *mr) {
     g_free(mr);
 }
 
-static struct item *
-map_rect_get_item_shapefile(struct map_rect_priv *mr) {
+static struct item *map_rect_get_item_shapefile(struct map_rect_priv *mr) {
     struct map_priv *m=mr->m;
     void *lines[5];
     struct longest_match_list *lml;
@@ -590,8 +567,7 @@ map_rect_get_item_shapefile(struct map_rect_priv *mr) {
     return &mr->item;
 }
 
-static struct item *
-map_rect_get_item_byid_shapefile(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_rect_get_item_byid_shapefile(struct map_rect_priv *mr, int id_hi, int id_lo) {
     mr->idx=id_hi;
     while (id_lo--) {
         if (!map_rect_get_item_shapefile(mr))
@@ -610,8 +586,7 @@ static struct map_methods map_methods_shapefile = {
     map_rect_get_item_byid_shapefile,
 };
 
-static struct map_priv *
-map_new_shapefile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *map_new_shapefile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m;
     struct attr *data=attr_search(attrs, NULL, attr_data);
     struct attr *charset=attr_search(attrs, NULL, attr_charset);
@@ -652,8 +627,7 @@ map_new_shapefile(struct map_methods *meth, struct attr **attrs, struct callback
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug,"shapefile: plugin_init");
     plugin_register_category_map("shapefile", map_new_shapefile);
 }

--- a/navit/map/textfile/textfile.c
+++ b/navit/map/textfile/textfile.c
@@ -38,15 +38,13 @@
 
 static int map_id;
 
-static void
-remove_comment_line(char* line) {
+static void remove_comment_line(char* line) {
     if (line[0]==TEXTFILE_COMMENT_CHAR) {
         line='\0';
     }
 }
 
-static void
-get_line(struct map_rect_priv *mr) {
+static void get_line(struct map_rect_priv *mr) {
     if(mr->f) {
         if (!mr->m->is_pipe)
             mr->pos=ftell(mr->f);
@@ -61,8 +59,7 @@ get_line(struct map_rect_priv *mr) {
     }
 }
 
-static void
-map_destroy_textfile(struct map_priv *m) {
+static void map_destroy_textfile(struct map_priv *m) {
     g_free(m->filename);
     if(m->charset) {
         g_free(m->charset);
@@ -70,12 +67,10 @@ map_destroy_textfile(struct map_priv *m) {
     g_free(m);
 }
 
-static void
-textfile_coord_rewind(void *priv_data) {
+static void textfile_coord_rewind(void *priv_data) {
 }
 
-static int
-parse_line(struct map_rect_priv *mr, int attr) {
+static int parse_line(struct map_rect_priv *mr, int attr) {
     int pos;
 
     pos=coord_parse(mr->line, projection_mg, &mr->c);
@@ -85,8 +80,7 @@ parse_line(struct map_rect_priv *mr, int attr) {
     return pos;
 }
 
-static int
-textfile_coord_get(void *priv_data, struct coord *c, int count) {
+static int textfile_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     int ret=0;
     dbg(lvl_warning,"enter, count: %d",count);
@@ -109,23 +103,20 @@ textfile_coord_get(void *priv_data, struct coord *c, int count) {
     return ret;
 }
 
-static void
-textfile_attr_rewind(void *priv_data) {
+static void textfile_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     mr->attr_pos=0;
     mr->attr_last=attr_none;
 }
 
-static void
-textfile_encode_attr(char *attr_val, enum attr_type attr_type, struct attr *attr) {
+static void textfile_encode_attr(char *attr_val, enum attr_type attr_type, struct attr *attr) {
     if (attr_type >= attr_type_int_begin && attr_type <= attr_type_int_end)
         attr->u.num=atoi(attr_val);
     else
         attr->u.str=attr_val;
 }
 
-static int
-textfile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int textfile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     char *str=NULL;
     dbg(lvl_debug,"mr=%p attrs='%s' ", mr, mr->attrs);
@@ -163,8 +154,7 @@ static struct item_methods methods_textfile = {
     textfile_attr_get,
 };
 
-static struct map_rect_priv *
-map_rect_new_textfile(struct map_priv *map, struct map_selection *sel) {
+static struct map_rect_priv *map_rect_new_textfile(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr;
 
     dbg(lvl_debug,"enter");
@@ -217,8 +207,7 @@ map_rect_new_textfile(struct map_priv *map, struct map_selection *sel) {
 }
 
 
-static void
-map_rect_destroy_textfile(struct map_rect_priv *mr) {
+static void map_rect_destroy_textfile(struct map_rect_priv *mr) {
     if (mr->f) {
         if (mr->m->is_pipe) {
 #ifdef HAVE_POPEN
@@ -231,8 +220,7 @@ map_rect_destroy_textfile(struct map_rect_priv *mr) {
     g_free(mr);
 }
 
-static struct item *
-map_rect_get_item_textfile(struct map_rect_priv *mr) {
+static struct item *map_rect_get_item_textfile(struct map_rect_priv *mr) {
     char *p,type[TEXTFILE_LINE_SIZE];
     dbg(lvl_debug,"map_rect_get_item_textfile id_hi=%d line=%s", mr->item.id_hi, mr->line);
     if (!mr->f) {
@@ -310,8 +298,7 @@ map_rect_get_item_textfile(struct map_rect_priv *mr) {
     }
 }
 
-static struct item *
-map_rect_get_item_byid_textfile(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_rect_get_item_byid_textfile(struct map_rect_priv *mr, int id_hi, int id_lo) {
     if (mr->m->is_pipe) {
 #ifndef _MSC_VER
         pclose(mr->f);
@@ -336,8 +323,7 @@ static struct map_methods map_methods_textfile = {
     map_rect_get_item_byid_textfile,
 };
 
-static struct map_priv *
-map_new_textfile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *map_new_textfile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m;
     struct attr *data=attr_search(attrs, NULL, attr_data);
     struct attr *charset=attr_search(attrs, NULL, attr_charset);
@@ -377,8 +363,7 @@ map_new_textfile(struct map_methods *meth, struct attr **attrs, struct callback_
     return m;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug,"textfile: plugin_init");
     plugin_register_category_map("textfile", map_new_textfile);
 }

--- a/navit/mapset.c
+++ b/navit/mapset.c
@@ -78,8 +78,7 @@ mapset_attr_iter_new(void) {
     return g_new0(struct attr_iter, 1);
 }
 
-void
-mapset_attr_iter_destroy(struct attr_iter *iter) {
+void mapset_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
@@ -89,8 +88,7 @@ mapset_attr_iter_destroy(struct attr_iter *iter) {
  * @param ms The mapset to add the map to
  * @param m The map to be added
  */
-int
-mapset_add_attr(struct mapset *ms, struct attr *attr) {
+int mapset_add_attr(struct mapset *ms, struct attr *attr) {
     switch (attr->type) {
     case attr_map:
         ms->attrs=attr_generic_add_attr(ms->attrs,attr);
@@ -101,8 +99,7 @@ mapset_add_attr(struct mapset *ms, struct attr *attr) {
     }
 }
 
-int
-mapset_remove_attr(struct mapset *ms, struct attr *attr) {
+int mapset_remove_attr(struct mapset *ms, struct attr *attr) {
     switch (attr->type) {
     case attr_map:
         ms->attrs=attr_generic_remove_attr(ms->attrs,attr);
@@ -113,8 +110,7 @@ mapset_remove_attr(struct mapset *ms, struct attr *attr) {
     }
 }
 
-int
-mapset_get_attr(struct mapset *ms, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int mapset_get_attr(struct mapset *ms, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     GList *map;
     map=ms->maps;
     attr->type=type;
@@ -253,8 +249,7 @@ mapset_get_map_by_name(struct mapset *ms, const char*map_name) {
  *
  * @param msh Mapset handle to be closed
  */
-void
-mapset_close(struct mapset_handle *msh) {
+void mapset_close(struct mapset_handle *msh) {
     g_free(msh);
 }
 
@@ -373,8 +368,7 @@ mapset_search_get_item(struct mapset_search *this_) {
  *
  * @param this The mapset search to be destroyed
  */
-void
-mapset_search_destroy(struct mapset_search *this_) {
+void mapset_search_destroy(struct mapset_search *this_) {
     if (this_) {
         map_search_destroy(this_->ms);
         g_free(this_);

--- a/navit/maptool/boundaries.c
+++ b/navit/maptool/boundaries.c
@@ -23,8 +23,7 @@
 #define strcasecmp _stricmp
 #endif
 
-char *
-osm_tag_value(struct item_bin *ib, char *key) {
+char *osm_tag_value(struct item_bin *ib, char *key) {
     char *tag=NULL;
     int len=strlen(key);
     while ((tag=item_bin_get_attr(ib, attr_osm_tag, tag))) {
@@ -35,14 +34,12 @@ osm_tag_value(struct item_bin *ib, char *key) {
 }
 
 #if 0
-static char *
-osm_tag_name(struct item_bin *ib) {
+static char *osm_tag_name(struct item_bin *ib) {
     return osm_tag_value(ib, "name");
 }
 #endif
 
-osmid
-boundary_relid(struct boundary *b) {
+osmid boundary_relid(struct boundary *b) {
     long long *id;
     if (!b)
         return 0;
@@ -53,8 +50,8 @@ boundary_relid(struct boundary *b) {
         return *id;
     return 0;
 }
-static void
-process_boundaries_member(void *func_priv, void *relation_priv, struct item_bin *member, void *member_priv) {
+static void process_boundaries_member(void *func_priv, void *relation_priv, struct item_bin *member,
+                                      void *member_priv) {
     struct boundary *b=relation_priv;
     enum geom_poly_segment_type role=(long)member_priv;
     int *dup;
@@ -63,8 +60,7 @@ process_boundaries_member(void *func_priv, void *relation_priv, struct item_bin 
         b->segments=g_list_prepend(b->segments,item_bin_to_poly_segment(member, role));
 }
 
-static GList *
-process_boundaries_setup(FILE *boundaries, struct relations *relations) {
+static GList *process_boundaries_setup(FILE *boundaries, struct relations *relations) {
     struct item_bin *ib;
     GList *boundaries_list=NULL;
     struct relations_func *relations_func;
@@ -156,8 +152,7 @@ process_boundaries_setup(FILE *boundaries, struct relations *relations) {
     return boundaries_list;
 }
 
-GList *
-boundary_find_matches(GList *l, struct coord *c) {
+GList *boundary_find_matches(GList *l, struct coord *c) {
     GList *ret=NULL;
     while (l) {
         struct boundary *boundary=l->data;
@@ -172,8 +167,7 @@ boundary_find_matches(GList *l, struct coord *c) {
 }
 
 #if 0
-static void
-test(GList *boundaries_list) {
+static void test(GList *boundaries_list) {
     struct item_bin *ib;
     FILE *f=fopen("country_276.bin.unsorted","r");
     printf("start\n");
@@ -188,8 +182,7 @@ test(GList *boundaries_list) {
     printf("end\n");
 }
 
-static void
-dump_hierarchy(GList *l, char *prefix) {
+static void dump_hierarchy(GList *l, char *prefix) {
     char *newprefix=g_alloca(sizeof(char)*(strlen(prefix)+2));
     strcpy(newprefix, prefix);
     strcat(newprefix," ");
@@ -202,8 +195,7 @@ dump_hierarchy(GList *l, char *prefix) {
     }
 }
 
-static gint
-boundary_bbox_compare(gconstpointer a, gconstpointer b) {
+static gint boundary_bbox_compare(gconstpointer a, gconstpointer b) {
     const struct boundary *boundarya=a;
     const struct boundary *boundaryb=b;
     long long areaa=bbox_area(&boundarya->r);
@@ -216,8 +208,7 @@ boundary_bbox_compare(gconstpointer a, gconstpointer b) {
 }
 #endif
 
-static GList *
-process_boundaries_insert(GList *list, struct boundary *boundary) {
+static GList *process_boundaries_insert(GList *list, struct boundary *boundary) {
     GList *l=list;
     while (l) {
         struct boundary *b=l->data;
@@ -235,8 +226,7 @@ process_boundaries_insert(GList *list, struct boundary *boundary) {
 }
 
 
-static GList *
-process_boundaries_finish(GList *boundaries_list) {
+static GList *process_boundaries_finish(GList *boundaries_list) {
     GList *l,*sl;
     GList *ret=NULL;
     l=boundaries_list;
@@ -303,8 +293,7 @@ process_boundaries_finish(GList *boundaries_list) {
     return ret;
 }
 
-GList *
-process_boundaries(FILE *boundaries, FILE *ways) {
+GList *process_boundaries(FILE *boundaries, FILE *ways) {
     GList *boundaries_list;
     struct relations *relations=relations_new();
 
@@ -314,8 +303,7 @@ process_boundaries(FILE *boundaries, FILE *ways) {
     return process_boundaries_finish(boundaries_list);
 }
 
-void
-free_boundaries(GList *bl) {
+void free_boundaries(GList *bl) {
     GList *l=bl;
     while (l) {
         struct boundary *boundary=l->data;

--- a/navit/maptool/buffer.c
+++ b/navit/maptool/buffer.c
@@ -30,8 +30,7 @@
  * @param b Buffer which is saved to file.
  * @param offset
  */
-void
-save_buffer(char *filename, struct buffer *b, long long offset) {
+void save_buffer(char *filename, struct buffer *b, long long offset) {
     FILE *f;
     f=fopen(filename,"rb+");
     if (! f)
@@ -52,8 +51,7 @@ save_buffer(char *filename, struct buffer *b, long long offset) {
  * @param offset
  * @return indicator if operation suceeded
  */
-int
-load_buffer(char *filename, struct buffer *b, long long offset, long long size) {
+int load_buffer(char *filename, struct buffer *b, long long offset, long long size) {
     FILE *f;
     long long len;
     dbg_assert(size>=0);
@@ -88,8 +86,7 @@ load_buffer(char *filename, struct buffer *b, long long offset, long long size) 
  * @param  filename Name of file for which the required size of the buffer is determined
  * @return required size of buffer
  */
-long long
-sizeof_buffer(char *filename) {
+long long sizeof_buffer(char *filename) {
     long long ret;
     FILE *f=fopen(filename,"rb");
     fseeko(f, 0, SEEK_END);

--- a/navit/maptool/ch.c
+++ b/navit/maptool/ch.c
@@ -80,8 +80,7 @@ GHashTable *sgr_nodes_hash;
 
 static int ch_levels=14;
 
-static int
-road_speed(enum item_type type) {
+static int road_speed(enum item_type type) {
     switch (type) {
     case type_street_0:
     case type_street_1_city:
@@ -122,24 +121,20 @@ road_speed(enum item_type type) {
     }
 }
 
-static void
-coord_slice_free(void *data) {
+static void coord_slice_free(void *data) {
     g_slice_free(struct coord, data);
 }
 
 
-static GHashTable *
-coord_hash_new(void) {
+static GHashTable *coord_hash_new(void) {
     return g_hash_table_new_full(coord_hash, coord_equal, coord_slice_free, NULL);
 }
 
-static void
-item_id_slice_free(void *data) {
+static void item_id_slice_free(void *data) {
     g_slice_free(struct item_id, data);
 }
 
-static void
-add_node_to_hash(FILE *idx, GHashTable *hash, struct coord *c, int *nodes) {
+static void add_node_to_hash(FILE *idx, GHashTable *hash, struct coord *c, int *nodes) {
     if (! g_hash_table_lookup(hash, c)) {
         struct coord *ct=g_slice_new(struct coord);
         *ct=*c;
@@ -150,19 +145,16 @@ add_node_to_hash(FILE *idx, GHashTable *hash, struct coord *c, int *nodes) {
 
 }
 
-static void
-edge_hash_slice_free(void *data) {
+static void edge_hash_slice_free(void *data) {
     g_slice_free(struct edge_hash_item, data);
 }
 
-static guint
-edge_hash_hash(gconstpointer key) {
+static guint edge_hash_hash(gconstpointer key) {
     const struct edge_hash_item *itm=key;
     return itm->first*2654435761UL+itm->last;
 }
 
-static gboolean
-edge_hash_equal(gconstpointer a, gconstpointer b) {
+static gboolean edge_hash_equal(gconstpointer a, gconstpointer b) {
     const struct edge_hash_item *itm_a=a;
     const struct edge_hash_item *itm_b=b;
     return (itm_a->first == itm_b->first && itm_a->last == itm_b->last);
@@ -170,8 +162,7 @@ edge_hash_equal(gconstpointer a, gconstpointer b) {
 
 
 
-static void
-ch_generate_ddsg(FILE *in, FILE *ref, FILE *idx, FILE *ddsg) {
+static void ch_generate_ddsg(FILE *in, FILE *ref, FILE *idx, FILE *ddsg) {
     GHashTable *hash=coord_hash_new();
     struct item_bin *ib;
     int nodes=0,edges=0;
@@ -219,8 +210,7 @@ ch_generate_ddsg(FILE *in, FILE *ref, FILE *idx, FILE *ddsg) {
     g_hash_table_destroy(hash);
 }
 
-static void
-ch_generate_sgr(char *suffix) {
+static void ch_generate_sgr(char *suffix) {
 #ifndef HAVE_API_WIN32_CE
     char command[1024];
     int system_result;
@@ -243,8 +233,7 @@ ch_generate_sgr(char *suffix) {
 #endif
 }
 
-static void
-ch_process_node(FILE *out, int node, int resolve) {
+static void ch_process_node(FILE *out, int node, int resolve) {
     int first_edge_id=nodes[node].first_edge;
     int last_edge_id=nodes[node+1].first_edge;
     int edge_id;
@@ -298,8 +287,7 @@ ch_process_node(FILE *out, int node, int resolve) {
     item_bin_write(item_bin, out);
 }
 
-static void
-ch_process_nodes(FILE *out, int pos, int count, int resolve) {
+static void ch_process_nodes(FILE *out, int pos, int count, int resolve) {
     int i;
     printf("count %d sum=%d newnode_count=%d\n",count,pos,newnode_count);
     for (i = 0 ; i < count ; i++)
@@ -307,8 +295,7 @@ ch_process_nodes(FILE *out, int pos, int count, int resolve) {
 }
 
 
-static void
-ch_process(FILE **files, int depth, int resolve) {
+static void ch_process(FILE **files, int depth, int resolve) {
     int count=newnode_count;
     int pos=0;
 
@@ -321,8 +308,7 @@ ch_process(FILE **files, int depth, int resolve) {
     ch_process_nodes(files[depth], pos, newnode_count-pos, resolve);
 }
 
-static void
-ch_setup(char *suffix) {
+static void ch_setup(char *suffix) {
     int i;
     if (!sgr) {
         int *data,size,offset=0;
@@ -376,8 +362,7 @@ ch_setup(char *suffix) {
     }
 }
 
-static void
-ch_create_tempfiles(char *suffix, FILE **files, int count, int mode) {
+static void ch_create_tempfiles(char *suffix, FILE **files, int count, int mode) {
     char name[256];
     int i;
 
@@ -387,8 +372,7 @@ ch_create_tempfiles(char *suffix, FILE **files, int count, int mode) {
     }
 }
 
-static void
-ch_close_tempfiles(FILE **files, int count) {
+static void ch_close_tempfiles(FILE **files, int count) {
     int i;
 
     for (i = 0 ; i <= count ; i++) {
@@ -397,8 +381,7 @@ ch_close_tempfiles(FILE **files, int count) {
 }
 
 #if 0
-static void
-ch_remove_tempfiles(char *suffix, int count) {
+static void ch_remove_tempfiles(char *suffix, int count) {
     char name[256];
     int i;
 
@@ -409,8 +392,7 @@ ch_remove_tempfiles(char *suffix, int count) {
 }
 #endif
 
-static void
-ch_copy_to_tiles(char *suffix, int count, struct tile_info *info, FILE *ref) {
+static void ch_copy_to_tiles(char *suffix, int count, struct tile_info *info, FILE *ref) {
     char name[256];
     int i;
     FILE *f;
@@ -426,8 +408,7 @@ ch_copy_to_tiles(char *suffix, int count, struct tile_info *info, FILE *ref) {
     }
 }
 
-void
-ch_generate_tiles(char *map_suffix, char *suffix, FILE *tilesdir_out, struct zip_info *zip_info) {
+void ch_generate_tiles(char *map_suffix, char *suffix, FILE *tilesdir_out, struct zip_info *zip_info) {
     struct tile_info info;
     FILE *in,*ref,*ddsg_coords,*ddsg;
     FILE **graphfiles;
@@ -460,8 +441,7 @@ ch_generate_tiles(char *map_suffix, char *suffix, FILE *tilesdir_out, struct zip
     write_tilesdir(&info, zip_info, tilesdir_out);
 }
 
-void
-ch_assemble_map(char *map_suffix, char *suffix, struct zip_info *zip_info) {
+void ch_assemble_map(char *map_suffix, char *suffix, struct zip_info *zip_info) {
     struct tile_info info;
     struct tile_head *th;
     FILE **graphfiles=g_alloca(sizeof(FILE*)*(ch_levels+1));

--- a/navit/maptool/coastline.c
+++ b/navit/maptool/coastline.c
@@ -40,8 +40,8 @@ static int distance_from_ll(struct coord *c, struct rect *bbox) {
     return -1;
 }
 
-static struct geom_poly_segment *
-find_next(struct rect *bbox, GList *segments, struct coord *c, int exclude, struct coord *ci) {
+static struct geom_poly_segment *find_next(struct rect *bbox, GList *segments, struct coord *c, int exclude,
+        struct coord *ci) {
     int min=INT_MAX,search=distance_from_ll(c, bbox)+(exclude?1:0);
     GList *curr;
     int i;
@@ -69,8 +69,8 @@ find_next(struct rect *bbox, GList *segments, struct coord *c, int exclude, stru
     return ret;
 }
 
-static void
-close_polygon(struct item_bin *ib, struct coord *from, struct coord *to, int dir, struct rect *bbox, int *edges) {
+static void close_polygon(struct item_bin *ib, struct coord *from, struct coord *to, int dir, struct rect *bbox,
+                          int *edges) {
     int i,e,dist,fromdist,todist;
     int full=(bbox->h.x-bbox->l.x+bbox->h.y-bbox->l.y)*2;
     int corners=0,first_corner=0;
@@ -131,8 +131,7 @@ struct coastline_tile_data {
     GList *k,*v;
 };
 
-static GList *
-tile_data_to_segments(int *tile_data) {
+static GList *tile_data_to_segments(int *tile_data) {
     int *end=tile_data+tile_data[0];
     int *curr=tile_data+1;
     GList *segments=NULL;
@@ -147,8 +146,7 @@ tile_data_to_segments(int *tile_data) {
     return segments;
 }
 
-static void
-tile_collector_process_tile(char *tile, int *tile_data, struct coastline_tile_data *data) {
+static void tile_collector_process_tile(char *tile, int *tile_data, struct coastline_tile_data *data) {
     int poly_start_valid,tile_start_valid,exclude,search=0;
     struct rect bbox;
     struct coord cn[2],end,poly_start,tile_start;
@@ -260,8 +258,7 @@ tile_collector_process_tile(char *tile, int *tile_data, struct coastline_tile_da
     g_hash_table_insert(data->tile_edges, g_strdup(tile), ct);
 }
 
-static void
-ocean_tile(GHashTable *hash, char *tile, char c, osmid wayid, struct item_bin_sink *out) {
+static void ocean_tile(GHashTable *hash, char *tile, char c, osmid wayid, struct item_bin_sink *out) {
     int len=strlen(tile);
     char *tile2=g_alloca(sizeof(char)*(len+1));
     struct rect bbox;
@@ -289,8 +286,7 @@ ocean_tile(GHashTable *hash, char *tile, char c, osmid wayid, struct item_bin_si
 /* ba */
 /* dc */
 
-static void
-tile_collector_add_siblings(char *tile, struct coastline_tile *ct, struct coastline_tile_data *data) {
+static void tile_collector_add_siblings(char *tile, struct coastline_tile *ct, struct coastline_tile_data *data) {
     int len=strlen(tile);
     char t=tile[len-1];
     struct item_bin_sink *out=data->sink->priv_data[1];
@@ -316,8 +312,7 @@ tile_collector_add_siblings(char *tile, struct coastline_tile *ct, struct coastl
         ocean_tile(data->tile_edges, tile, 'b', ct->wayid, out);
 }
 
-static int
-tile_sibling_edges(GHashTable *hash, char *tile, char c) {
+static int tile_sibling_edges(GHashTable *hash, char *tile, char c) {
     int len=strlen(tile);
     char *tile2=g_alloca(sizeof(char)*(len+1));
     struct coastline_tile *ct;
@@ -330,8 +325,7 @@ tile_sibling_edges(GHashTable *hash, char *tile, char c) {
 }
 
 #if 0
-static void
-ocean_tile2(struct rect *r, int dx, int dy, int wf, int hf, struct item_bin_sink *out) {
+static void ocean_tile2(struct rect *r, int dx, int dy, int wf, int hf, struct item_bin_sink *out) {
     struct item_bin *ib;
     int w=r->h.x-r->l.x;
     int h=r->h.y-r->l.y;
@@ -363,8 +357,7 @@ ocean_tile2(struct rect *r, int dx, int dy, int wf, int hf, struct item_bin_sink
 }
 #endif
 
-static void
-tile_collector_add_siblings2(char *tile, struct coastline_tile *ct, struct coastline_tile_data *data) {
+static void tile_collector_add_siblings2(char *tile, struct coastline_tile *ct, struct coastline_tile_data *data) {
     int edges=ct->edges;
     int pedges=0;
     int debug=0;
@@ -409,8 +402,7 @@ tile_collector_add_siblings2(char *tile, struct coastline_tile *ct, struct coast
     g_hash_table_insert(data->tile_edges, g_strdup(tile2), cn);
 }
 
-static void
-foreach_tile_func(gpointer key, gpointer value, gpointer user_data) {
+static void foreach_tile_func(gpointer key, gpointer value, gpointer user_data) {
     struct coastline_tile_data *data=user_data;
     if (strlen((char *)key) == data->level) {
         data->k=g_list_prepend(data->k, key);
@@ -418,9 +410,8 @@ foreach_tile_func(gpointer key, gpointer value, gpointer user_data) {
     }
 }
 
-static void
-foreach_tile(struct coastline_tile_data *data, void(*func)(char *, struct coastline_tile *,
-             struct coastline_tile_data *)) {
+static void foreach_tile(struct coastline_tile_data *data, void(*func)(char *, struct coastline_tile *,
+                         struct coastline_tile_data *)) {
     GList *k,*v;
     data->k=NULL;
     data->v=NULL;
@@ -437,8 +428,7 @@ foreach_tile(struct coastline_tile_data *data, void(*func)(char *, struct coastl
     g_list_free(data->v);
 }
 
-static int
-tile_collector_finish(struct item_bin_sink_func *tile_collector) {
+static int tile_collector_finish(struct item_bin_sink_func *tile_collector) {
     struct coastline_tile_data data;
     int i;
     GHashTable *hash;
@@ -478,14 +468,13 @@ tile_collector_finish(struct item_bin_sink_func *tile_collector) {
 }
 
 
-static int
-coastline_processor_process(struct item_bin_sink_func *func, struct item_bin *ib, struct tile_data *tile_data) {
+static int coastline_processor_process(struct item_bin_sink_func *func, struct item_bin *ib,
+                                       struct tile_data *tile_data) {
     item_bin_write_clipped(ib, func->priv_data[0], func->priv_data[1]);
     return 0;
 }
 
-static struct item_bin_sink_func *
-coastline_processor_new(struct item_bin_sink *out) {
+static struct item_bin_sink_func *coastline_processor_new(struct item_bin_sink *out) {
     struct item_bin_sink_func *coastline_processor=item_bin_sink_func_new(coastline_processor_process);
     struct item_bin_sink *tiles=item_bin_sink_new();
     struct item_bin_sink_func *tile_collector=tile_collector_new(out);
@@ -503,8 +492,7 @@ coastline_processor_new(struct item_bin_sink *out) {
     return coastline_processor;
 }
 
-static void
-coastline_processor_finish(struct item_bin_sink_func *coastline_processor) {
+static void coastline_processor_finish(struct item_bin_sink_func *coastline_processor) {
     struct tile_parameter *param=coastline_processor->priv_data[0];
     struct item_bin_sink *tiles=coastline_processor->priv_data[1];
     struct item_bin_sink_func *tile_collector=coastline_processor->priv_data[2];
@@ -514,8 +502,7 @@ coastline_processor_finish(struct item_bin_sink_func *coastline_processor) {
     item_bin_sink_func_destroy(coastline_processor);
 }
 
-void
-process_coastlines(FILE *in, FILE *out) {
+void process_coastlines(FILE *in, FILE *out) {
     struct item_bin_sink *reader=file_reader_new(in,-1,0);
     struct item_bin_sink_func *file_writer=file_writer_new(out);
     struct item_bin_sink *result=item_bin_sink_new();

--- a/navit/maptool/google/protobuf-c/protobuf-c.c
+++ b/navit/maptool/google/protobuf-c/protobuf-c.c
@@ -58,8 +58,7 @@
 #define TRUE 1
 #define FALSE 0
 
-static void
-alloc_failed_warning (unsigned size, const char *filename, unsigned line) {
+static void alloc_failed_warning (unsigned size, const char *filename, unsigned line) {
     fprintf (stderr,
              "WARNING: out-of-memory allocating a block of size %u (%s:%u)\n",
              size, filename, line);
@@ -138,10 +137,9 @@ ProtobufCAllocator protobuf_c_system_allocator = {
 };
 
 /* === buffer-simple === */
-void
-protobuf_c_buffer_simple_append (ProtobufCBuffer *buffer,
-                                 size_t           len,
-                                 const uint8_t   *data) {
+void protobuf_c_buffer_simple_append (ProtobufCBuffer *buffer,
+                                      size_t           len,
+                                      const uint8_t   *data) {
     ProtobufCBufferSimple *simp = (ProtobufCBufferSimple *) buffer;
     size_t new_len = simp->len + len;
     if (new_len > simp->alloced) {
@@ -167,8 +165,7 @@ protobuf_c_buffer_simple_append (ProtobufCBuffer *buffer,
 /* Return the number of bytes required to store the
    tag for the field (which includes 3 bits for
    the wire-type, and a single bit that denotes the end-of-tag. */
-static inline size_t
-get_tag_size (unsigned number) {
+static inline size_t get_tag_size (unsigned number) {
     if (number < (1<<4))
         return 1;
     else if (number < (1<<11))
@@ -184,8 +181,7 @@ get_tag_size (unsigned number) {
 /* Return the number of bytes required to store
    a variable-length unsigned integer that fits in 32-bit uint
    in base-128 encoding. */
-static inline size_t
-uint32_size (uint32_t v) {
+static inline size_t uint32_size (uint32_t v) {
     if (v < (1<<7))
         return 1;
     else if (v < (1<<14))
@@ -200,8 +196,7 @@ uint32_size (uint32_t v) {
 /* Return the number of bytes required to store
    a variable-length signed integer that fits in 32-bit int
    in base-128 encoding. */
-static inline size_t
-int32_size (int32_t v) {
+static inline size_t int32_size (int32_t v) {
     if (v < 0)
         return 10;
     else if (v < (1<<7))
@@ -216,8 +211,7 @@ int32_size (int32_t v) {
         return 5;
 }
 /* return the zigzag-encoded 32-bit unsigned int from a 32-bit signed int */
-static inline uint32_t
-zigzag32 (int32_t v) {
+static inline uint32_t zigzag32 (int32_t v) {
     if (v < 0)
         return ((uint32_t)(-v)) * 2 - 1;
     else
@@ -227,16 +221,14 @@ zigzag32 (int32_t v) {
    a variable-length signed integer that fits in 32-bit int,
    converted to unsigned via the zig-zag algorithm,
    then packed using base-128 encoding. */
-static inline size_t
-sint32_size (int32_t v) {
+static inline size_t sint32_size (int32_t v) {
     return uint32_size(zigzag32(v));
 }
 
 /* Return the number of bytes required to store
    a variable-length unsigned integer that fits in 64-bit uint
    in base-128 encoding. */
-static inline size_t
-uint64_size (uint64_t v) {
+static inline size_t uint64_size (uint64_t v) {
     uint32_t upper_v = (v>>32);
     if (upper_v == 0)
         return uint32_size ((uint32_t)v);
@@ -255,8 +247,7 @@ uint64_size (uint64_t v) {
 }
 
 /* return the zigzag-encoded 64-bit unsigned int from a 64-bit signed int */
-static inline uint64_t
-zigzag64 (int64_t v) {
+static inline uint64_t zigzag64 (int64_t v) {
     if (v < 0)
         return ((uint64_t)(-v)) * 2 - 1;
     else
@@ -267,16 +258,14 @@ zigzag64 (int64_t v) {
    a variable-length signed integer that fits in 64-bit int,
    converted to unsigned via the zig-zag algorithm,
    then packed using base-128 encoding. */
-static inline size_t
-sint64_size (int64_t v) {
+static inline size_t sint64_size (int64_t v) {
     return uint64_size(zigzag64(v));
 }
 
 /* Get serialized size of a single field in the message,
    including the space needed by the identifying tag. */
-static size_t
-required_field_get_packed_size (const ProtobufCFieldDescriptor *field,
-                                const void *member) {
+static size_t required_field_get_packed_size (const ProtobufCFieldDescriptor *field,
+        const void *member) {
     size_t rv = get_tag_size (field->id);
     switch (field->type) {
     case PROTOBUF_C_TYPE_SINT32:
@@ -328,10 +317,9 @@ required_field_get_packed_size (const ProtobufCFieldDescriptor *field,
 /* Get serialized size of a single optional field in the message,
    including the space needed by the identifying tag.
    Returns 0 if the optional field isn't set. */
-static size_t
-optional_field_get_packed_size (const ProtobufCFieldDescriptor *field,
-                                const protobuf_c_boolean *has,
-                                const void *member) {
+static size_t optional_field_get_packed_size (const ProtobufCFieldDescriptor *field,
+        const protobuf_c_boolean *has,
+        const void *member) {
     if (field->type == PROTOBUF_C_TYPE_MESSAGE
             || field->type == PROTOBUF_C_TYPE_STRING) {
         const void *ptr = * (const void * const *) member;
@@ -348,10 +336,9 @@ optional_field_get_packed_size (const ProtobufCFieldDescriptor *field,
 /* Get serialized size of a repeated field in the message,
    which may consist of any number of values (including 0).
    Includes the space needed by the identifying tags (as needed). */
-static size_t
-repeated_field_get_packed_size (const ProtobufCFieldDescriptor *field,
-                                size_t count,
-                                const void *member) {
+static size_t repeated_field_get_packed_size (const ProtobufCFieldDescriptor *field,
+        size_t count,
+        const void *member) {
     size_t header_size;
     size_t rv = 0;
     unsigned i;
@@ -426,14 +413,12 @@ repeated_field_get_packed_size (const ProtobufCFieldDescriptor *field,
 /* Get the packed size of a unknown field (meaning one that
    is passed through mostly uninterpreted... this is done
    for forward compatibilty with the addition of new fields). */
-static inline size_t
-unknown_field_get_packed_size (const ProtobufCMessageUnknownField *field) {
+static inline size_t unknown_field_get_packed_size (const ProtobufCMessageUnknownField *field) {
     return get_tag_size (field->tag) + field->len;
 }
 
 /* Get the number of bytes that the message will occupy once serialized. */
-size_t
-protobuf_c_message_get_packed_size(const ProtobufCMessage *message) {
+size_t protobuf_c_message_get_packed_size(const ProtobufCMessage *message) {
     unsigned i;
     size_t rv = 0;
     ASSERT_IS_MESSAGE (message);
@@ -456,8 +441,7 @@ protobuf_c_message_get_packed_size(const ProtobufCMessage *message) {
 /* === pack() === */
 /* Pack an unsigned 32-bit integer in base-128 encoding, and return the number of bytes needed:
    this will be 5 or less. */
-static inline size_t
-uint32_pack (uint32_t value, uint8_t *out) {
+static inline size_t uint32_pack (uint32_t value, uint8_t *out) {
     unsigned rv = 0;
     if (value >= 0x80) {
         out[rv++] = value | 0x80;
@@ -482,8 +466,7 @@ uint32_pack (uint32_t value, uint8_t *out) {
 
 /* Pack a 32-bit signed integer, returning the number of bytes needed.
    Negative numbers are packed as twos-complement 64-bit integers. */
-static inline size_t
-int32_pack (int32_t value, uint8_t *out) {
+static inline size_t int32_pack (int32_t value, uint8_t *out) {
     if (value < 0) {
         out[0] = value | 0x80;
         out[1] = (value>>7) | 0x80;
@@ -498,15 +481,13 @@ int32_pack (int32_t value, uint8_t *out) {
 }
 
 /* Pack a 32-bit integer in zigwag encoding. */
-static inline size_t
-sint32_pack (int32_t value, uint8_t *out) {
+static inline size_t sint32_pack (int32_t value, uint8_t *out) {
     return uint32_pack (zigzag32 (value), out);
 }
 
 /* Pack a 64-bit unsigned integer that fits in a 64-bit uint,
    using base-128 encoding. */
-static size_t
-uint64_pack (uint64_t value, uint8_t *out) {
+static size_t uint64_pack (uint64_t value, uint8_t *out) {
     uint32_t hi = value>>32;
     uint32_t lo = value;
     unsigned rv;
@@ -535,15 +516,13 @@ uint64_pack (uint64_t value, uint8_t *out) {
 /* Pack a 64-bit signed integer in zigzan encoding,
    return the size of the packed output.
    (Max returned value is 10) */
-static inline size_t
-sint64_pack (int64_t value, uint8_t *out) {
+static inline size_t sint64_pack (int64_t value, uint8_t *out) {
     return uint64_pack (zigzag64 (value), out);
 }
 
 /* Pack a 32-bit value, little-endian.
    Used for fixed32, sfixed32, float) */
-static inline size_t
-fixed32_pack (uint32_t value, uint8_t *out) {
+static inline size_t fixed32_pack (uint32_t value, uint8_t *out) {
 #ifdef IS_LITTLE_ENDIAN
     memcpy (out, &value, 4);
 #else
@@ -560,8 +539,7 @@ fixed32_pack (uint32_t value, uint8_t *out) {
 /* XXX: the big-endian impl is really only good for 32-bit machines,
    a 64-bit version would be appreciated, plus a way
    to decide to use 64-bit math where convenient. */
-static inline size_t
-fixed64_pack (uint64_t value, uint8_t *out) {
+static inline size_t fixed64_pack (uint64_t value, uint8_t *out) {
 #ifdef IS_LITTLE_ENDIAN
     memcpy (out, &value, 8);
 #else
@@ -576,8 +554,7 @@ fixed64_pack (uint64_t value, uint8_t *out) {
    can really assume any integer value. */
 /* XXX: perhaps on some platforms "*out = !!value" would be
    a better impl, b/c that is idiotmatic c++ in some stl impls. */
-static inline size_t
-boolean_pack (protobuf_c_boolean value, uint8_t *out) {
+static inline size_t boolean_pack (protobuf_c_boolean value, uint8_t *out) {
     *out = value ? 1 : 0;
     return 1;
 }
@@ -591,8 +568,7 @@ boolean_pack (protobuf_c_boolean value, uint8_t *out) {
    (See Issue 13 in the bug tracker for a
    little more explanation).
  */
-static inline size_t
-string_pack (const char * str, uint8_t *out) {
+static inline size_t string_pack (const char * str, uint8_t *out) {
     if (str == NULL) {
         out[0] = 0;
         return 1;
@@ -604,16 +580,14 @@ string_pack (const char * str, uint8_t *out) {
     }
 }
 
-static inline size_t
-binary_data_pack (const ProtobufCBinaryData *bd, uint8_t *out) {
+static inline size_t binary_data_pack (const ProtobufCBinaryData *bd, uint8_t *out) {
     size_t len = bd->len;
     size_t rv = uint32_pack (len, out);
     memcpy (out + rv, bd->data, len);
     return rv + len;
 }
 
-static inline size_t
-prefixed_message_pack (const ProtobufCMessage *message, uint8_t *out) {
+static inline size_t prefixed_message_pack (const ProtobufCMessage *message, uint8_t *out) {
     if (message == NULL) {
         out[0] = 0;
         return 1;
@@ -628,18 +602,16 @@ prefixed_message_pack (const ProtobufCMessage *message, uint8_t *out) {
 
 /* wire-type will be added in required_field_pack() */
 /* XXX: just call uint64_pack on 64-bit platforms. */
-static size_t
-tag_pack (uint32_t id, uint8_t *out) {
+static size_t tag_pack (uint32_t id, uint8_t *out) {
     if (id < (1<<(32-3)))
         return uint32_pack (id<<3, out);
     else
         return uint64_pack (((uint64_t)id) << 3, out);
 }
 
-static size_t
-required_field_pack (const ProtobufCFieldDescriptor *field,
-                     const void *member,
-                     uint8_t *out) {
+static size_t required_field_pack (const ProtobufCFieldDescriptor *field,
+                                   const void *member,
+                                   uint8_t *out) {
     size_t rv = tag_pack (field->id, out);
     switch (field->type) {
     case PROTOBUF_C_TYPE_SINT32:
@@ -692,11 +664,10 @@ required_field_pack (const ProtobufCFieldDescriptor *field,
     PROTOBUF_C_ASSERT_NOT_REACHED ();
     return 0;
 }
-static size_t
-optional_field_pack (const ProtobufCFieldDescriptor *field,
-                     const protobuf_c_boolean *has,
-                     const void *member,
-                     uint8_t *out) {
+static size_t optional_field_pack (const ProtobufCFieldDescriptor *field,
+                                   const protobuf_c_boolean *has,
+                                   const void *member,
+                                   uint8_t *out) {
     if (field->type == PROTOBUF_C_TYPE_MESSAGE
             || field->type == PROTOBUF_C_TYPE_STRING) {
         const void *ptr = * (const void * const *) member;
@@ -711,8 +682,7 @@ optional_field_pack (const ProtobufCFieldDescriptor *field,
 }
 
 /* TODO: implement as a table lookup */
-static inline size_t
-sizeof_elt_in_repeated_array (ProtobufCType type) {
+static inline size_t sizeof_elt_in_repeated_array (ProtobufCType type) {
     switch (type) {
     case PROTOBUF_C_TYPE_SINT32:
     case PROTOBUF_C_TYPE_INT32:
@@ -741,8 +711,7 @@ sizeof_elt_in_repeated_array (ProtobufCType type) {
     return 0;
 }
 
-static void
-copy_to_little_endian_32 (void *out, const void *in, unsigned N) {
+static void copy_to_little_endian_32 (void *out, const void *in, unsigned N) {
 #ifdef IS_LITTLE_ENDIAN
     memcpy (out, in, N * 4);
 #else
@@ -752,8 +721,7 @@ copy_to_little_endian_32 (void *out, const void *in, unsigned N) {
         fixed32_pack (ini[i], (uint8_t*)out + 4*i);
 #endif
 }
-static void
-copy_to_little_endian_64 (void *out, const void *in, unsigned N) {
+static void copy_to_little_endian_64 (void *out, const void *in, unsigned N) {
 #ifdef IS_LITTLE_ENDIAN
     memcpy (out, in, N * 8);
 #else
@@ -764,8 +732,7 @@ copy_to_little_endian_64 (void *out, const void *in, unsigned N) {
 #endif
 }
 
-static unsigned
-get_type_min_size (ProtobufCType type) {
+static unsigned get_type_min_size (ProtobufCType type) {
     if (type == PROTOBUF_C_TYPE_SFIXED32
             || type == PROTOBUF_C_TYPE_FIXED32
             || type == PROTOBUF_C_TYPE_FLOAT)
@@ -777,11 +744,10 @@ get_type_min_size (ProtobufCType type) {
     return 1;
 }
 
-static size_t
-repeated_field_pack (const ProtobufCFieldDescriptor *field,
-                     size_t count,
-                     const void *member,
-                     uint8_t *out) {
+static size_t repeated_field_pack (const ProtobufCFieldDescriptor *field,
+                                   size_t count,
+                                   const void *member,
+                                   uint8_t *out) {
     char *array = * (char * const *) member;
     unsigned i;
     if (field->packed) {
@@ -880,18 +846,16 @@ repeated_field_pack (const ProtobufCFieldDescriptor *field,
         return rv;
     }
 }
-static size_t
-unknown_field_pack (const ProtobufCMessageUnknownField *field,
-                    uint8_t *out) {
+static size_t unknown_field_pack (const ProtobufCMessageUnknownField *field,
+                                  uint8_t *out) {
     size_t rv = tag_pack (field->tag, out);
     out[0] |= field->wire_type;
     memcpy (out + rv, field->data, field->len);
     return rv + field->len;
 }
 
-size_t
-protobuf_c_message_pack           (const ProtobufCMessage *message,
-                                   uint8_t                *out) {
+size_t protobuf_c_message_pack           (const ProtobufCMessage *message,
+        uint8_t                *out) {
     unsigned i;
     size_t rv = 0;
     ASSERT_IS_MESSAGE (message);
@@ -922,10 +886,9 @@ protobuf_c_message_pack           (const ProtobufCMessage *message,
 }
 
 /* === pack_to_buffer() === */
-static size_t
-required_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
-                               const void *member,
-                               ProtobufCBuffer *buffer) {
+static size_t required_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
+        const void *member,
+        ProtobufCBuffer *buffer) {
     size_t rv;
     uint8_t scratch[MAX_UINT64_ENCODED_SIZE * 2];
     rv = tag_pack (field->id, scratch);
@@ -1021,11 +984,10 @@ required_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
     }
     return rv;
 }
-static size_t
-optional_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
-                               const protobuf_c_boolean *has,
-                               const void *member,
-                               ProtobufCBuffer *buffer) {
+static size_t optional_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
+        const protobuf_c_boolean *has,
+        const void *member,
+        ProtobufCBuffer *buffer) {
     if (field->type == PROTOBUF_C_TYPE_MESSAGE
             || field->type == PROTOBUF_C_TYPE_STRING) {
         const void *ptr = * (const void * const *) member;
@@ -1039,10 +1001,9 @@ optional_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
     return required_field_pack_to_buffer (field, member, buffer);
 }
 
-static size_t
-get_packed_payload_length (const ProtobufCFieldDescriptor *field,
-                           unsigned count,
-                           const void *array) {
+static size_t get_packed_payload_length (const ProtobufCFieldDescriptor *field,
+        unsigned count,
+        const void *array) {
     unsigned rv = 0;
     unsigned i;
     switch (field->type) {
@@ -1097,11 +1058,10 @@ get_packed_payload_length (const ProtobufCFieldDescriptor *field,
     }
     return rv;
 }
-static size_t
-pack_buffer_packed_payload (const ProtobufCFieldDescriptor *field,
-                            unsigned count,
-                            const void *array,
-                            ProtobufCBuffer *buffer) {
+static size_t pack_buffer_packed_payload (const ProtobufCFieldDescriptor *field,
+        unsigned count,
+        const void *array,
+        ProtobufCBuffer *buffer) {
     uint8_t scratch[16];
     size_t rv = 0;
     unsigned i;
@@ -1192,11 +1152,10 @@ no_packing_needed:
 #endif
 }
 
-static size_t
-repeated_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
-                               unsigned count,
-                               const void *member,
-                               ProtobufCBuffer *buffer) {
+static size_t repeated_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
+        unsigned count,
+        const void *member,
+        ProtobufCBuffer *buffer) {
     char *array = * (char * const *) member;
     if (count == 0)
         return 0;
@@ -1228,9 +1187,8 @@ repeated_field_pack_to_buffer (const ProtobufCFieldDescriptor *field,
     }
 }
 
-static size_t
-unknown_field_pack_to_buffer (const ProtobufCMessageUnknownField *field,
-                              ProtobufCBuffer *buffer) {
+static size_t unknown_field_pack_to_buffer (const ProtobufCMessageUnknownField *field,
+        ProtobufCBuffer *buffer) {
     uint8_t header[MAX_UINT64_ENCODED_SIZE];
     size_t rv = tag_pack (field->tag, header);
     header[0] |= field->wire_type;
@@ -1239,9 +1197,8 @@ unknown_field_pack_to_buffer (const ProtobufCMessageUnknownField *field,
     return rv + field->len;
 }
 
-size_t
-protobuf_c_message_pack_to_buffer (const ProtobufCMessage *message,
-                                   ProtobufCBuffer  *buffer) {
+size_t protobuf_c_message_pack_to_buffer (const ProtobufCMessage *message,
+        ProtobufCBuffer  *buffer) {
     unsigned i;
     size_t rv = 0;
     ASSERT_IS_MESSAGE (message);
@@ -1270,10 +1227,9 @@ protobuf_c_message_pack_to_buffer (const ProtobufCMessage *message,
 # define UNPACK_ERROR(args)  do { } while (0)
 #endif
 
-static inline int
-int_range_lookup (unsigned n_ranges,
-                  const ProtobufCIntRange *ranges,
-                  int value) {
+static inline int int_range_lookup (unsigned n_ranges,
+                                    const ProtobufCIntRange *ranges,
+                                    int value) {
     unsigned start, n;
     if (n_ranges == 0)
         return -1;
@@ -1301,11 +1257,10 @@ int_range_lookup (unsigned n_ranges,
     return -1;
 }
 
-static size_t
-parse_tag_and_wiretype (size_t len,
-                        const uint8_t *data,
-                        uint32_t *tag_out,
-                        ProtobufCWireType *wiretype_out) {
+static size_t parse_tag_and_wiretype (size_t len,
+                                      const uint8_t *data,
+                                      uint32_t *tag_out,
+                                      ProtobufCWireType *wiretype_out) {
     unsigned max_rv = len > 5 ? 5 : len;
     uint32_t tag = (data[0]&0x7f) >> 3;
     unsigned shift = 4;
@@ -1339,8 +1294,7 @@ struct _ScannedMember {
     const uint8_t *data;
 };
 
-static inline uint32_t
-scan_length_prefixed_data (size_t len, const uint8_t *data, size_t *prefix_len_out) {
+static inline uint32_t scan_length_prefixed_data (size_t len, const uint8_t *data, size_t *prefix_len_out) {
     unsigned hdr_max = len < 5 ? len : 5;
     unsigned hdr_len;
     uint32_t val = 0;
@@ -1366,8 +1320,7 @@ scan_length_prefixed_data (size_t len, const uint8_t *data, size_t *prefix_len_o
     return hdr_len + val;
 }
 
-static size_t
-max_b128_numbers (size_t len, const uint8_t *data) {
+static size_t max_b128_numbers (size_t len, const uint8_t *data) {
     size_t rv = 0;
     while (len--)
         if ((*data++ & 0x80) == 0)
@@ -1381,11 +1334,10 @@ max_b128_numbers (size_t len, const uint8_t *data) {
    This function detects certain kinds of errors
    but not others; the remaining error checking is done by
    parse_packed_repeated_member() */
-static protobuf_c_boolean
-count_packed_elements (ProtobufCType type,
-                       size_t len,
-                       const uint8_t *data,
-                       size_t *count_out) {
+static protobuf_c_boolean count_packed_elements (ProtobufCType type,
+        size_t len,
+        const uint8_t *data,
+        size_t *count_out) {
     switch (type) {
     case PROTOBUF_C_TYPE_SFIXED32:
     case PROTOBUF_C_TYPE_FIXED32:
@@ -1429,8 +1381,7 @@ count_packed_elements (ProtobufCType type,
     }
 }
 
-static inline uint32_t
-parse_uint32 (unsigned len, const uint8_t *data) {
+static inline uint32_t parse_uint32 (unsigned len, const uint8_t *data) {
     unsigned rv = data[0] & 0x7f;
     if (len > 1) {
         rv |= ((data[1] & 0x7f) << 7);
@@ -1445,19 +1396,16 @@ parse_uint32 (unsigned len, const uint8_t *data) {
     }
     return rv;
 }
-static inline uint32_t
-parse_int32 (unsigned len, const uint8_t *data) {
+static inline uint32_t parse_int32 (unsigned len, const uint8_t *data) {
     return parse_uint32 (len, data);
 }
-static inline int32_t
-unzigzag32 (uint32_t v) {
+static inline int32_t unzigzag32 (uint32_t v) {
     if (v&1)
         return -(v>>1) - 1;
     else
         return v>>1;
 }
-static inline uint32_t
-parse_fixed_uint32 (const uint8_t *data) {
+static inline uint32_t parse_fixed_uint32 (const uint8_t *data) {
 #ifdef IS_LITTLE_ENDIAN
     uint32_t t;
     memcpy (&t, data, 4);
@@ -1466,8 +1414,7 @@ parse_fixed_uint32 (const uint8_t *data) {
     return data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
 #endif
 }
-static uint64_t
-parse_uint64 (unsigned len, const uint8_t *data) {
+static uint64_t parse_uint64 (unsigned len, const uint8_t *data) {
     unsigned shift, i;
     if (len < 5)
         return parse_uint32 (len, data);
@@ -1482,15 +1429,13 @@ parse_uint64 (unsigned len, const uint8_t *data) {
     }
     return rv;
 }
-static inline int64_t
-unzigzag64 (uint64_t v) {
+static inline int64_t unzigzag64 (uint64_t v) {
     if (v&1)
         return -(v>>1) - 1;
     else
         return v>>1;
 }
-static inline uint64_t
-parse_fixed_uint64 (const uint8_t *data) {
+static inline uint64_t parse_fixed_uint64 (const uint8_t *data) {
 #ifdef IS_LITTLE_ENDIAN
     uint64_t t;
     memcpy (&t, data, 8);
@@ -1500,19 +1445,17 @@ parse_fixed_uint64 (const uint8_t *data) {
            | (((uint64_t)parse_fixed_uint32(data+4)) << 32);
 #endif
 }
-static protobuf_c_boolean
-parse_boolean (unsigned len, const uint8_t *data) {
+static protobuf_c_boolean parse_boolean (unsigned len, const uint8_t *data) {
     unsigned i;
     for (i = 0; i < len; i++)
         if (data[i] & 0x7f)
             return 1;
     return 0;
 }
-static protobuf_c_boolean
-parse_required_member (ScannedMember *scanned_member,
-                       void *member,
-                       ProtobufCAllocator *allocator,
-                       protobuf_c_boolean maybe_clear) {
+static protobuf_c_boolean parse_required_member (ScannedMember *scanned_member,
+        void *member,
+        ProtobufCAllocator *allocator,
+        protobuf_c_boolean maybe_clear) {
     unsigned len = scanned_member->len;
     const uint8_t *data = scanned_member->data;
     ProtobufCWireType wire_type = scanned_member->wire_type;
@@ -1624,11 +1567,10 @@ parse_required_member (ScannedMember *scanned_member,
     return 0;
 }
 
-static protobuf_c_boolean
-parse_optional_member (ScannedMember *scanned_member,
-                       void *member,
-                       ProtobufCMessage *message,
-                       ProtobufCAllocator *allocator) {
+static protobuf_c_boolean parse_optional_member (ScannedMember *scanned_member,
+        void *member,
+        ProtobufCMessage *message,
+        ProtobufCAllocator *allocator) {
     if (!parse_required_member (scanned_member, member, allocator, TRUE))
         return 0;
     if (scanned_member->field->quantifier_offset != 0)
@@ -1638,11 +1580,10 @@ parse_optional_member (ScannedMember *scanned_member,
     return 1;
 }
 
-static protobuf_c_boolean
-parse_repeated_member (ScannedMember *scanned_member,
-                       void *member,
-                       ProtobufCMessage *message,
-                       ProtobufCAllocator *allocator) {
+static protobuf_c_boolean parse_repeated_member (ScannedMember *scanned_member,
+        void *member,
+        ProtobufCMessage *message,
+        ProtobufCAllocator *allocator) {
     const ProtobufCFieldDescriptor *field = scanned_member->field;
     size_t *p_n = STRUCT_MEMBER_PTR(size_t, message, field->quantifier_offset);
     size_t siz = sizeof_elt_in_repeated_array (field->type);
@@ -1668,10 +1609,9 @@ static unsigned scan_varint (unsigned len, const uint8_t *data) {
     return i + 1;
 }
 
-static protobuf_c_boolean
-parse_packed_repeated_member (ScannedMember *scanned_member,
-                              void *member,
-                              ProtobufCMessage *message) {
+static protobuf_c_boolean parse_packed_repeated_member (ScannedMember *scanned_member,
+        void *member,
+        ProtobufCMessage *message) {
     const ProtobufCFieldDescriptor *field = scanned_member->field;
     size_t *p_n = STRUCT_MEMBER_PTR(size_t, message, field->quantifier_offset);
     size_t siz = sizeof_elt_in_repeated_array (field->type);
@@ -1795,10 +1735,9 @@ no_unpacking_needed:
 #endif
 }
 
-static protobuf_c_boolean
-parse_member (ScannedMember *scanned_member,
-              ProtobufCMessage *message,
-              ProtobufCAllocator *allocator) {
+static protobuf_c_boolean parse_member (ScannedMember *scanned_member,
+                                        ProtobufCMessage *message,
+                                        ProtobufCAllocator *allocator) {
     const ProtobufCFieldDescriptor *field = scanned_member->field;
     void *member;
     if (field == NULL) {
@@ -1831,9 +1770,8 @@ parse_member (ScannedMember *scanned_member,
 /* TODO: expose/use this function if desc->message_init==NULL
    (which occurs for old code, and may be useful for certain
    programatic techniques for generating descriptors). */
-static void
-protobuf_c_message_init_generic (const ProtobufCMessageDescriptor *desc,
-                                 ProtobufCMessage *message) {
+static void protobuf_c_message_init_generic (const ProtobufCMessageDescriptor *desc,
+        ProtobufCMessage *message) {
     unsigned i;
     memset (message, 0, desc->sizeof_message);
     message->descriptor = desc;
@@ -1900,11 +1838,10 @@ protobuf_c_message_init_generic (const ProtobufCMessageDescriptor *desc,
    - BOUND_SIZEOF_SCANNED_MEMBER_LOG2                    \
    - FIRST_SCANNED_MEMBER_SLAB_SIZE_LOG2)
 
-ProtobufCMessage *
-protobuf_c_message_unpack         (const ProtobufCMessageDescriptor *desc,
-                                   ProtobufCAllocator  *allocator,
-                                   size_t               len,
-                                   const uint8_t       *data) {
+ProtobufCMessage *protobuf_c_message_unpack         (const ProtobufCMessageDescriptor *desc,
+        ProtobufCAllocator  *allocator,
+        size_t               len,
+        const uint8_t       *data) {
     ProtobufCMessage *rv;
     size_t rem = len;
     const uint8_t *at = data;
@@ -2149,9 +2086,8 @@ error_cleanup_during_scan:
 }
 
 /* === free_unpacked === */
-void
-protobuf_c_message_free_unpacked  (ProtobufCMessage    *message,
-                                   ProtobufCAllocator  *allocator) {
+void protobuf_c_message_free_unpacked  (ProtobufCMessage    *message,
+                                        ProtobufCAllocator  *allocator) {
     const ProtobufCMessageDescriptor *desc = message->descriptor;
     unsigned f;
     ASSERT_IS_MESSAGE (message);
@@ -2209,12 +2145,11 @@ typedef void (*GenericHandler)(void *service,
                                const ProtobufCMessage *input,
                                ProtobufCClosure  closure,
                                void             *closure_data);
-void
-protobuf_c_service_invoke_internal(ProtobufCService *service,
-                                   unsigned          method_index,
-                                   const ProtobufCMessage *input,
-                                   ProtobufCClosure  closure,
-                                   void             *closure_data) {
+void protobuf_c_service_invoke_internal(ProtobufCService *service,
+                                        unsigned          method_index,
+                                        const ProtobufCMessage *input,
+                                        ProtobufCClosure  closure,
+                                        void             *closure_data) {
     GenericHandler *handlers;
     GenericHandler handler;
 
@@ -2235,10 +2170,9 @@ protobuf_c_service_invoke_internal(ProtobufCService *service,
     (*handler) (service, input, closure, closure_data);
 }
 
-void
-protobuf_c_service_generated_init (ProtobufCService *service,
-                                   const ProtobufCServiceDescriptor *descriptor,
-                                   ProtobufCServiceDestroy destroy) {
+void protobuf_c_service_generated_init (ProtobufCService *service,
+                                        const ProtobufCServiceDescriptor *descriptor,
+                                        ProtobufCServiceDestroy destroy) {
     ASSERT_IS_SERVICE_DESCRIPTOR(descriptor);
     service->descriptor = descriptor;
     service->destroy = destroy;

--- a/navit/maptool/itembin.c
+++ b/navit/maptool/itembin.c
@@ -27,8 +27,7 @@
 
 
 
-int
-item_bin_read(struct item_bin *ib, FILE *in) {
+int item_bin_read(struct item_bin *ib, FILE *in) {
     if (fread(ib, 4, 1, in) == 0)
         return 0;
     if (!ib->len)
@@ -38,21 +37,18 @@ item_bin_read(struct item_bin *ib, FILE *in) {
     return 0;
 }
 
-void
-item_bin_set_type(struct item_bin *ib, enum item_type type) {
+void item_bin_set_type(struct item_bin *ib, enum item_type type) {
     ib->type=type;
 }
 
-void
-item_bin_init(struct item_bin *ib, enum item_type type) {
+void item_bin_init(struct item_bin *ib, enum item_type type) {
     ib->clen=0;
     ib->len=2;
     item_bin_set_type(ib, type);
 }
 
 
-void
-item_bin_add_coord(struct item_bin *ib, struct coord *coords_to_add, int count) {
+void item_bin_add_coord(struct item_bin *ib, struct coord *coords_to_add, int count) {
     struct coord *coord_list=(struct coord *)(ib+1);
     coord_list+=ib->clen/2;
     memcpy(coord_list, coords_to_add, count*sizeof(struct coord));
@@ -60,15 +56,13 @@ item_bin_add_coord(struct item_bin *ib, struct coord *coords_to_add, int count) 
     ib->len+=count*2;
 }
 
-void
-item_bin_add_coord_reverse(struct item_bin *ib, struct coord *c, int count) {
+void item_bin_add_coord_reverse(struct item_bin *ib, struct coord *c, int count) {
     int i;
     for (i = count-1 ; i >= 0 ; i--)
         item_bin_add_coord(ib, &c[i], 1);
 }
 
-void
-item_bin_bbox(struct item_bin *ib, struct rect *r) {
+void item_bin_bbox(struct item_bin *ib, struct rect *r) {
     struct coord c;
     item_bin_add_coord(ib, &r->l, 1);
     c.x=r->h.x;
@@ -81,8 +75,7 @@ item_bin_bbox(struct item_bin *ib, struct rect *r) {
     item_bin_add_coord(ib, &r->l, 1);
 }
 
-void
-item_bin_copy_coord(struct item_bin *ib, struct item_bin *from, int dir) {
+void item_bin_copy_coord(struct item_bin *ib, struct item_bin *from, int dir) {
     struct coord *c=(struct coord *)(from+1);
     int i,count=from->clen/2;
     if (dir >= 0) {
@@ -93,8 +86,7 @@ item_bin_copy_coord(struct item_bin *ib, struct item_bin *from, int dir) {
         item_bin_add_coord(ib, &c[count-i], 1);
 }
 
-void
-item_bin_copy_attr(struct item_bin *ib, struct item_bin *from, enum attr_type attr) {
+void item_bin_copy_attr(struct item_bin *ib, struct item_bin *from, enum attr_type attr) {
     struct attr_bin *ab=item_bin_get_attr_bin(from, attr, NULL);
     if (ab)
         item_bin_add_attr_data(ib, ab->type, (void *)(ab+1), (ab->len-1)*4);
@@ -102,14 +94,12 @@ item_bin_copy_attr(struct item_bin *ib, struct item_bin *from, enum attr_type at
     assert(item_bin_get_wayid(ib) == item_bin_get_wayid(from));
 }
 
-void
-item_bin_add_coord_rect(struct item_bin *ib, struct rect *r) {
+void item_bin_add_coord_rect(struct item_bin *ib, struct rect *r) {
     item_bin_add_coord(ib, &r->l, 1);
     item_bin_add_coord(ib, &r->h, 1);
 }
 
-int
-attr_bin_write_data(struct attr_bin *ab, enum attr_type type, void *data, int size) {
+int attr_bin_write_data(struct attr_bin *ab, enum attr_type type, void *data, int size) {
     int pad=(4-(size%4))%4;
     ab->type=type;
     memcpy(ab+1, data, size);
@@ -118,19 +108,16 @@ attr_bin_write_data(struct attr_bin *ab, enum attr_type type, void *data, int si
     return ab->len+1;
 }
 
-int
-attr_bin_write_attr(struct attr_bin *ab, struct attr *attr) {
+int attr_bin_write_attr(struct attr_bin *ab, struct attr *attr) {
     return attr_bin_write_data(ab, attr->type, attr_data_get(attr), attr_data_size(attr));
 }
 
-void
-item_bin_add_attr_data(struct item_bin *ib, enum attr_type type, void *data, int size) {
+void item_bin_add_attr_data(struct item_bin *ib, enum attr_type type, void *data, int size) {
     struct attr_bin *ab=(struct attr_bin *)((int *)ib+ib->len+1);
     ib->len+=attr_bin_write_data(ab, type, data, size);
 }
 
-void
-item_bin_add_attr(struct item_bin *ib, struct attr *attr) {
+void item_bin_add_attr(struct item_bin *ib, struct attr *attr) {
     struct attr_bin *ab=(struct attr_bin *)((int *)ib+ib->len+1);
     if (ATTR_IS_GROUP(attr->type)) {
         int i=0;
@@ -151,8 +138,7 @@ item_bin_add_attr(struct item_bin *ib, struct attr *attr) {
 
 }
 
-void
-item_bin_remove_attr(struct item_bin *ib, void *ptr) {
+void item_bin_remove_attr(struct item_bin *ib, void *ptr) {
     unsigned char *s=(unsigned char *)ib;
     unsigned char *e=s+(ib->len+1)*4;
     s+=sizeof(struct item_bin)+ib->clen*4;
@@ -167,16 +153,14 @@ item_bin_remove_attr(struct item_bin *ib, void *ptr) {
     }
 }
 
-void
-item_bin_add_attr_int(struct item_bin *ib, enum attr_type type, int val) {
+void item_bin_add_attr_int(struct item_bin *ib, enum attr_type type, int val) {
     struct attr attr;
     attr.type=type;
     attr.u.num=val;
     item_bin_add_attr(ib, &attr);
 }
 
-void *
-item_bin_get_attr(struct item_bin *ib, enum attr_type type, void *last) {
+void *item_bin_get_attr(struct item_bin *ib, enum attr_type type, void *last) {
     unsigned char *s=(unsigned char *)ib;
     unsigned char *e=s+(ib->len+1)*4;
     s+=sizeof(struct item_bin)+ib->clen*4;
@@ -218,16 +202,14 @@ item_bin_get_attr_bin_last(struct item_bin *ib) {
     return ab;
 }
 
-void
-item_bin_add_attr_longlong(struct item_bin *ib, enum attr_type type, long long val) {
+void item_bin_add_attr_longlong(struct item_bin *ib, enum attr_type type, long long val) {
     struct attr attr;
     attr.type=type;
     attr.u.num64=&val;
     item_bin_add_attr(ib, &attr);
 }
 
-void
-item_bin_add_attr_string(struct item_bin *ib, enum attr_type type, char *str) {
+void item_bin_add_attr_string(struct item_bin *ib, enum attr_type type, char *str) {
     struct attr attr;
     if (! str)
         return;
@@ -236,8 +218,7 @@ item_bin_add_attr_string(struct item_bin *ib, enum attr_type type, char *str) {
     item_bin_add_attr(ib, &attr);
 }
 
-void
-item_bin_add_attr_range(struct item_bin *ib, enum attr_type type, short min, short max) {
+void item_bin_add_attr_range(struct item_bin *ib, enum attr_type type, short min, short max) {
     struct attr attr;
     attr.type=type;
     attr.u.range.min=min;
@@ -245,8 +226,7 @@ item_bin_add_attr_range(struct item_bin *ib, enum attr_type type, short min, sho
     item_bin_add_attr(ib, &attr);
 }
 
-void
-item_bin_write(struct item_bin *ib, FILE *out) {
+void item_bin_write(struct item_bin *ib, FILE *out) {
     dbg_assert(fwrite(ib, (ib->len+1)*4, 1, out)==1);
 }
 
@@ -259,8 +239,7 @@ item_bin_dup(struct item_bin *ib) {
     return ret;
 }
 
-void
-item_bin_write_clipped(struct item_bin *ib, struct tile_parameter *param, struct item_bin_sink *out) {
+void item_bin_write_clipped(struct item_bin *ib, struct tile_parameter *param, struct item_bin_sink *out) {
     struct tile_data tile_data;
     int i;
     bbox((struct coord *)(ib+1), ib->clen/2, &tile_data.item_bbox);
@@ -283,8 +262,7 @@ item_bin_write_clipped(struct item_bin *ib, struct tile_parameter *param, struct
     }
 }
 
-static char *
-coord_to_str(struct coord *c) {
+static char *coord_to_str(struct coord *c) {
     int x=c->x;
     int y=c->y;
     char *sx="";
@@ -300,16 +278,14 @@ coord_to_str(struct coord *c) {
     return g_strdup_printf("%s0x%x %s0x%x",sx,x,sy,y);
 }
 
-static void
-dump_coord(struct coord *c, FILE *out) {
+static void dump_coord(struct coord *c, FILE *out) {
     char *str=coord_to_str(c);
     fprintf(out,"%s",str);
     g_free(str);
 }
 
 
-void
-item_bin_dump(struct item_bin *ib, FILE *out) {
+void item_bin_dump(struct item_bin *ib, FILE *out) {
     struct coord *c;
     struct attr_bin *a;
     struct attr attr;
@@ -345,8 +321,7 @@ item_bin_dump(struct item_bin *ib, FILE *out) {
     }
 }
 
-void
-dump_itembin(struct item_bin *ib) {
+void dump_itembin(struct item_bin *ib) {
     item_bin_dump(ib, stdout);
 }
 
@@ -407,8 +382,7 @@ static struct population_table district_population[] = {
     {type_district_label_1e7,10000000},
 };
 
-void
-item_bin_set_type_by_population(struct item_bin *ib, int population) {
+void item_bin_set_type_by_population(struct item_bin *ib, int population) {
     struct population_table *table;
     int i,count;
 
@@ -429,8 +403,7 @@ item_bin_set_type_by_population(struct item_bin *ib, int population) {
 }
 
 
-void
-item_bin_write_match(struct item_bin *ib, enum attr_type type, enum attr_type match, int maxdepth, FILE *out) {
+void item_bin_write_match(struct item_bin *ib, enum attr_type type, enum attr_type match, int maxdepth, FILE *out) {
     char *word=item_bin_get_attr(ib, type, NULL);
     int i,words=0,len;
     char tilename[32]="";
@@ -474,8 +447,7 @@ item_bin_write_match(struct item_bin *ib, enum attr_type type, enum attr_type ma
     } while (word);
 }
 
-static int
-item_bin_sort_compare(const void *p1, const void *p2) {
+static int item_bin_sort_compare(const void *p1, const void *p2) {
     struct item_bin *ib1=*((struct item_bin **)p1),*ib2=*((struct item_bin **)p2);
     struct attr_bin *attr1,*attr2;
     char *s1,*s2;
@@ -516,8 +488,7 @@ item_bin_sort_compare(const void *p1, const void *p2) {
     return ret;
 }
 
-int
-item_bin_sort_file(char *in_file, char *out_file, struct rect *r, int *size) {
+int item_bin_sort_file(char *in_file, char *out_file, struct rect *r, int *size) {
     int j,k,count,rc=0;
     struct coord *c;
     struct item_bin *ib;
@@ -574,8 +545,7 @@ item_bin_to_poly_segment(struct item_bin *ib, int type) {
     return ret;
 }
 
-void
-clip_line(struct item_bin *ib, struct rect *r, struct tile_parameter *param, struct item_bin_sink *out) {
+void clip_line(struct item_bin *ib, struct rect *r, struct tile_parameter *param, struct item_bin_sink *out) {
     char *buffer=g_alloca(sizeof(char)*(ib->len*4+32));
     struct item_bin *ib_new=(struct item_bin *)buffer;
     struct coord *pa=(struct coord *)(ib+1);
@@ -619,8 +589,7 @@ clip_line(struct item_bin *ib, struct rect *r, struct tile_parameter *param, str
     }
 }
 
-void
-clip_polygon(struct item_bin *ib, struct rect *r, struct tile_parameter *param, struct item_bin_sink *out) {
+void clip_polygon(struct item_bin *ib, struct rect *r, struct tile_parameter *param, struct item_bin_sink *out) {
     int count_in=ib->clen/2;
     struct coord *pin,*p,*s,pi;
     char *buffer1=g_alloca(sizeof(char)*(ib->len*4+ib->clen*7+32));

--- a/navit/maptool/maptool.c
+++ b/navit/maptool/maptool.c
@@ -122,8 +122,7 @@ static int assafe_strcp2buf(char *str, int maxlen, char *buf) {
     return i;
 }
 
-static void
-progress_time(void) {
+static void progress_time(void) {
     struct timespec ts;
     int seconds;
     const int buflen=20;
@@ -145,8 +144,7 @@ progress_time(void) {
     }
 }
 
-static void
-progress_memory(void) {
+static void progress_memory(void) {
 #ifdef HAVE_SBRK
     long mem=(long)sbrk(0)-start_brk;
     const int buflen=20;
@@ -163,8 +161,7 @@ progress_memory(void) {
 #endif
 }
 
-static void
-sig_alrm_do(int sig) {
+static void sig_alrm_do(int sig) {
     const int buflen=1024;
     char buf[buflen];
     int pos=0;
@@ -205,23 +202,20 @@ sig_alrm_do(int sig) {
 #endif
 }
 
-void
-sig_alrm(int sig) {
+void sig_alrm(int sig) {
     fflush(stderr);
     sig_alrm_do(sig);
 }
 
 
 
-void
-sig_alrm_end(void) {
+void sig_alrm_end(void) {
 #ifndef _WIN32
     alarm(0);
 #endif
 }
 
-static struct files_relation_processing *
-files_relation_processing_new(FILE *line2poi, char *suffix) {
+static struct files_relation_processing *files_relation_processing_new(FILE *line2poi, char *suffix) {
     struct files_relation_processing *result = g_new(struct files_relation_processing, 1);
     result->ways_in=tempfile(suffix,"ways_split",0);
     result->ways_out=tempfile(suffix,"ways_split_relproc_tmp",1);
@@ -236,8 +230,7 @@ files_relation_processing_new(FILE *line2poi, char *suffix) {
     return result;
 }
 
-static void
-files_relation_processing_destroy(struct files_relation_processing *files_relproc, char *suffix) {
+static void files_relation_processing_destroy(struct files_relation_processing *files_relproc, char *suffix) {
     fclose(files_relproc->ways_in);
     fclose(files_relproc->nodes_in);
     fclose(files_relproc->ways_out);
@@ -268,15 +261,13 @@ static void add_plugin(char *path) {
     plugin_new(&pl_attr,attrs);
 }
 
-static void
-maptool_init(FILE* rule_file) {
+static void maptool_init(FILE* rule_file) {
     if (plugins)
         plugins_init(plugins);
     osm_init(rule_file);
 }
 
-static void
-usage(void) {
+static void usage(void) {
     FILE *f = stdout;
     /* DEVELOPERS : don't forget to update the manpage if you modify theses options */
     fprintf(f,"\n");
@@ -358,8 +349,7 @@ struct maptool_params {
     int max_index_size;
 };
 
-static int
-parse_option(struct maptool_params *p, char **argv, int argc, int *option_index) {
+static int parse_option(struct maptool_params *p, char **argv, int argc, int *option_index) {
     char *optarg_cp,*attr_name,*attr_value;
     struct map *handle;
     struct attr *attrs[10];
@@ -538,8 +528,7 @@ parse_option(struct maptool_params *p, char **argv, int argc, int *option_index)
     return 3;
 }
 
-static int
-start_phase(struct maptool_params *p, char *str) {
+static int start_phase(struct maptool_params *p, char *str) {
     phase++;
     if (p->start <= phase && p->end >= phase) {
         fprintf(stderr,"PROGRESS: Phase %d: %s",phase,str);
@@ -552,14 +541,12 @@ start_phase(struct maptool_params *p, char *str) {
         return 0;
 }
 
-static void
-exit_with_error(char* error_message) {
+static void exit_with_error(char* error_message) {
     fprintf(stderr, "%s", error_message);
     exit(1);
 }
 
-static void
-osm_read_input_data(struct maptool_params *p, char *suffix) {
+static void osm_read_input_data(struct maptool_params *p, char *suffix) {
     unlink("coords.tmp");
     if (p->process_ways)
         p->osm.ways=tempfile(suffix,"ways",1);
@@ -627,8 +614,7 @@ osm_read_input_data(struct maptool_params *p, char *suffix) {
 }
 int debug_ref=0;
 
-static void
-osm_count_references(struct maptool_params *p, char *suffix, int clear) {
+static void osm_count_references(struct maptool_params *p, char *suffix, int clear) {
     int i,first=1;
     fprintf(stderr,"%d slices\n",slices);
     for (i = slices-1 ; i>=0 ; i--) {
@@ -663,8 +649,7 @@ osm_count_references(struct maptool_params *p, char *suffix, int clear) {
 }
 
 
-static void
-osm_resolve_coords_and_split_at_intersections(struct maptool_params *p, char *suffix) {
+static void osm_resolve_coords_and_split_at_intersections(struct maptool_params *p, char *suffix) {
     FILE *ways, *ways_split, *ways_split_index, *graph, *coastline;
     int i;
 
@@ -694,8 +679,7 @@ osm_resolve_coords_and_split_at_intersections(struct maptool_params *p, char *su
     tempfile_unlink(suffix,"ways_to_resolve");
 }
 
-static void
-osm_process_way2poi(struct maptool_params *p, char *suffix) {
+static void osm_process_way2poi(struct maptool_params *p, char *suffix) {
     FILE *poly2poi=tempfile(suffix,"poly2poi_resolved",0);
     FILE *line2poi=tempfile(suffix,"line2poi_resolved",0);
     FILE *way2poi_result=tempfile(suffix,"way2poi_result",1);
@@ -710,8 +694,7 @@ osm_process_way2poi(struct maptool_params *p, char *suffix) {
     fclose(way2poi_result);
 }
 
-static void
-osm_process_coastlines(struct maptool_params *p, char *suffix) {
+static void osm_process_coastlines(struct maptool_params *p, char *suffix) {
     FILE *coastline=tempfile(suffix,"coastline",0);
     if (coastline) {
         FILE *coastline_result=tempfile(suffix,"coastline_result",1);
@@ -721,8 +704,7 @@ osm_process_coastlines(struct maptool_params *p, char *suffix) {
     }
 }
 
-static void
-osm_process_turn_restrictions(struct maptool_params *p, char *suffix) {
+static void osm_process_turn_restrictions(struct maptool_params *p, char *suffix) {
     FILE *ways_split, *ways_split_index, *relations, *coords;
     p->osm.turn_restrictions=tempfile(suffix,"turn_restrictions",0);
     if (!p->osm.turn_restrictions)
@@ -741,8 +723,7 @@ osm_process_turn_restrictions(struct maptool_params *p, char *suffix) {
         tempfile_unlink(suffix,"turn_restrictions");
 }
 
-static void
-maptool_dump(struct maptool_params *p, char *suffix) {
+static void maptool_dump(struct maptool_params *p, char *suffix) {
     char *files[10];
     int i,files_count=0;
     if (p->process_nodes)
@@ -760,9 +741,9 @@ maptool_dump(struct maptool_params *p, char *suffix) {
     }
 }
 
-static void
-maptool_generate_tiles(struct maptool_params *p, char *suffix, char **filenames, int filename_count, int first,
-                       char *suffix0) {
+static void maptool_generate_tiles(struct maptool_params *p, char *suffix, char **filenames, int filename_count,
+                                   int first,
+                                   char *suffix0) {
     struct zip_info *zip_info;
     FILE *tilesdir;
     FILE *files[10];
@@ -789,9 +770,8 @@ maptool_generate_tiles(struct maptool_params *p, char *suffix, char **filenames,
     zip_set_zipnum(zip_info,zipnum);
 }
 
-static void
-maptool_assemble_map(struct maptool_params *p, char *suffix, char **filenames, char **referencenames,
-                     int filename_count, int first, int last, char *suffix0) {
+static void maptool_assemble_map(struct maptool_params *p, char *suffix, char **filenames, char **referencenames,
+                                 int filename_count, int first, int last, char *suffix0) {
     FILE *files[10];
     FILE *references[10];
     struct zip_info *zip_info;
@@ -867,8 +847,7 @@ maptool_assemble_map(struct maptool_params *p, char *suffix, char **filenames, c
     }
 }
 
-static void
-maptool_load_node_table(struct maptool_params *p, int last) {
+static void maptool_load_node_table(struct maptool_params *p, int last) {
     if (!p->node_table_loaded) {
         slices=(sizeof_buffer("coords.tmp")+(long long)slice_size-(long long)1)/(long long)slice_size;
         assert(slices>0);
@@ -877,16 +856,14 @@ maptool_load_node_table(struct maptool_params *p, int last) {
     }
 }
 
-static void
-maptool_load_countries(struct maptool_params *p) {
+static void maptool_load_countries(struct maptool_params *p) {
     if (!p->countries_loaded) {
         load_countries();
         p->countries_loaded=1;
     }
 }
 
-static void
-maptool_load_tilesdir(struct maptool_params *p, char *suffix) {
+static void maptool_load_tilesdir(struct maptool_params *p, char *suffix) {
     if (!p->tilesdir_loaded) {
         FILE *tilesdir=tempfile(suffix,"tilesdir",0);
         load_tilesdir(tilesdir);

--- a/navit/maptool/misc.c
+++ b/navit/maptool/misc.c
@@ -52,8 +52,7 @@ struct rect world_bbox = {
     { WORLD_BOUNDINGBOX_MAX_X, WORLD_BOUNDINGBOX_MAX_Y},
 };
 
-void
-bbox_extend(struct coord *c, struct rect *r) {
+void bbox_extend(struct coord *c, struct rect *r) {
     if (c->x < r->l.x)
         r->l.x=c->x;
     if (c->y < r->l.y)
@@ -64,8 +63,7 @@ bbox_extend(struct coord *c, struct rect *r) {
         r->h.y=c->y;
 }
 
-void
-bbox(struct coord *c, int count, struct rect *r) {
+void bbox(struct coord *c, int count, struct rect *r) {
     if (! count)
         return;
     r->l=*c;
@@ -76,8 +74,7 @@ bbox(struct coord *c, int count, struct rect *r) {
     }
 }
 
-int
-contains_bbox(int xl, int yl, int xh, int yh, struct rect *r) {
+int contains_bbox(int xl, int yl, int xh, int yh, struct rect *r) {
     if (r->h.x < xl || r->h.x > xh) {
         return 0;
     }
@@ -93,8 +90,7 @@ contains_bbox(int xl, int yl, int xh, int yh, struct rect *r) {
     return 1;
 }
 
-int
-bbox_contains_coord(struct rect *r, struct coord *c) {
+int bbox_contains_coord(struct rect *r, struct coord *c) {
     if (r->h.x < c->x)
         return 0;
     if (r->l.x > c->x)
@@ -106,8 +102,7 @@ bbox_contains_coord(struct rect *r, struct coord *c) {
     return 1;
 }
 
-int
-bbox_contains_bbox(struct rect *out, struct rect *in) {
+int bbox_contains_bbox(struct rect *out, struct rect *in) {
     if (out->h.x < in->h.x)
         return 0;
     if (out->l.x > in->l.x)
@@ -119,13 +114,11 @@ bbox_contains_bbox(struct rect *out, struct rect *in) {
     return 1;
 }
 
-long long
-bbox_area(struct rect const *r) {
+long long bbox_area(struct rect const *r) {
     return ((long long)r->h.x-r->l.x)*(r->h.y-r->l.y);
 }
 
-void
-phase1_map(GList *maps, FILE *out_ways, FILE *out_nodes) {
+void phase1_map(GList *maps, FILE *out_ways, FILE *out_nodes) {
     struct map_rect *mr;
     struct item *item;
     int count;
@@ -159,8 +152,7 @@ phase1_map(GList *maps, FILE *out_ways, FILE *out_nodes) {
     }
 }
 
-int
-item_order_by_type(enum item_type type) {
+int item_order_by_type(enum item_type type) {
     int max=14;
     switch (type) {
     case type_town_label_1e7:
@@ -221,8 +213,7 @@ item_order_by_type(enum item_type type) {
     return max;
 }
 
-static void
-phase34_process_file(struct tile_info *info, FILE *in, FILE *reference) {
+static void phase34_process_file(struct tile_info *info, FILE *in, FILE *reference) {
     struct item_bin *ib;
     struct attr_bin *a;
     int max;
@@ -243,8 +234,7 @@ phase34_process_file(struct tile_info *info, FILE *in, FILE *reference) {
     }
 }
 
-static void
-phase34_process_file_range(struct tile_info *info, FILE *in, FILE *reference) {
+static void phase34_process_file_range(struct tile_info *info, FILE *in, FILE *reference) {
     struct item_bin *ib;
     int min,max;
 
@@ -257,8 +247,8 @@ phase34_process_file_range(struct tile_info *info, FILE *in, FILE *reference) {
     }
 }
 
-static int
-phase34(struct tile_info *info, struct zip_info *zip_info, FILE **in, FILE **reference, int in_count, int with_range) {
+static int phase34(struct tile_info *info, struct zip_info *zip_info, FILE **in, FILE **reference, int in_count,
+                   int with_range) {
     int i;
 
     processed_nodes=processed_nodes_out=processed_ways=processed_relations=processed_tiles=0;
@@ -285,16 +275,14 @@ phase34(struct tile_info *info, struct zip_info *zip_info, FILE **in, FILE **ref
 }
 
 
-void
-dump(FILE *in) {
+void dump(FILE *in) {
     struct item_bin *ib;
     while ((ib=read_item(in))) {
         dump_itembin(ib);
     }
 }
 
-int
-phase4(FILE **in, int in_count, int with_range, char *suffix, FILE *tilesdir_out, struct zip_info *zip_info) {
+int phase4(FILE **in, int in_count, int with_range, char *suffix, FILE *tilesdir_out, struct zip_info *zip_info) {
     struct tile_info info;
     info.write=0;
     info.maxlen=0;
@@ -304,9 +292,8 @@ phase4(FILE **in, int in_count, int with_range, char *suffix, FILE *tilesdir_out
     return phase34(&info, zip_info, in, NULL, in_count, with_range);
 }
 
-static int
-process_slice(FILE **in, FILE **reference, int in_count, int with_range, long long size, char *suffix,
-              struct zip_info *zip_info) {
+static int process_slice(FILE **in, FILE **reference, int in_count, int with_range, long long size, char *suffix,
+                         struct zip_info *zip_info) {
     struct tile_head *th;
     char *slice_data,*zip_data;
     int zipfiles=0;
@@ -356,8 +343,7 @@ process_slice(FILE **in, FILE **reference, int in_count, int with_range, long lo
     return zipfiles;
 }
 
-int
-phase5(FILE **in, FILE **references, int in_count, int with_range, char *suffix, struct zip_info *zip_info) {
+int phase5(FILE **in, FILE **references, int in_count, int with_range, char *suffix, struct zip_info *zip_info) {
     long long size;
     int slices;
     int zipnum,written_tiles;
@@ -403,16 +389,14 @@ phase5(FILE **in, FILE **references, int in_count, int with_range, char *suffix,
     return 0;
 }
 
-void
-process_binfile(FILE *in, FILE *out) {
+void process_binfile(FILE *in, FILE *out) {
     struct item_bin *ib;
     while ((ib=read_item(in))) {
         item_bin_write(ib, out);
     }
 }
 
-void
-add_aux_tiles(char *name, struct zip_info *info) {
+void add_aux_tiles(char *name, struct zip_info *info) {
     char buffer[4096];
     char *s;
     FILE *in;

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -776,8 +776,7 @@ static char *attrmap= {
     "w	barrier=city_wall	city_wall\n"
 };
 
-static void
-build_attrmap_line(char *line) {
+static void build_attrmap_line(char *line) {
     char *t=NULL,*kvl=NULL,*i=NULL,*p,*kv;
     struct attr_mapping *attr_mapping=g_malloc0(sizeof(struct attr_mapping));
     int idx,attr_mapping_count=0;
@@ -835,8 +834,7 @@ build_attrmap_line(char *line) {
 
 }
 
-static void
-build_attrmap(FILE* rule_file) {
+static void build_attrmap(FILE* rule_file) {
     attr_hash=g_hash_table_new(g_str_hash, g_str_equal);
     attr_present_count=1;
 
@@ -867,8 +865,7 @@ build_attrmap(FILE* rule_file) {
     attr_present=g_malloc0(sizeof(*attr_present)*attr_present_count);
 }
 
-static void
-build_countrytable(void) {
+static void build_countrytable(void) {
     int i;
     char *names,*str,*tok;
     country_table_hash=g_hash_table_new(g_str_hash, g_str_equal);
@@ -882,8 +879,7 @@ build_countrytable(void) {
     }
 }
 
-static void
-osm_logv(char *prefix, char *objtype, osmid id, int cont, struct coord_geo *geo, char *fmt, va_list ap) {
+static void osm_logv(char *prefix, char *objtype, osmid id, int cont, struct coord_geo *geo, char *fmt, va_list ap) {
     char str[4096];
     vsnprintf(str, sizeof(str), fmt, ap);
     if(cont)
@@ -896,24 +892,21 @@ osm_logv(char *prefix, char *objtype, osmid id, int cont, struct coord_geo *geo,
         fprintf(stderr,"%s[no osm object info] %s",prefix, str);
 }
 
-void
-osm_warning(char *type, osmid id, int cont, char *fmt, ...) {
+void osm_warning(char *type, osmid id, int cont, char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     osm_logv("OSM Warning:", type, id, cont, NULL, fmt, ap);
     va_end(ap);
 }
 
-void
-osm_info(char *type, osmid id, int cont, char *fmt, ...) {
+void osm_info(char *type, osmid id, int cont, char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     osm_logv("OSM Info:", type, id, cont, NULL, fmt, ap);
     va_end(ap);
 }
 
-static void
-itembin_warning(struct item_bin *ib, int cont, char *fmt, ...) {
+static void itembin_warning(struct item_bin *ib, int cont, char *fmt, ...) {
     char *type=NULL;
     osmid id;
     struct coord_geo geo;
@@ -934,14 +927,12 @@ itembin_warning(struct item_bin *ib, int cont, char *fmt, ...) {
     va_end(ap);
 }
 
-static void
-attr_strings_clear(void) {
+static void attr_strings_clear(void) {
     attr_strings_buffer_free_offset=0;
     memset(attr_strings, 0, sizeof(attr_strings));
 }
 
-static void
-attr_strings_save(enum attr_strings_type id, char *str) {
+static void attr_strings_save(enum attr_strings_type id, char *str) {
     int str_size=strlen(str)+1;
     dbg_assert(attr_strings_buffer_free_offset+str_size<sizeof(attr_strings_buffer));
     attr_strings[id]=attr_strings_buffer+attr_strings_buffer_free_offset;
@@ -949,37 +940,32 @@ attr_strings_save(enum attr_strings_type id, char *str) {
     attr_strings_buffer_free_offset+=str_size;
 }
 
-static osmid
-item_bin_get_nodeid_from_attr(struct item_bin *ib, enum attr_type attr_type) {
+static osmid item_bin_get_nodeid_from_attr(struct item_bin *ib, enum attr_type attr_type) {
     unsigned long long *ret=item_bin_get_attr(ib, attr_type, NULL);
     if (ret)
         return *ret;
     return 0;
 }
 
-osmid
-item_bin_get_nodeid(struct item_bin *ib) {
+osmid item_bin_get_nodeid(struct item_bin *ib) {
     return item_bin_get_nodeid_from_attr(ib, attr_osm_nodeid);
 }
 
-osmid
-item_bin_get_wayid(struct item_bin *ib) {
+osmid item_bin_get_wayid(struct item_bin *ib) {
     unsigned long long *ret=item_bin_get_attr(ib, attr_osm_wayid, NULL);
     if (ret)
         return *ret;
     return 0;
 }
 
-osmid
-item_bin_get_relationid(struct item_bin *ib) {
+osmid item_bin_get_relationid(struct item_bin *ib) {
     unsigned long long *ret=item_bin_get_attr(ib, attr_osm_relationid, NULL);
     if (ret)
         return *ret;
     return 0;
 }
 
-osmid
-item_bin_get_id(struct item_bin *ib) {
+osmid item_bin_get_id(struct item_bin *ib) {
     osmid ret;
     if (ib->type < 0x80000000)
         return item_bin_get_nodeid(ib);
@@ -992,8 +978,7 @@ item_bin_get_id(struct item_bin *ib) {
 static int node_is_tagged;
 static void relation_add_tag(char *k, char *v);
 
-static int
-access_value(char *v) {
+static int access_value(char *v) {
     if (!strcmp(v,"1"))
         return 1;
     if (!strcmp(v,"yes"))
@@ -1021,11 +1006,9 @@ access_value(char *v) {
     return 3;
 }
 
-static void
-osm_update_attr_present(char *k, char *v);
+static void osm_update_attr_present(char *k, char *v);
 
-void
-osm_add_tag(char *k, char *v) {
+void osm_add_tag(char *k, char *v) {
     int level=2;
     if (in_relation) {
         relation_add_tag(k,v);
@@ -1298,8 +1281,7 @@ osm_add_tag(char *k, char *v) {
     osm_update_attr_present(k, v);
 }
 
-static void
-osm_update_attr_present(char *k, char *v) {
+static void osm_update_attr_present(char *k, char *v) {
     const int bufsize=BUFFER_SIZE*2+2;
     int idx;
     char *p, buffer[bufsize];
@@ -1337,8 +1319,7 @@ osm_update_attr_present(char *k, char *v) {
 
 int coord_count;
 
-static void
-extend_buffer(struct buffer *b) {
+static void extend_buffer(struct buffer *b) {
     b->malloced+=b->malloced_step;
     b->base=g_realloc(b->base, b->malloced);
 }
@@ -1349,8 +1330,7 @@ static struct node_item *current_node;
 osmid id_last_node;
 GHashTable *node_hash,*way_hash;
 
-static void
-node_buffer_to_hash(void) {
+static void node_buffer_to_hash(void) {
     int i,count=node_buffer.size/sizeof(struct node_item);
     struct node_item *ni=(struct node_item *)node_buffer.base;
 
@@ -1358,8 +1338,7 @@ node_buffer_to_hash(void) {
         g_hash_table_insert(node_hash, (gpointer)(long long)(ni[i].nd_id), (gpointer)(long long)i);
 }
 
-void
-flush_nodes(int final) {
+void flush_nodes(int final) {
     fprintf(stderr,"flush_nodes %d\n",final);
     save_buffer("coords.tmp",&node_buffer,slices*slice_size);
     if (!final) {
@@ -1368,8 +1347,7 @@ flush_nodes(int final) {
     slices++;
 }
 
-static struct node_item*
-allocate_node_item_in_buffer(void) {
+static struct node_item* allocate_node_item_in_buffer(void) {
     struct node_item* new_node;
     if (node_buffer.size + sizeof(struct node_item) > node_buffer.malloced)
         extend_buffer(&node_buffer);
@@ -1381,13 +1359,11 @@ allocate_node_item_in_buffer(void) {
     return new_node;
 }
 
-static void
-remove_last_node_item_from_buffer(void) {
+static void remove_last_node_item_from_buffer(void) {
     node_buffer.size-=sizeof(struct node_item);
 }
 
-void
-osm_add_node(osmid id, double lat, double lon) {
+void osm_add_node(osmid id, double lat, double lon) {
     in_node=1;
     attr_strings_clear();
     node_is_tagged=0;
@@ -1425,8 +1401,7 @@ osm_add_node(osmid id, double lat, double lon) {
 
 }
 
-void
-clear_node_item_buffer(void) {
+void clear_node_item_buffer(void) {
     int j,count=node_buffer.size/sizeof(struct node_item);
     struct node_item *ni=(struct node_item *)(node_buffer.base);
     for (j = 0 ; j < count ; j++) {
@@ -1434,8 +1409,7 @@ clear_node_item_buffer(void) {
     }
 }
 
-static long long
-node_item_find_index_in_ordered_list(osmid id) {
+static long long node_item_find_index_in_ordered_list(osmid id) {
     struct node_item *node_buffer_base=(struct node_item *)(node_buffer.base);
     long long node_count=node_buffer.size/sizeof(struct node_item);
     long long search_step=node_count>4 ? node_count/4 : 1;
@@ -1474,8 +1448,7 @@ node_item_find_index_in_ordered_list(osmid id) {
     return search_index;
 }
 
-static struct node_item *
-node_item_get(osmid id) {
+static struct node_item *node_item_get(osmid id) {
     struct node_item *node_buffer_base=(struct node_item *)(node_buffer.base);
     long long result_index;
     if (node_hash) {
@@ -1492,8 +1465,7 @@ node_item_get(osmid id) {
 }
 
 #if 0
-static int
-load_node(FILE *coords, int p, struct node_item *ret) {
+static int load_node(FILE *coords, int p, struct node_item *ret) {
     fseek(coords, p*sizeof(struct node_item), SEEK_SET);
     if (fread(ret, sizeof(*ret), 1, coords) != 1) {
         fprintf(stderr,"read failed\n");
@@ -1504,8 +1476,7 @@ load_node(FILE *coords, int p, struct node_item *ret) {
 #endif
 
 #if 0
-static int
-node_item_get_from_file(FILE *coords, osmid id, struct node_item *ret) {
+static int node_item_get_from_file(FILE *coords, osmid id, struct node_item *ret) {
     int count;
     int interval;
     int p;
@@ -1569,8 +1540,7 @@ node_item_get_from_file(FILE *coords, osmid id, struct node_item *ret) {
     }
 }
 #endif
-void
-osm_add_way(osmid id) {
+void osm_add_way(osmid id) {
     static osmid wayid_last;
 
     in_way=1;
@@ -1596,8 +1566,7 @@ char relation_type[BUFFER_SIZE];
 char iso_code[BUFFER_SIZE];
 int boundary;
 
-void
-osm_add_relation(osmid id) {
+void osm_add_relation(osmid id) {
     osmid_attr_value=id;
     in_relation=1;
     debug_attr_buffer[0]='\0';
@@ -1608,8 +1577,7 @@ osm_add_relation(osmid id) {
     item_bin_add_attr_longlong(tmp_item_bin, attr_osm_relationid, osmid_attr_value);
 }
 
-static int
-country_id_from_iso2(char *iso) {
+static int country_id_from_iso2(char *iso) {
     int ret=0;
     if (iso) {
         struct country_search *search;
@@ -1626,8 +1594,7 @@ country_id_from_iso2(char *iso) {
     return ret;
 }
 
-static struct country_table *
-country_from_countryid(int id) {
+static struct country_table *country_from_countryid(int id) {
     int i;
     for (i = 0 ; i < sizeof(country_table)/sizeof(struct country_table) ; i++) {
         if (country_table[i].countryid == id)
@@ -1642,8 +1609,7 @@ country_from_iso2(char *iso) {
 }
 
 
-void
-osm_end_relation(struct maptool_osm *osm) {
+void osm_end_relation(struct maptool_osm *osm) {
     enum item_type type;
 
     in_relation=0;
@@ -1667,8 +1633,7 @@ osm_end_relation(struct maptool_osm *osm) {
     attr_longest_match_clear();
 }
 
-void
-osm_add_member(enum relation_member_type type, osmid ref, char *role) {
+void osm_add_member(enum relation_member_type type, osmid ref, char *role) {
     const int bufsize=BUFFER_SIZE*3+3;
     char member_buffer[bufsize];
     struct attr memberattr = { attr_osm_member };
@@ -1678,8 +1643,7 @@ osm_add_member(enum relation_member_type type, osmid ref, char *role) {
     item_bin_add_attr(tmp_item_bin, &memberattr);
 }
 
-static void
-relation_add_tag(char *k, char *v) {
+static void relation_add_tag(char *k, char *v) {
     int add_tag=1;
     if (!strcmp(k,"type")) {
         g_strlcpy(relation_type, v, sizeof(relation_type));
@@ -1713,8 +1677,8 @@ relation_add_tag(char *k, char *v) {
 }
 
 
-static int
-attr_longest_match(struct attr_mapping **mapping, int mapping_count, enum item_type *types, int types_count) {
+static int attr_longest_match(struct attr_mapping **mapping, int mapping_count, enum item_type *types,
+                              int types_count) {
     int i,j,longest=0,ret=0,sum,val;
     struct attr_mapping *curr;
     for (i = 0 ; i < mapping_count ; i++) {
@@ -1739,13 +1703,11 @@ attr_longest_match(struct attr_mapping **mapping, int mapping_count, enum item_t
     return ret;
 }
 
-static void
-attr_longest_match_clear(void) {
+static void attr_longest_match_clear(void) {
     memset(attr_present, 0, sizeof(*attr_present)*attr_present_count);
 }
 
-void
-osm_end_way(struct maptool_osm *osm) {
+void osm_end_way(struct maptool_osm *osm) {
     int i,count;
     int *def_flags,add_flags;
     enum item_type types[10];
@@ -1846,8 +1808,7 @@ osm_end_way(struct maptool_osm *osm) {
     attr_longest_match_clear();
 }
 
-void
-osm_end_node(struct maptool_osm *osm) {
+void osm_end_node(struct maptool_osm *osm) {
     int count,i;
     char *postal;
     enum item_type types[10];
@@ -1920,15 +1881,13 @@ struct town_country {
     struct country_table *country;
 };
 
-static struct town_country *
-town_country_new(struct country_table *country) {
+static struct town_country *town_country_new(struct country_table *country) {
     struct town_country *ret=g_malloc0(sizeof(struct town_country));
     ret->country=country;
     return ret;
 }
 
-static void
-town_country_destroy(struct town_country *tc) {
+static void town_country_destroy(struct town_country *tc) {
     g_free(tc);
 }
 
@@ -1939,8 +1898,7 @@ town_country_destroy(struct town_country *tc) {
  * @param in country country to add the town to
  * @returns refernce to then new town_country structure added to the list, or NULL if GList already had an entry for the country given
  */
-static struct town_country *
-town_country_list_insert_if_new(GList **town_country_list, struct country_table *country) {
+static struct town_country *town_country_list_insert_if_new(GList **town_country_list, struct country_table *country) {
     GList *l;
     struct town_country *ret;
 
@@ -1957,8 +1915,7 @@ town_country_list_insert_if_new(GList **town_country_list, struct country_table 
     return ret;
 }
 
-static GList *
-osm_process_town_unknown_country(void) {
+static GList *osm_process_town_unknown_country(void) {
     static struct country_table *unknown;
     if (!unknown)
         unknown=country_from_countryid(999);
@@ -1974,8 +1931,7 @@ osm_process_town_unknown_country(void) {
  * @param in town_hash hash of all town names
  * @returns refernce to a list of struct town_country* the town belongs to
  */
-static char *
-osm_process_town_get_town_name_from_is_in(struct item_bin *ib, GHashTable *town_hash) {
+static char *osm_process_town_get_town_name_from_is_in(struct item_bin *ib, GHashTable *town_hash) {
     char *is_in=item_bin_get_attr(ib, attr_osm_is_in, NULL);
     char *tok,*dup,*buf;
     char *town=NULL;
@@ -2002,8 +1958,7 @@ osm_process_town_get_town_name_from_is_in(struct item_bin *ib, GHashTable *town_
  * @param in ib pointer to item_bin structure holding town information
  * @returns refernce to a list of struct town_country* the town belongs to
  */
-static GList *
-osm_process_town_by_is_in(struct item_bin *ib) {
+static GList *osm_process_town_by_is_in(struct item_bin *ib) {
     struct country_table *country;
     char *is_in=item_bin_get_attr(ib, attr_osm_is_in, NULL);
     char *tok,*dup,*buf;
@@ -2035,8 +1990,7 @@ osm_process_town_by_is_in(struct item_bin *ib) {
  * @param in matches list of administrative boundaries the town belongs to (data is struct boundary *)
  * @returns nothing
  */
-static void
-osm_process_town_by_boundary_update_attrs(struct item_bin *town, struct town_country *tc, GList *matches) {
+static void osm_process_town_by_boundary_update_attrs(struct item_bin *town, struct town_country *tc, GList *matches) {
     long long *nodeid;
     long long node_id=0;
     int max_possible_adm_level=-1;
@@ -2118,8 +2072,7 @@ osm_process_town_by_boundary_update_attrs(struct item_bin *town, struct town_cou
  * @param in c town center coordinates
  * @returns refernce to the list of town_country structures
  */
-static GList *
-osm_process_town_by_boundary(GList *bl, struct item_bin *town, struct coord *c) {
+static GList *osm_process_town_by_boundary(GList *bl, struct item_bin *town, struct coord *c) {
     GList *matches=boundary_find_matches(bl, c);
     GList *town_country_list=NULL;
     GList *l;
@@ -2138,8 +2091,7 @@ osm_process_town_by_boundary(GList *bl, struct item_bin *town, struct coord *c) 
     return town_country_list;
 }
 
-static void
-osm_town_relations_to_poly(GList *boundaries, FILE *towns_poly) {
+static void osm_town_relations_to_poly(GList *boundaries, FILE *towns_poly) {
     while(boundaries) {
         struct boundary *b=boundaries->data;
         if(item_is_poly_place(*b->ib)) {
@@ -2168,8 +2120,7 @@ osm_town_relations_to_poly(GList *boundaries, FILE *towns_poly) {
 }
 
 
-void
-osm_process_towns(FILE *in, FILE *boundaries, FILE *ways, char *suffix) {
+void osm_process_towns(FILE *in, FILE *boundaries, FILE *ways, char *suffix) {
     struct item_bin *ib;
     GList *bl;
     GHashTable *town_hash;
@@ -2302,8 +2253,7 @@ osm_process_towns(FILE *in, FILE *boundaries, FILE *ways, char *suffix) {
     fprintf(stderr, "Finished processing towns\n");
 }
 
-void
-sort_countries(int keep_tmpfiles) {
+void sort_countries(int keep_tmpfiles) {
     int i;
     struct country_table *co;
     char *name_in,*name_out;
@@ -2330,8 +2280,7 @@ struct relation_member {
     char *role;
 };
 
-static void
-parse_relation_member_string(char *relation_member_string, struct relation_member *memb) {
+static void parse_relation_member_string(char *relation_member_string, struct relation_member *memb) {
     int len;
     int type_numeric;
     sscanf(relation_member_string,RELATION_MEMBER_PARSE_FORMAT,&type_numeric,&memb->id,&len);
@@ -2339,8 +2288,7 @@ parse_relation_member_string(char *relation_member_string, struct relation_membe
     memb->role=relation_member_string+len;
 }
 
-static int
-search_relation_member(struct item_bin *ib, char *role, struct relation_member *memb, int *min_count) {
+static int search_relation_member(struct item_bin *ib, char *role, struct relation_member *memb, int *min_count) {
     char *str=NULL;
     int count=0;
     while ((str=item_bin_get_attr(ib, attr_osm_member, str))) {
@@ -2356,8 +2304,7 @@ search_relation_member(struct item_bin *ib, char *role, struct relation_member *
 }
 
 #if 0
-static int
-load_way_index(FILE *ways_index, int p, long long *idx) {
+static int load_way_index(FILE *ways_index, int p, long long *idx) {
     int step=sizeof(*idx)*2;
     fseek(ways_index, p*step, SEEK_SET);
     if (fread(idx, step, 1, ways_index) != 1) {
@@ -2369,8 +2316,7 @@ load_way_index(FILE *ways_index, int p, long long *idx) {
 #endif
 
 #if 0
-static int
-seek_to_way(FILE *way, FILE *ways_index, osmid wayid) {
+static int seek_to_way(FILE *way, FILE *ways_index, osmid wayid) {
     long offset;
     long long idx[2];
     int count,interval,p;
@@ -2434,8 +2380,8 @@ seek_to_way(FILE *way, FILE *ways_index, osmid wayid) {
 #endif
 
 #if 0
-static struct coord *
-get_way(FILE *way, FILE *ways_index, struct coord *c, long long wayid, struct item_bin *ret, int debug) {
+static struct coord *get_way(FILE *way, FILE *ways_index, struct coord *c, long long wayid, struct item_bin *ret,
+                             int debug) {
     long long currid;
     int last;
     struct coord *ic;
@@ -2475,9 +2421,8 @@ struct process_relation_member_func_priv {
     GList *allocations;
 };
 
-static void
-process_associated_street_member(void *func_priv, void *relation_priv, struct item_bin *member,
-                                 void *member_priv_unused) {
+static void process_associated_street_member(void *func_priv, void *relation_priv, struct item_bin *member,
+        void *member_priv_unused) {
     struct process_relation_member_func_priv *fp=func_priv;
     struct associated_street *rel=relation_priv;
     if(!fp->out) {
@@ -2511,8 +2456,7 @@ struct house_number_interpolation {
     char* house_number_last_node;
 };
 
-static void
-process_house_number_interpolation_member(void *func_priv, void *relation_priv, struct item_bin *member,
+static void process_house_number_interpolation_member(void *func_priv, void *relation_priv, struct item_bin *member,
         void *member_priv_unused) {
     struct process_relation_member_func_priv *fp=func_priv;
     struct house_number_interpolation *rel=relation_priv;
@@ -2562,17 +2506,16 @@ process_house_number_interpolation_member(void *func_priv, void *relation_priv, 
     }
 }
 
-static void
-relation_func_writethrough(void *func_priv, void *relation_priv_unused, struct item_bin *member,
-                           void *member_priv_unused) {
+static void relation_func_writethrough(void *func_priv, void *relation_priv_unused, struct item_bin *member,
+                                       void *member_priv_unused) {
     FILE *out=*(FILE **)func_priv;
     if(out)
         item_bin_write(member,out);
 }
 
 
-static void
-process_associated_streets_setup(FILE *in, struct relations *relations, struct process_relation_member_func_priv *fp) {
+static void process_associated_streets_setup(FILE *in, struct relations *relations,
+        struct process_relation_member_func_priv *fp) {
     struct relation_member relm;
     long long relid;
     struct item_bin *ib;
@@ -2613,8 +2556,7 @@ process_associated_streets_setup(FILE *in, struct relations *relations, struct p
     relations_add_relation_default_entry(relations, relations_func);
 }
 
-void
-process_associated_streets(FILE *in, struct files_relation_processing *files_relproc) {
+void process_associated_streets(FILE *in, struct files_relation_processing *files_relproc) {
     struct relations *relations=relations_new();
     struct process_relation_member_func_priv fp= {NULL,NULL};
     fseek(in, 0, SEEK_SET);
@@ -2644,8 +2586,7 @@ process_associated_streets(FILE *in, struct files_relation_processing *files_rel
     g_list_free(fp.allocations);
 }
 
-static void
-process_house_number_interpolations_setup(FILE *in, struct relations *relations,
+static void process_house_number_interpolations_setup(FILE *in, struct relations *relations,
         struct process_relation_member_func_priv *fp) {
     struct item_bin *ib;
     struct relations_func *relations_func_process_hn_interpol;
@@ -2668,8 +2609,7 @@ process_house_number_interpolations_setup(FILE *in, struct relations *relations,
     relations_add_relation_default_entry(relations, relations_func_new(relation_func_writethrough, &fp->out));
 }
 
-void
-process_house_number_interpolations(FILE *in, struct files_relation_processing *files_relproc) {
+void process_house_number_interpolations(FILE *in, struct files_relation_processing *files_relproc) {
     struct relations *relations=relations_new();
     struct process_relation_member_func_priv fp= {NULL,NULL};
     fseek(in, 0, SEEK_SET);
@@ -2711,8 +2651,8 @@ struct turn_restriction {
     int order;
 };
 
-static void
-process_turn_restrictions_member(void *func_priv, void *relation_priv, struct item_bin *member, void *member_priv) {
+static void process_turn_restrictions_member(void *func_priv, void *relation_priv, struct item_bin *member,
+        void *member_priv) {
     int i,count,type=(long)member_priv;
     struct turn_restriction *turn_restriction=relation_priv;
     struct coord *c=(struct coord *)(member+1);
@@ -2741,8 +2681,7 @@ process_turn_restrictions_member(void *func_priv, void *relation_priv, struct it
 
 }
 
-static void
-process_turn_restrictions_fromto(struct turn_restriction *t, int type, struct coord **c) {
+static void process_turn_restrictions_fromto(struct turn_restriction *t, int type, struct coord **c) {
     int i,j;
     for (i = 0 ; i < t->c_count[type] ; i+=2) {
         for (j = 0 ; j < t->c_count[1] ; j++) {
@@ -2760,16 +2699,14 @@ process_turn_restrictions_fromto(struct turn_restriction *t, int type, struct co
     }
 }
 
-static void
-process_turn_restrictions_dump_coord(struct coord *c, int count) {
+static void process_turn_restrictions_dump_coord(struct coord *c, int count) {
     int i;
     for (i = 0 ; i < count ; i++) {
         fprintf(stderr,"(0x%x,0x%x)",c[i].x,c[i].y);
     }
 }
 
-static void
-process_turn_restrictions_finish(GList *tr, FILE *out) {
+static void process_turn_restrictions_finish(GList *tr, FILE *out) {
     GList *l=tr;
     while (l) {
         struct turn_restriction *t=l->data;
@@ -2830,8 +2767,7 @@ process_turn_restrictions_finish(GList *tr, FILE *out) {
     g_list_free(tr);
 }
 
-static GList *
-process_turn_restrictions_setup(FILE *in, struct relations *relations) {
+static GList *process_turn_restrictions_setup(FILE *in, struct relations *relations) {
     struct relation_member fromm,tom,viam,tmpm;
     long long relid;
     struct item_bin *ib;
@@ -2899,8 +2835,7 @@ process_turn_restrictions_setup(FILE *in, struct relations *relations) {
     return turn_restrictions;
 }
 
-void
-process_turn_restrictions(FILE *in, FILE *coords, FILE *ways, FILE *ways_index, FILE *out) {
+void process_turn_restrictions(FILE *in, FILE *coords, FILE *ways, FILE *ways_index, FILE *out) {
     struct relations *relations=relations_new();
     GList *turn_restrictions;
     fseek(in, 0, SEEK_SET);
@@ -2910,8 +2845,7 @@ process_turn_restrictions(FILE *in, FILE *coords, FILE *ways, FILE *ways_index, 
     relations_destroy(relations);
 }
 #if 0
-void
-process_turn_restrictions_old(FILE *in, FILE *coords, FILE *ways, FILE *ways_index, FILE *out) {
+void process_turn_restrictions_old(FILE *in, FILE *coords, FILE *ways, FILE *ways_index, FILE *out) {
     struct relation_member fromm,tom,viam,tmpm;
     struct node_item ni;
     long long relid;
@@ -3029,8 +2963,7 @@ process_turn_restrictions_old(FILE *in, FILE *coords, FILE *ways, FILE *ways_ind
 #endif
 
 #if 0
-static void
-process_countries(FILE *way, FILE *ways_index) {
+static void process_countries(FILE *way, FILE *ways_index) {
     FILE *in=fopen("country_de.tmp","r");
     struct item_bin *ib;
     char buffer2[400000];
@@ -3081,16 +3014,14 @@ process_countries(FILE *way, FILE *ways_index) {
 }
 #endif
 
-static void
-node_ref_way(osmid node) {
+static void node_ref_way(osmid node) {
     struct node_item *ni;
     ni=node_item_get(node);
     if (ni)
         ni->ref_way++;
 }
 
-static void
-nodes_ref_item_bin(struct item_bin *ib) {
+static void nodes_ref_item_bin(struct item_bin *ib) {
     int i;
     struct coord *c=(struct coord *)(ib+1);
     for (i = 0 ; i < ib->clen/2 ; i++)
@@ -3098,8 +3029,7 @@ nodes_ref_item_bin(struct item_bin *ib) {
 }
 
 
-void
-osm_add_nd(osmid ref) {
+void osm_add_nd(osmid ref) {
     SET_REF(coord_buffer[coord_count], ref);
     coord_count++;
     if (coord_count > MAX_COORD_COUNT) {
@@ -3108,9 +3038,8 @@ osm_add_nd(osmid ref) {
     }
 }
 
-static void
-write_item_way_subsection_index(FILE *out, FILE *out_index, FILE *out_graph, struct item_bin *orig,
-                                long long *last_id) {
+static void write_item_way_subsection_index(FILE *out, FILE *out_index, FILE *out_graph, struct item_bin *orig,
+        long long *last_id) {
     osmid idx[2];
     idx[0]=item_bin_get_wayid(orig);
     idx[1]=ftello(out);
@@ -3125,9 +3054,9 @@ write_item_way_subsection_index(FILE *out, FILE *out_index, FILE *out_graph, str
     }
 }
 
-static void
-write_item_way_subsection(FILE *out, FILE *out_index, FILE *out_graph, struct item_bin *orig, int first, int last,
-                          long long *last_id) {
+static void write_item_way_subsection(FILE *out, FILE *out_index, FILE *out_graph, struct item_bin *orig, int first,
+                                      int last,
+                                      long long *last_id) {
     struct item_bin new;
     struct coord *c=(struct coord *)(orig+1);
     char *attr=(char *)(c+orig->clen/2);
@@ -3143,8 +3072,7 @@ write_item_way_subsection(FILE *out, FILE *out_index, FILE *out_graph, struct it
     dbg_assert(fwrite(attr, attr_len*4, 1, out)==1);
 }
 
-void
-ref_ways(FILE *in) {
+void ref_ways(FILE *in) {
     struct item_bin *ib;
 
     fseek(in, 0, SEEK_SET);
@@ -3152,8 +3080,7 @@ ref_ways(FILE *in) {
         nodes_ref_item_bin(ib);
 }
 
-void
-resolve_ways(FILE *in, FILE *out) {
+void resolve_ways(FILE *in, FILE *out) {
     struct item_bin *ib;
     struct coord *c;
     int i;
@@ -3183,8 +3110,7 @@ resolve_ways(FILE *in, FILE *out) {
   * @param in type input file original contents type: type_line or type_area
   * @returns nothing
   */
-void
-process_way2poi(FILE *in, FILE *out, int type) {
+void process_way2poi(FILE *in, FILE *out, int type) {
     struct item_bin *ib;
     while ((ib=read_item(in))) {
         int count=ib->clen/2;
@@ -3216,8 +3142,7 @@ process_way2poi(FILE *in, FILE *out, int type) {
 }
 
 
-int
-map_resolve_coords_and_split_at_intersections(FILE *in, FILE *out, FILE *out_index, FILE *out_graph,
+int map_resolve_coords_and_split_at_intersections(FILE *in, FILE *out, FILE *out_index, FILE *out_graph,
         FILE *out_coastline, int final) {
     struct coord *c;
     int i,ccount,last,remaining;
@@ -3267,9 +3192,9 @@ map_resolve_coords_and_split_at_intersections(FILE *in, FILE *out, FILE *out_ind
     return 0;
 }
 
-static void
-index_country_add(struct zip_info *info, int country_id, char*first_key, char *last_key, char *tile, char *filename,
-                  int size, FILE *out) {
+static void index_country_add(struct zip_info *info, int country_id, char*first_key, char *last_key, char *tile,
+                              char *filename,
+                              int size, FILE *out) {
     struct item_bin *item_bin=init_item(type_countryindex);
     int num=0, zip_num;
     char tilename[32];
@@ -3292,8 +3217,7 @@ index_country_add(struct zip_info *info, int country_id, char*first_key, char *l
     item_bin_write(item_bin, out);
 }
 
-void
-write_countrydir(struct zip_info *zip_info, int max_index_size) {
+void write_countrydir(struct zip_info *zip_info, int max_index_size) {
     int i;
     int max=11;
     char filename[32];
@@ -3391,8 +3315,7 @@ write_countrydir(struct zip_info *zip_info, int max_index_size) {
     }
 }
 
-void
-load_countries(void) {
+void load_countries(void) {
     char filename[32];
     FILE *f;
     int i;
@@ -3424,8 +3347,7 @@ load_countries(void) {
     }
 }
 
-void
-remove_countryfiles(void) {
+void remove_countryfiles(void) {
     int i,j;
     char filename[32];
     struct country_table *co;

--- a/navit/maptool/osm_o5m.c
+++ b/navit/maptool/osm_o5m.c
@@ -30,8 +30,7 @@ static double latlon_scale=10000000.0;
 
 #define buffer_end(o,x) ((o)->buffer_start+(x) > (o)->buffer_end && !fill_buffer((o), (x)))
 
-static int
-fill_buffer(struct o5m *o, int min) {
+static int fill_buffer(struct o5m *o, int min) {
     int count;
 
     memmove(o->buffer, o->buffer_start, o->buffer_end-o->buffer_start);
@@ -44,8 +43,7 @@ fill_buffer(struct o5m *o, int min) {
     return (min <= o->buffer_end - o->buffer);
 }
 
-static unsigned long long
-get_uval(unsigned char **p) {
+static unsigned long long get_uval(unsigned char **p) {
     unsigned char c;
     unsigned long long ret=0;
     int shift=0;
@@ -59,8 +57,7 @@ get_uval(unsigned char **p) {
     }
 }
 
-static long long
-get_sval(unsigned char **p) {
+static long long get_sval(unsigned char **p) {
     unsigned long long ret=get_uval(p);
     if (ret & 1) {
         return -((long long)(ret >> 1)+1);
@@ -69,8 +66,7 @@ get_sval(unsigned char **p) {
     }
 }
 
-static void
-get_strings(struct string_table *st, unsigned char **p, char **s1, char **s2) {
+static void get_strings(struct string_table *st, unsigned char **p, char **s1, char **s2) {
     int len,xlen=0;
     *s1=(char *)*p;
     len=strlen(*s1);
@@ -88,8 +84,7 @@ get_strings(struct string_table *st, unsigned char **p, char **s1, char **s2) {
     }
 }
 
-static void
-get_strings_ref(struct string_table *st, int ref, char **s1, char **s2) {
+static void get_strings_ref(struct string_table *st, int ref, char **s1, char **s2) {
     int pos=st->pos-ref;
 
     if (pos < 0)
@@ -99,8 +94,7 @@ get_strings_ref(struct string_table *st, int ref, char **s1, char **s2) {
         *s2=*s1+strlen(*s1)+1;
 }
 
-static void
-print_escaped(char *s) {
+static void print_escaped(char *s) {
     for (;;) {
         switch (*s) {
         case 0:
@@ -122,8 +116,7 @@ print_escaped(char *s) {
     }
 }
 
-static void
-o5m_reset(struct o5m *o) {
+static void o5m_reset(struct o5m *o) {
     o->lat=0;
     o->lon=0;
     o->id=0;
@@ -134,13 +127,11 @@ o5m_reset(struct o5m *o) {
     o->timestamp=0;
 }
 
-static void
-o5m_print_start(struct o5m *o, int c) {
+static void o5m_print_start(struct o5m *o, int c) {
     printf("\t<%s id=\""LONGLONG_FMT"\"",types[c-0x10],o->id);
 }
 
-static void
-o5m_print_version(struct o5m *o, int tags) {
+static void o5m_print_version(struct o5m *o, int tags) {
     char timestamp_str[64];
     if (o->version) {
         strftime(timestamp_str, sizeof(timestamp_str), "%Y-%m-%dT%H:%M:%SZ", gmtime(&o->timestamp));
@@ -154,13 +145,11 @@ o5m_print_version(struct o5m *o, int tags) {
     printf("%s\n",tags?">":"/>");
 }
 
-static void
-o5m_print_end(char c) {
+static void o5m_print_end(char c) {
     printf("\t</%s>\n",types[c-0x10]);
 }
 
-int
-map_collect_data_osm_o5m(FILE *in, struct maptool_osm *osm) {
+int map_collect_data_osm_o5m(FILE *in, struct maptool_osm *osm) {
     struct o5m o;
     unsigned char c, *end, *rend;
     int len, rlen, ref, tags;

--- a/navit/maptool/osm_protobuf.c
+++ b/navit/maptool/osm_protobuf.c
@@ -46,8 +46,7 @@ static double latlon_scale=10000000.0;
 		return NULL;                                                   \
 	}
 
-static OSMPBF__BlobHeader *
-read_header(FILE *f) {
+static OSMPBF__BlobHeader *read_header(FILE *f) {
     unsigned char *buffer,lenb[4];
     int len;
 
@@ -62,8 +61,7 @@ read_header(FILE *f) {
 }
 
 
-static OSMPBF__Blob *
-read_blob(OSMPBF__BlobHeader *header, FILE *f, unsigned char *buffer) {
+static OSMPBF__Blob *read_blob(OSMPBF__BlobHeader *header, FILE *f, unsigned char *buffer) {
     int len=header->datasize;
     SANITY_CHECK_LENGTH(len, MAX_BLOB_LENGTH)
     if (fread(buffer, len, 1, f) != 1)
@@ -71,8 +69,7 @@ read_blob(OSMPBF__BlobHeader *header, FILE *f, unsigned char *buffer) {
     return osmpbf__blob__unpack(&protobuf_c_system_allocator, len, buffer);
 }
 
-static unsigned char *
-uncompress_blob(OSMPBF__Blob *blob) {
+static unsigned char *uncompress_blob(OSMPBF__Blob *blob) {
     unsigned char *ret=g_malloc(blob->raw_size);
     int zerr;
     z_stream strm;
@@ -100,8 +97,7 @@ uncompress_blob(OSMPBF__Blob *blob) {
     return ret;
 }
 
-static int
-get_string(char *buffer, int buffer_size, OSMPBF__PrimitiveBlock *primitive_block, int id, int escape) {
+static int get_string(char *buffer, int buffer_size, OSMPBF__PrimitiveBlock *primitive_block, int id, int escape) {
     int len=primitive_block->stringtable->s[id].len;
     char *data=(char *)primitive_block->stringtable->s[id].data;
     if (primitive_block->stringtable->s[id].len >= buffer_size) {
@@ -138,8 +134,7 @@ get_string(char *buffer, int buffer_size, OSMPBF__PrimitiveBlock *primitive_bloc
 }
 
 
-static void
-process_osmheader(OSMPBF__Blob *blob, unsigned char *data) {
+static void process_osmheader(OSMPBF__Blob *blob, unsigned char *data) {
     OSMPBF__HeaderBlock *header_block;
     header_block=osmpbf__header_block__unpack(&protobuf_c_system_allocator, blob->raw_size, data);
     osmpbf__header_block__free_unpacked(header_block, &protobuf_c_system_allocator);
@@ -147,8 +142,7 @@ process_osmheader(OSMPBF__Blob *blob, unsigned char *data) {
 
 #if 0
 
-static void
-process_user(OSMPBF__PrimitiveBlock *primitive_block, int user_sid, int uid, int swap) {
+static void process_user(OSMPBF__PrimitiveBlock *primitive_block, int user_sid, int uid, int swap) {
     char userbuff[1024];
     get_string(userbuff, sizeof(userbuff), primitive_block, user_sid, 1);
     if (userbuff[0] && uid != -1) {
@@ -159,8 +153,7 @@ process_user(OSMPBF__PrimitiveBlock *primitive_block, int user_sid, int uid, int
     }
 }
 
-static void
-process_timestamp(long long timestamp) {
+static void process_timestamp(long long timestamp) {
     time_t ts;
     struct tm *tm;
     char tsbuff[1024];
@@ -172,8 +165,7 @@ process_timestamp(long long timestamp) {
 
 #endif
 
-static void
-process_tag(OSMPBF__PrimitiveBlock *primitive_block, int key, int val) {
+static void process_tag(OSMPBF__PrimitiveBlock *primitive_block, int key, int val) {
     char keybuff[1024];
     char valbuff[1024];
     get_string(keybuff, sizeof(keybuff), primitive_block, key, 0);
@@ -182,8 +174,7 @@ process_tag(OSMPBF__PrimitiveBlock *primitive_block, int key, int val) {
 }
 
 
-static void
-process_dense(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__DenseNodes *dense, struct maptool_osm *osm) {
+static void process_dense(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__DenseNodes *dense, struct maptool_osm *osm) {
     int i,j=0,has_tags;
     long long id=0,lat=0,lon=0,changeset=0,timestamp=0;
     int user_sid=0,uid=0;
@@ -213,16 +204,14 @@ process_dense(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__DenseNodes *dense
 }
 
 #if 0
-static void
-process_info(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Info *info) {
+static void process_info(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Info *info) {
     printf(" version=\"%d\" changeset=\"%Ld\"",info->version,info->changeset);
     process_user(primitive_block, info->user_sid, info->uid, 1);
     process_timestamp(info->timestamp);
 }
 #endif
 
-static void
-process_way(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Way *way, struct maptool_osm *osm) {
+static void process_way(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Way *way, struct maptool_osm *osm) {
     int i;
     long long ref=0;
 
@@ -236,8 +225,8 @@ process_way(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Way *way, struct ma
     osm_end_way(osm);
 }
 
-static void
-process_relation(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Relation *relation, struct maptool_osm *osm) {
+static void process_relation(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Relation *relation,
+                             struct maptool_osm *osm) {
     int i;
     long long ref=0;
     char rolebuff[1024];
@@ -253,8 +242,7 @@ process_relation(OSMPBF__PrimitiveBlock *primitive_block, OSMPBF__Relation *rela
     osm_end_relation(osm);
 }
 
-static void
-process_osmdata(OSMPBF__Blob *blob, unsigned char *data, struct maptool_osm *osm) {
+static void process_osmdata(OSMPBF__Blob *blob, unsigned char *data, struct maptool_osm *osm) {
     int i,j;
     OSMPBF__PrimitiveBlock *primitive_block;
     primitive_block=osmpbf__primitive_block__unpack(&protobuf_c_system_allocator, blob->raw_size, data);
@@ -270,8 +258,7 @@ process_osmdata(OSMPBF__Blob *blob, unsigned char *data, struct maptool_osm *osm
 }
 
 
-int
-map_collect_data_osm_protobuf(FILE *in, struct maptool_osm *osm) {
+int map_collect_data_osm_protobuf(FILE *in, struct maptool_osm *osm) {
     OSMPBF__BlobHeader *header;
     OSMPBF__Blob *blob;
     unsigned char *data;

--- a/navit/maptool/osm_protobufdb.c
+++ b/navit/maptool/osm_protobufdb.c
@@ -63,8 +63,7 @@ struct osm_protobufdb_context {
     OSMPBF__StringTable *st;
 } context;
 
-static int
-osm_protobufdb_write_blob(OSMPBF__Blob *blob, FILE *out) {
+static int osm_protobufdb_write_blob(OSMPBF__Blob *blob, FILE *out) {
     unsigned char lenb[4];
     int len,blen;
     unsigned char *buffer;
@@ -94,8 +93,7 @@ osm_protobufdb_write_blob(OSMPBF__Blob *blob, FILE *out) {
 }
 
 #if 0
-void
-dump_block(OSMPBF__PrimitiveBlock *pb) {
+void dump_block(OSMPBF__PrimitiveBlock *pb) {
     int i,j;
     printf("%d groups\n",pb->n_primitivegroup);
     for (i = 0 ; i < pb->n_primitivegroup ; i++) {
@@ -107,8 +105,7 @@ dump_block(OSMPBF__PrimitiveBlock *pb) {
 }
 #endif
 
-static int
-osm_protobufdb_finish_block(struct osm_protobufdb_context *ctx) {
+static int osm_protobufdb_finish_block(struct osm_protobufdb_context *ctx) {
     OSMPBF__Blob *blob,empty_blob=OSMPBF__BLOB__INIT;
     int len;
     if (!ctx->pb)
@@ -135,8 +132,7 @@ osm_protobufdb_finish_block(struct osm_protobufdb_context *ctx) {
     return 1;
 }
 
-static int
-osm_protobufdb_start_block(struct osm_protobufdb_context *ctx, int blocknum) {
+static int osm_protobufdb_start_block(struct osm_protobufdb_context *ctx, int blocknum) {
     OSMPBF__PrimitiveBlock pb=OSMPBF__PRIMITIVE_BLOCK__INIT;
     OSMPBF__StringTable st=OSMPBF__STRING_TABLE__INIT;
     if (ctx->active_block == blocknum)
@@ -151,8 +147,7 @@ osm_protobufdb_start_block(struct osm_protobufdb_context *ctx, int blocknum) {
     return 1;
 }
 
-static int
-osm_protobufdb_start_group(struct osm_protobufdb_context *ctx, int groupnum) {
+static int osm_protobufdb_start_group(struct osm_protobufdb_context *ctx, int groupnum) {
     OSMPBF__PrimitiveGroup pg=OSMPBF__PRIMITIVE_GROUP__INIT;
     if (ctx->pb->n_primitivegroup <= groupnum) {
         ctx->pb->primitivegroup=g_realloc(ctx->pb->primitivegroup, (groupnum+1)*sizeof(ctx->pb->primitivegroup[0]));
@@ -173,8 +168,7 @@ osm_protobufdb_start_group(struct osm_protobufdb_context *ctx, int groupnum) {
 }
 
 #if 0
-static int
-osm_protobufdb_start_densenode(struct osm_protobufdb_context *ctx) {
+static int osm_protobufdb_start_densenode(struct osm_protobufdb_context *ctx) {
     OSMPBF__DenseInfo di=OSMPBF__DENSE_INFO__INIT;
     OSMPBF__DenseNodes dn=OSMPBF__DENSE_NODES__INIT;
 
@@ -193,8 +187,7 @@ osm_protobufdb_start_densenode(struct osm_protobufdb_context *ctx) {
     return 1;
 }
 
-static void
-osm_protobufdb_write_primitive_group(OSMPBF__PrimitiveGroup *pg, OSMPBF__PrimitiveBlock *pb) {
+static void osm_protobufdb_write_primitive_group(OSMPBF__PrimitiveGroup *pg, OSMPBF__PrimitiveBlock *pb) {
     pb->primitivegroup=g_realloc(pb->primitivegroup,(pb->n_primitivegroup+1)*sizeof(OSMPBF__PrimitiveGroup *));
     pb->primitivegroup[pb->n_primitivegroup++]=pg;
 }
@@ -211,8 +204,8 @@ osm_protobufdb_write_primitive_group(OSMPBF__PrimitiveGroup *pg, OSMPBF__Primiti
 }
 
 #if 0
-static int
-osm_protobufdb_insert_densenode(long long id, OSMPBF__Node *offset, OSMPBF__Info *offseti, OSMPBF__DenseNodes *dn) {
+static int osm_protobufdb_insert_densenode(long long id, OSMPBF__Node *offset, OSMPBF__Info *offseti,
+        OSMPBF__DenseNodes *dn) {
     int i,l,p;
     memset(offset, 0, sizeof(*offset));
     offseti->timestamp=0;
@@ -241,9 +234,9 @@ osm_protobufdb_insert_densenode(long long id, OSMPBF__Node *offset, OSMPBF__Info
     return p;
 }
 
-static void
-osm_protobufdb_modify_densenode(OSMPBF__Node *node, OSMPBF__Info *info, OSMPBF__Node *offset, OSMPBF__Info *offseti,
-                                int pos, OSMPBF__DenseNodes *dn) {
+static void osm_protobufdb_modify_densenode(OSMPBF__Node *node, OSMPBF__Info *info, OSMPBF__Node *offset,
+        OSMPBF__Info *offseti,
+        int pos, OSMPBF__DenseNodes *dn) {
     int i;
     if (pos+1 < dn->n_id) {
         dn->id[pos+1]+=dn->id[pos]-node->id;
@@ -271,8 +264,7 @@ osm_protobufdb_modify_densenode(OSMPBF__Node *node, OSMPBF__Info *info, OSMPBF__
 }
 #endif
 
-static int
-osm_protobufdb_insert_node(long long id, OSMPBF__PrimitiveGroup *pg) {
+static int osm_protobufdb_insert_node(long long id, OSMPBF__PrimitiveGroup *pg) {
     int l,p;
     OSMPBF__Node node=OSMPBF__NODE__INIT;
     l=pg->n_nodes;
@@ -283,8 +275,7 @@ osm_protobufdb_insert_node(long long id, OSMPBF__PrimitiveGroup *pg) {
     return p;
 }
 
-static void
-osm_protobufdb_modify_node(OSMPBF__Node *node, OSMPBF__Info *info, int pos, OSMPBF__PrimitiveGroup *pg) {
+static void osm_protobufdb_modify_node(OSMPBF__Node *node, OSMPBF__Info *info, int pos, OSMPBF__PrimitiveGroup *pg) {
     OSMPBF__Node *n=pg->nodes[pos];
     OSMPBF__Info *old_info;
 
@@ -306,8 +297,7 @@ osm_protobufdb_modify_node(OSMPBF__Node *node, OSMPBF__Info *info, int pos, OSMP
 
 }
 
-static int
-osm_protobufdb_insert_way(long long id, OSMPBF__PrimitiveGroup *pg) {
+static int osm_protobufdb_insert_way(long long id, OSMPBF__PrimitiveGroup *pg) {
     int l,p;
     OSMPBF__Way way=OSMPBF__WAY__INIT;
     l=pg->n_ways;
@@ -318,8 +308,7 @@ osm_protobufdb_insert_way(long long id, OSMPBF__PrimitiveGroup *pg) {
     return p;
 }
 
-static void
-osm_protobufdb_modify_way(OSMPBF__Way *way, OSMPBF__Info *info, int pos, OSMPBF__PrimitiveGroup *pg) {
+static void osm_protobufdb_modify_way(OSMPBF__Way *way, OSMPBF__Info *info, int pos, OSMPBF__PrimitiveGroup *pg) {
     OSMPBF__Way *w=pg->ways[pos];
     OSMPBF__Info *old_info;
     int i;
@@ -348,8 +337,7 @@ osm_protobufdb_modify_way(OSMPBF__Way *way, OSMPBF__Info *info, int pos, OSMPBF_
 
 }
 
-static int
-osm_protobufdb_insert_relation(long long id, OSMPBF__PrimitiveGroup *pg) {
+static int osm_protobufdb_insert_relation(long long id, OSMPBF__PrimitiveGroup *pg) {
     int l,p;
     OSMPBF__Relation relation=OSMPBF__RELATION__INIT;
     l=pg->n_relations;
@@ -360,8 +348,8 @@ osm_protobufdb_insert_relation(long long id, OSMPBF__PrimitiveGroup *pg) {
     return p;
 }
 
-static void
-osm_protobufdb_modify_relation(OSMPBF__Relation *relation, OSMPBF__Info *info, int pos, OSMPBF__PrimitiveGroup *pg) {
+static void osm_protobufdb_modify_relation(OSMPBF__Relation *relation, OSMPBF__Info *info, int pos,
+        OSMPBF__PrimitiveGroup *pg) {
     OSMPBF__Relation *r=pg->relations[pos];
     OSMPBF__Info *old_info;
     int i;
@@ -392,8 +380,7 @@ osm_protobufdb_modify_relation(OSMPBF__Relation *relation, OSMPBF__Info *info, i
 
 }
 
-static int
-osm_protobufdb_string(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_string(struct osm_protobufdb_context *ctx, char *str) {
     char *strd;
     OSMPBF__StringTable *st=ctx->st;
 
@@ -418,8 +405,7 @@ osm_protobufdb_string(struct osm_protobufdb_context *ctx, char *str) {
 }
 
 
-static int
-osm_protobufdb_finish_file(struct osm_protobufdb_context *ctx) {
+static int osm_protobufdb_finish_file(struct osm_protobufdb_context *ctx) {
     osm_protobufdb_finish_block(ctx);
     if (ctx->f) {
         fclose(ctx->f);
@@ -430,8 +416,7 @@ osm_protobufdb_finish_file(struct osm_protobufdb_context *ctx) {
 }
 
 
-static int
-osm_protobufdb_start_file(struct osm_protobufdb_context *ctx, int type, int num) {
+static int osm_protobufdb_start_file(struct osm_protobufdb_context *ctx, int type, int num) {
     char name[1024];
     if (ctx->current_file == num)
         return 0;
@@ -444,18 +429,15 @@ osm_protobufdb_start_file(struct osm_protobufdb_context *ctx, int type, int num)
     return 1;
 }
 
-static void
-test(void) {
+static void test(void) {
     context.current_file=-1;
 }
 
-static void
-finish(void) {
+static void finish(void) {
     osm_protobufdb_finish_file(&context);
 }
 
-static long long
-osm_protobufdb_timestamp(char *str) {
+static long long osm_protobufdb_timestamp(char *str) {
     struct tm tm;
     int res=sscanf(str,"%d-%d-%dT%d:%d:%dZ",&tm.tm_year,&tm.tm_mon,&tm.tm_mday,&tm.tm_hour,&tm.tm_min,&tm.tm_sec);
     if (res != 6)
@@ -469,8 +451,7 @@ osm_protobufdb_timestamp(char *str) {
 #endif
 }
 
-static void
-osm_protobufdb_parse_info(struct osm_protobufdb_context *ctx, char *str) {
+static void osm_protobufdb_parse_info(struct osm_protobufdb_context *ctx, char *str) {
     char version[1024];
     char changeset[1024];
     char user[1024];
@@ -502,8 +483,7 @@ osm_protobufdb_parse_info(struct osm_protobufdb_context *ctx, char *str) {
     }
 }
 
-static int
-osm_protobufdb_parse_node(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_parse_node(struct osm_protobufdb_context *ctx, char *str) {
     char id[1024];
     char lat[1024];
     char lon[1024];
@@ -533,8 +513,7 @@ osm_protobufdb_parse_node(struct osm_protobufdb_context *ctx, char *str) {
     return 1;
 }
 
-static int
-osm_protobufdb_end_node(struct osm_protobufdb_context *ctx) {
+static int osm_protobufdb_end_node(struct osm_protobufdb_context *ctx) {
     int p;
     p=osm_protobufdb_insert_node(ctx->n.id, ctx->pg);
     osm_protobufdb_modify_node(&ctx->n, &ctx->i, p, ctx->pg);
@@ -543,8 +522,7 @@ osm_protobufdb_end_node(struct osm_protobufdb_context *ctx) {
 }
 
 
-static int
-osm_protobufdb_parse_way(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_parse_way(struct osm_protobufdb_context *ctx, char *str) {
     char id[1024];
     OSMPBF__Way *w=&ctx->w, wi=OSMPBF__WAY__INIT;
 
@@ -566,8 +544,7 @@ osm_protobufdb_parse_way(struct osm_protobufdb_context *ctx, char *str) {
     return 1;
 }
 
-static int
-osm_protobufdb_end_way(struct osm_protobufdb_context *ctx) {
+static int osm_protobufdb_end_way(struct osm_protobufdb_context *ctx) {
     int p;
     p=osm_protobufdb_insert_way(ctx->w.id, ctx->pg);
     osm_protobufdb_modify_way(&ctx->w, &ctx->i, p, ctx->pg);
@@ -575,8 +552,7 @@ osm_protobufdb_end_way(struct osm_protobufdb_context *ctx) {
     return 1;
 }
 
-static int
-osm_protobufdb_parse_relation(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_parse_relation(struct osm_protobufdb_context *ctx, char *str) {
     char id[1024];
     OSMPBF__Relation *r=&ctx->r, ri=OSMPBF__RELATION__INIT;
 
@@ -598,8 +574,7 @@ osm_protobufdb_parse_relation(struct osm_protobufdb_context *ctx, char *str) {
     return 1;
 }
 
-static int
-osm_protobufdb_end_relation(struct osm_protobufdb_context *ctx) {
+static int osm_protobufdb_end_relation(struct osm_protobufdb_context *ctx) {
     int p;
     p=osm_protobufdb_insert_relation(ctx->r.id, ctx->pg);
     osm_protobufdb_modify_relation(&ctx->r, &ctx->i, p, ctx->pg);
@@ -607,8 +582,7 @@ osm_protobufdb_end_relation(struct osm_protobufdb_context *ctx) {
     return 1;
 }
 
-static int
-osm_protobufdb_parse_tag(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_parse_tag(struct osm_protobufdb_context *ctx, char *str) {
     OSMPBF__Node *n=&ctx->n;
     OSMPBF__Way *w=&ctx->w;
     OSMPBF__Relation *r=&ctx->r;
@@ -640,8 +614,7 @@ osm_protobufdb_parse_tag(struct osm_protobufdb_context *ctx, char *str) {
     return 1;
 }
 
-static int
-osm_protobufdb_parse_nd(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_parse_nd(struct osm_protobufdb_context *ctx, char *str) {
     OSMPBF__Way *w=&ctx->w;
     char ref_buffer[BUFFER_SIZE];
     if (!osm_xml_get_attribute(str, "ref", ref_buffer, BUFFER_SIZE))
@@ -653,8 +626,7 @@ osm_protobufdb_parse_nd(struct osm_protobufdb_context *ctx, char *str) {
     return 1;
 }
 
-static int
-osm_protobufdb_parse_member(struct osm_protobufdb_context *ctx, char *str) {
+static int osm_protobufdb_parse_member(struct osm_protobufdb_context *ctx, char *str) {
     OSMPBF__Relation *r=&ctx->r;
     char type_buffer[BUFFER_SIZE];
     char ref_buffer[BUFFER_SIZE];
@@ -685,8 +657,7 @@ osm_protobufdb_parse_member(struct osm_protobufdb_context *ctx, char *str) {
 
 
 
-int
-osm_protobufdb_load(FILE *in, char *dir) {
+int osm_protobufdb_load(FILE *in, char *dir) {
     int size=BUFFER_SIZE;
     char buffer[size];
     char *p;

--- a/navit/maptool/osm_psql.c
+++ b/navit/maptool/osm_psql.c
@@ -27,8 +27,7 @@
 #ifdef HAVE_POSTGRESQL
 #include <postgresql/libpq-fe.h>
 
-int
-map_collect_data_osm_db(char *dbstr, struct maptool_osm *osm) {
+int map_collect_data_osm_db(char *dbstr, struct maptool_osm *osm) {
     PGconn *conn;
     PGresult *res;
     char query[256];

--- a/navit/maptool/osm_relations.c
+++ b/navit/maptool/osm_relations.c
@@ -40,14 +40,12 @@ struct relations_member {
     struct relations_func *func;
 };
 
-static guint
-relations_member_hash(gconstpointer key) {
+static guint relations_member_hash(gconstpointer key) {
     const struct relations_member *memb=key;
     return (memb->memberid >> 32)^(memb->memberid & 0xffffffff);
 }
 
-static gboolean
-relations_member_equal(gconstpointer a, gconstpointer b) {
+static gboolean relations_member_equal(gconstpointer a, gconstpointer b) {
     const struct relations_member *memba=a;
     const struct relations_member *membb=b;
     return (memba->memberid == membb->memberid);
@@ -72,8 +70,8 @@ relations_func_new(void (*func)(void *func_priv, void *relation_priv, struct ite
     return relations_func;
 }
 
-static struct relations_member *
-relations_member_new(struct relations_func *func, void *relation_priv, void *member_priv, osmid id) {
+static struct relations_member *relations_member_new(struct relations_func *func, void *relation_priv,
+        void *member_priv, osmid id) {
     struct relations_member *memb=g_new(struct relations_member, 1);
     memb->memberid=id;
     memb->relation_priv=relation_priv;
@@ -92,9 +90,8 @@ relations_member_new(struct relations_func *func, void *relation_priv, void *mem
  * @param in type Type of this member (node, way etc.).
  * @param in id OSM ID of relation member.
  */
-void
-relations_add_relation_member_entry(struct relations *rel, struct relations_func *func, void
-                                    *relation_priv, void *member_priv, enum relation_member_type type, osmid id) {
+void relations_add_relation_member_entry(struct relations *rel, struct relations_func *func, void
+        *relation_priv, void *member_priv, enum relation_member_type type, osmid id) {
     struct relations_member *memb=relations_member_new(func, relation_priv, member_priv, id);
     GHashTable *member_hash=rel->member_hash[type-1];
     // The real key is the OSM ID, but we recycle "memb" as key to avoid a second allocating for the key.
@@ -109,8 +106,7 @@ relations_add_relation_member_entry(struct relations *rel, struct relations_func
  * @param in rel relations collection to add the new member to
  * @param in func structure defining function to call when this member is read
  */
-void
-relations_add_relation_default_entry(struct relations *rel, struct relations_func *func) {
+void relations_add_relation_default_entry(struct relations *rel, struct relations_func *func) {
     struct relations_member *memb=relations_member_new(func, NULL, NULL, 0);
     rel->default_members=g_list_append(rel->default_members, memb);
 }
@@ -124,8 +120,7 @@ relations_add_relation_default_entry(struct relations *rel, struct relations_fun
  * @param in nodes file containing nodes in "coords.tmp" format
  * @param in ways file containing items in item_bin format. This file may contain both nodes, ways, and relations in that format.
  */
-void
-relations_process(struct relations *rel, FILE *nodes, FILE *ways) {
+void relations_process(struct relations *rel, FILE *nodes, FILE *ways) {
     char buffer[128];
     struct item_bin *ib=(struct item_bin *)buffer;
     osmid *id;
@@ -169,8 +164,7 @@ relations_process(struct relations *rel, FILE *nodes, FILE *ways) {
     }
 }
 
-static void
-relations_destroy_func(void *key, GList *l, void *data) {
+static void relations_destroy_func(void *key, GList *l, void *data) {
     GList *ll=l;
     while (ll) {
         g_free(ll->data);
@@ -179,8 +173,7 @@ relations_destroy_func(void *key, GList *l, void *data) {
     g_list_free(l);
 }
 
-void
-relations_destroy(struct relations *relations) {
+void relations_destroy(struct relations *relations) {
     int i;
 
     for (i = 0 ; i < 3 ; i++) {

--- a/navit/maptool/osm_xml.c
+++ b/navit/maptool/osm_xml.c
@@ -26,8 +26,7 @@
 #endif
 #include "maptool.h"
 
-int
-osm_xml_get_attribute(char *xml, char *attribute, char *buffer, int buffer_size) {
+int osm_xml_get_attribute(char *xml, char *attribute, char *buffer, int buffer_size) {
     int len=strlen(attribute);
     char *pos,*i,s,*attr;
     attr=g_alloca(len+2);
@@ -70,8 +69,7 @@ static struct entity {
     {"&#125;",'}'},
 };
 
-void
-osm_xml_decode_entities(char *buffer) {
+void osm_xml_decode_entities(char *buffer) {
     char *pos=buffer;
     int i,len;
 
@@ -88,8 +86,7 @@ osm_xml_decode_entities(char *buffer) {
     }
 }
 
-static int
-parse_tag(char *p) {
+static int parse_tag(char *p) {
     char k_buffer[BUFFER_SIZE];
     char v_buffer[BUFFER_SIZE];
     if (!osm_xml_get_attribute(p, "k", k_buffer, BUFFER_SIZE))
@@ -102,8 +99,7 @@ parse_tag(char *p) {
 }
 
 
-static int
-parse_node(char *p) {
+static int parse_node(char *p) {
     char id_buffer[BUFFER_SIZE];
     char lat_buffer[BUFFER_SIZE];
     char lon_buffer[BUFFER_SIZE];
@@ -118,8 +114,7 @@ parse_node(char *p) {
 }
 
 
-static int
-parse_way(char *p) {
+static int parse_way(char *p) {
     char id_buffer[BUFFER_SIZE];
     if (!osm_xml_get_attribute(p, "id", id_buffer, BUFFER_SIZE))
         return 0;
@@ -127,8 +122,7 @@ parse_way(char *p) {
     return 1;
 }
 
-static int
-parse_relation(char *p) {
+static int parse_relation(char *p) {
     char id_buffer[BUFFER_SIZE];
     if (!osm_xml_get_attribute(p, "id", id_buffer, BUFFER_SIZE))
         return 0;
@@ -136,8 +130,7 @@ parse_relation(char *p) {
     return 1;
 }
 
-static int
-parse_member(char *p) {
+static int parse_member(char *p) {
     char type_buffer[BUFFER_SIZE];
     char ref_buffer[BUFFER_SIZE];
     char role_buffer[BUFFER_SIZE];
@@ -163,8 +156,7 @@ parse_member(char *p) {
     return 1;
 }
 
-static int
-parse_nd(char *p) {
+static int parse_nd(char *p) {
     char ref_buffer[BUFFER_SIZE];
     if (!osm_xml_get_attribute(p, "ref", ref_buffer, BUFFER_SIZE))
         return 0;
@@ -172,13 +164,11 @@ parse_nd(char *p) {
     return 1;
 }
 
-static int
-xml_declaration_in_line(char* buffer) {
+static int xml_declaration_in_line(char* buffer) {
     return !strncmp(buffer, "<?xml ", 6);
 }
 
-int
-map_collect_data_osm(FILE *in, struct maptool_osm *osm) {
+int map_collect_data_osm(FILE *in, struct maptool_osm *osm) {
     int size=BUFFER_SIZE;
     char buffer[BUFFER_SIZE];
     char *p;

--- a/navit/maptool/sourcesink.c
+++ b/navit/maptool/sourcesink.c
@@ -38,25 +38,21 @@ item_bin_sink_func_new(int (*func)(struct item_bin_sink_func *func, struct item_
     return ret;
 }
 
-void
-item_bin_sink_func_destroy(struct item_bin_sink_func *func) {
+void item_bin_sink_func_destroy(struct item_bin_sink_func *func) {
     g_free(func);
 }
 
-void
-item_bin_sink_add_func(struct item_bin_sink *sink, struct item_bin_sink_func *func) {
+void item_bin_sink_add_func(struct item_bin_sink *sink, struct item_bin_sink_func *func) {
     sink->sink_funcs=g_list_append(sink->sink_funcs, func);
 }
 
-void
-item_bin_sink_destroy(struct item_bin_sink *sink) {
+void item_bin_sink_destroy(struct item_bin_sink *sink) {
     /* g_list_foreach(sink->sink_funcs, (GFunc)g_free, NULL); */
     g_list_free(sink->sink_funcs);
     g_free(sink);
 }
 
-int
-item_bin_write_to_sink(struct item_bin *ib, struct item_bin_sink *sink, struct tile_data *tile_data) {
+int item_bin_write_to_sink(struct item_bin *ib, struct item_bin_sink *sink, struct tile_data *tile_data) {
     GList *list=sink->sink_funcs;
     int ret=0;
     while (list) {
@@ -82,8 +78,7 @@ file_reader_new(FILE *in, int limit, int offset) {
     return ret;
 }
 
-int
-file_reader_finish(struct item_bin_sink *sink) {
+int file_reader_finish(struct item_bin_sink *sink) {
     struct item_bin *ib;
     int ret =0;
     FILE *in=sink->priv_data[0];
@@ -104,8 +99,7 @@ file_reader_finish(struct item_bin_sink *sink) {
     return 0;
 }
 
-int
-file_writer_process(struct item_bin_sink_func *func, struct item_bin *ib, struct tile_data *tile_data) {
+int file_writer_process(struct item_bin_sink_func *func, struct item_bin *ib, struct tile_data *tile_data) {
     FILE *out=func->priv_data[0];
     item_bin_write(ib, out);
     return 0;
@@ -121,15 +115,14 @@ file_writer_new(FILE *out) {
     return file_writer;
 }
 
-int
-file_writer_finish(struct item_bin_sink_func *file_writer) {
+int file_writer_finish(struct item_bin_sink_func *file_writer) {
     item_bin_sink_func_destroy(file_writer);
     return 0;
 }
 
 
-int
-tile_collector_process(struct item_bin_sink_func *tile_collector, struct item_bin *ib, struct tile_data *tile_data) {
+int tile_collector_process(struct item_bin_sink_func *tile_collector, struct item_bin *ib,
+                           struct tile_data *tile_data) {
     int *buffer,*buffer2;
     int len=ib->len+1;
     GHashTable *hash=tile_collector->priv_data[0];

--- a/navit/maptool/tempfile.c
+++ b/navit/maptool/tempfile.c
@@ -23,12 +23,10 @@
 #include "maptool.h"
 #include "debug.h"
 
-char *
-tempfile_name(char *suffix, char *name) {
+char *tempfile_name(char *suffix, char *name) {
     return g_strdup_printf("%s_%s.tmp",name, suffix);
 }
-FILE *
-tempfile(char *suffix, char *name, int mode) {
+FILE *tempfile(char *suffix, char *name, int mode) {
     char *buffer=tempfile_name(suffix, name);
     FILE *ret=NULL;
     switch (mode) {
@@ -46,15 +44,13 @@ tempfile(char *suffix, char *name, int mode) {
     return ret;
 }
 
-void
-tempfile_unlink(char *suffix, char *name) {
+void tempfile_unlink(char *suffix, char *name) {
     char buffer[4096];
     sprintf(buffer,"%s_%s.tmp",name, suffix);
     unlink(buffer);
 }
 
-void
-tempfile_rename(char *suffix, char *from, char *to) {
+void tempfile_rename(char *suffix, char *from, char *to) {
     char buffer_from[4096],buffer_to[4096];
     sprintf(buffer_from,"%s_%s.tmp",from,suffix);
     sprintf(buffer_to,"%s_%s.tmp",to,suffix);

--- a/navit/maptool/tile.c
+++ b/navit/maptool/tile.c
@@ -71,8 +71,7 @@ static char** th_get_subtile( const struct tile_head* th, int idx ) {
     return (char**)subtile_ptr;
 }
 
-int
-tile(struct rect *r, char *suffix, char *ret, int max, int overlap, struct rect *tr) {
+int tile(struct rect *r, char *suffix, char *ret, int max, int overlap, struct rect *tr) {
     int x0,x2,x4;
     int y0,y2,y4;
     int xo,yo;
@@ -136,8 +135,7 @@ tile(struct rect *r, char *suffix, char *ret, int max, int overlap, struct rect 
     return i;
 }
 
-void
-tile_bbox(char *tile, struct rect *r, int overlap) {
+void tile_bbox(char *tile, struct rect *r, int overlap) {
     struct coord c;
     int xo,yo;
     *r=world_bbox;
@@ -168,8 +166,7 @@ tile_bbox(char *tile, struct rect *r, int overlap) {
     }
 }
 
-int
-tile_len(char *tile) {
+int tile_len(char *tile) {
     int ret=0;
     while (tile[0] >= 'a' && tile[0] <= 'd') {
         tile++;
@@ -178,8 +175,7 @@ tile_len(char *tile) {
     return ret;
 }
 
-static void
-tile_extend(char *tile, struct item_bin *ib, GList **tiles_list) {
+static void tile_extend(char *tile, struct item_bin *ib, GList **tiles_list) {
     struct tile_head *th=NULL;
     if (debug_tile(tile))
         fprintf(stderr,"Tile:Writing %d bytes to '%s' (%p,%p) 0x%x "LONGLONG_FMT"\n", (ib->len+1)*4, tile,
@@ -214,8 +210,7 @@ tile_extend(char *tile, struct item_bin *ib, GList **tiles_list) {
     g_hash_table_insert(tile_hash, string_hash_lookup( th->name ), th);
 }
 
-static int
-tile_data_size(char *tile) {
+static int tile_data_size(char *tile) {
     struct tile_head *th;
     th=g_hash_table_lookup(tile_hash, tile);
     if (! th)
@@ -223,8 +218,7 @@ tile_data_size(char *tile) {
     return th->total_size;
 }
 
-static int
-merge_tile(char *base, char *sub) {
+static int merge_tile(char *base, char *sub) {
     struct tile_head *thb, *ths;
     thb=g_hash_table_lookup(tile_hash, base);
     ths=g_hash_table_lookup(tile_hash, sub);
@@ -251,18 +245,15 @@ merge_tile(char *base, char *sub) {
     return 1;
 }
 
-static gint
-get_tiles_list_cmp(gconstpointer s1, gconstpointer s2) {
+static gint get_tiles_list_cmp(gconstpointer s1, gconstpointer s2) {
     return strcmp((char *)s1, (char *)s2);
 }
 
-static void
-get_tiles_list_func(char *key, struct tile_head *th, GList **list) {
+static void get_tiles_list_func(char *key, struct tile_head *th, GList **list) {
     *list=g_list_prepend(*list, key);
 }
 
-static GList *
-get_tiles_list(void) {
+static GList *get_tiles_list(void) {
     GList *ret=NULL;
     g_hash_table_foreach(tile_hash, (GHFunc)get_tiles_list_func, &ret);
     ret=g_list_sort(ret, get_tiles_list_cmp);
@@ -270,8 +261,7 @@ get_tiles_list(void) {
 }
 
 #if 0
-static void
-write_tile(char *key, struct tile_head *th, gpointer dummy) {
+static void write_tile(char *key, struct tile_head *th, gpointer dummy) {
     FILE *f;
     char buffer[1024];
     fprintf(stderr,"DEBUG: Writing %s\n", key);
@@ -289,8 +279,7 @@ write_tile(char *key, struct tile_head *th, gpointer dummy) {
 }
 #endif
 
-static void
-write_item(char *tile, struct item_bin *ib, FILE *reference) {
+static void write_item(char *tile, struct item_bin *ib, FILE *reference) {
     struct tile_head *th;
     int size;
 
@@ -337,16 +326,14 @@ write_item(char *tile, struct item_bin *ib, FILE *reference) {
     }
 }
 
-void
-tile_write_item_to_tile(struct tile_info *info, struct item_bin *ib, FILE *reference, char *name) {
+void tile_write_item_to_tile(struct tile_info *info, struct item_bin *ib, FILE *reference, char *name) {
     if (info->write)
         write_item(name, ib, reference);
     else
         tile_extend(name, ib, info->tiles_list);
 }
 
-void
-tile_write_item_minmax(struct tile_info *info, struct item_bin *ib, FILE *reference, int min, int max) {
+void tile_write_item_minmax(struct tile_info *info, struct item_bin *ib, FILE *reference, int min, int max) {
     struct rect r;
     char buffer[1024];
     bbox((struct coord *)(ib+1), ib->clen/2, &r);
@@ -355,8 +342,7 @@ tile_write_item_minmax(struct tile_info *info, struct item_bin *ib, FILE *refere
     tile_write_item_to_tile(info, ib, reference, buffer);
 }
 
-int
-add_aux_tile(struct zip_info *zip_info, char *name, char *filename, int size) {
+int add_aux_tile(struct zip_info *zip_info, char *name, char *filename, int size) {
     struct aux_tile *at;
     GList *l;
     l=aux_tile_list;
@@ -376,8 +362,7 @@ add_aux_tile(struct zip_info *zip_info, char *name, char *filename, int size) {
     return zip_add_member(zip_info);
 }
 
-int
-write_aux_tiles(struct zip_info *zip_info) {
+int write_aux_tiles(struct zip_info *zip_info) {
     GList *l=aux_tile_list;
     struct aux_tile *at;
     char *buffer;
@@ -405,8 +390,7 @@ write_aux_tiles(struct zip_info *zip_info) {
     return count;
 }
 
-static int
-add_tile_hash(struct tile_head *th) {
+static int add_tile_hash(struct tile_head *th) {
     int idx,len,maxnamelen=0;
     char **data;
 
@@ -430,8 +414,7 @@ add_tile_hash(struct tile_head *th) {
 }
 
 
-int
-create_tile_hash(void) {
+int create_tile_hash(void) {
     struct tile_head *th;
     int len,maxnamelen=0;
 
@@ -446,8 +429,7 @@ create_tile_hash(void) {
     return maxnamelen;
 }
 
-static void
-create_tile_hash_list(GList *list) {
+static void create_tile_hash_list(GList *list) {
     GList *next;
     struct tile_head *th;
 
@@ -464,8 +446,7 @@ create_tile_hash_list(GList *list) {
     }
 }
 
-void
-load_tilesdir(FILE *in) {
+void load_tilesdir(FILE *in) {
     char tile[32],subtile[32],c;
     int size,zipnum=0;
     struct tile_head **last;
@@ -498,8 +479,7 @@ load_tilesdir(FILE *in) {
     *last=NULL;
 }
 
-void
-write_tilesdir(struct tile_info *info, struct zip_info *zip_info, FILE *out) {
+void write_tilesdir(struct tile_info *info, struct zip_info *zip_info, FILE *out) {
     int idx,len,maxlen;
     GList *next,*tiles_list;
     char **data;
@@ -558,8 +538,7 @@ write_tilesdir(struct tile_info *info, struct zip_info *zip_info, FILE *out) {
     }
 }
 
-void
-merge_tiles(struct tile_info *info) {
+void merge_tiles(struct tile_info *info) {
     struct tile_head *th;
     char basetile[1024];
     char subtile[1024];
@@ -630,8 +609,7 @@ merge_tiles(struct tile_info *info) {
 
 struct attr map_information_attrs[32];
 
-void
-index_init(struct zip_info *info, int version) {
+void index_init(struct zip_info *info, int version) {
     struct item_bin *item_bin;
     int i;
     map_information_attrs[0].type=attr_version;
@@ -645,8 +623,7 @@ index_init(struct zip_info *info, int version) {
     item_bin_write(item_bin, zip_get_index(info));
 }
 
-void
-index_submap_add(struct tile_info *info, struct tile_head *th) {
+void index_submap_add(struct tile_info *info, struct tile_head *th) {
     int tlen=tile_len(th->name);
     int len=tlen;
     char *index_tile;

--- a/navit/maptool/zip.c
+++ b/navit/maptool/zip.c
@@ -39,16 +39,14 @@ struct zip_info {
     FILE *dir;
 };
 
-static int
-zip_write(struct zip_info *info, void *data, int len) {
+static int zip_write(struct zip_info *info, void *data, int len) {
     if (fwrite(data, len, 1, info->res2) != 1)
         return 0;
     return 1;
 }
 
 #ifdef HAVE_ZLIB
-static int
-compress2_int(Byte *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int level) {
+static int compress2_int(Byte *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int level) {
     z_stream stream;
     int err;
 
@@ -77,8 +75,7 @@ compress2_int(Byte *dest, uLongf *destLen, const Bytef *source, uLong sourceLen,
 }
 #endif
 
-void
-write_zipmember(struct zip_info *zip_info, char *name, int filelen, char *data, int data_size) {
+void write_zipmember(struct zip_info *zip_info, char *name, int filelen, char *data, int data_size) {
     struct zip_lfh lfh = {
         0x04034b50,
         0x0a,
@@ -175,8 +172,7 @@ write_zipmember(struct zip_info *zip_info, char *name, int filelen, char *data, 
     g_free(compbuffer);
 }
 
-int
-zip_write_index(struct zip_info *info) {
+int zip_write_index(struct zip_info *info) {
     int size=ftell(info->index);
     char *buffer;
 
@@ -193,16 +189,14 @@ zip_write_index(struct zip_info *info) {
     return 0;
 }
 
-static void
-zip_write_file_data(struct zip_info *info, FILE *in) {
+static void zip_write_file_data(struct zip_info *info, FILE *in) {
     size_t size;
     char buffer[4096];
     while ((size=fread(buffer, 1, 4096, in)))
         zip_write(info, buffer, size);
 }
 
-int
-zip_write_directory(struct zip_info *info) {
+int zip_write_directory(struct zip_info *info) {
     struct zip_eoc eoc = {
         0x06054b50,
         0x0000,
@@ -261,34 +255,28 @@ zip_new(void) {
     return g_new0(struct zip_info, 1);
 }
 
-void
-zip_set_zip64(struct zip_info *info, int on) {
+void zip_set_zip64(struct zip_info *info, int on) {
     info->zip64=on;
 }
 
-void
-zip_set_compression_level(struct zip_info *info, int level) {
+void zip_set_compression_level(struct zip_info *info, int level) {
     info->compression_level=level;
 }
 
-void
-zip_set_maxnamelen(struct zip_info *info, int max) {
+void zip_set_maxnamelen(struct zip_info *info, int max) {
     info->maxnamelen=max;
 }
 
-int
-zip_get_maxnamelen(struct zip_info *info) {
+int zip_get_maxnamelen(struct zip_info *info) {
     return info->maxnamelen;
 }
 
-int
-zip_add_member(struct zip_info *info) {
+int zip_add_member(struct zip_info *info) {
     return info->zipnum++;
 }
 
 
-int
-zip_set_timestamp(struct zip_info *info, char *timestamp) {
+int zip_set_timestamp(struct zip_info *info, char *timestamp) {
     int year,month,day,hour,min,sec;
 
     if (sscanf(timestamp,"%d-%d-%dT%d:%d:%d",&year,&month,&day,&hour,&min,&sec) == 6) {
@@ -299,8 +287,7 @@ zip_set_timestamp(struct zip_info *info, char *timestamp) {
     return 0;
 }
 
-int
-zip_open(struct zip_info *info, char *out, char *dir, char *index) {
+int zip_open(struct zip_info *info, char *out, char *dir, char *index) {
     info->res2=fopen(out,"wb+");
     if(!info->res2) {
         fprintf(stderr,"Could not open output zip file %s\n", out);
@@ -319,29 +306,24 @@ zip_open(struct zip_info *info, char *out, char *dir, char *index) {
     return 1;
 }
 
-FILE *
-zip_get_index(struct zip_info *info) {
+FILE *zip_get_index(struct zip_info *info) {
     return info->index;
 }
 
-int
-zip_get_zipnum(struct zip_info *info) {
+int zip_get_zipnum(struct zip_info *info) {
     return info->zipnum;
 }
 
-void
-zip_set_zipnum(struct zip_info *info, int num) {
+void zip_set_zipnum(struct zip_info *info, int num) {
     info->zipnum=num;
 }
 
-void
-zip_close(struct zip_info *info) {
+void zip_close(struct zip_info *info) {
     fclose(info->index);
     fclose(info->dir);
     fclose(info->res2);
 }
 
-void
-zip_destroy(struct zip_info *info) {
+void zip_destroy(struct zip_info *info) {
     g_free(info);
 }

--- a/navit/maptype.c
+++ b/navit/maptype.c
@@ -26,9 +26,8 @@
 
 static struct maptype *maptype_root;
 
-void
-maptype_register(char *name, struct map_priv *(*map_new)(struct map_methods *meth, char *data, char **charset,
-                 enum projection *pro)) {
+void maptype_register(char *name, struct map_priv *(*map_new)(struct map_methods *meth, char *data, char **charset,
+                      enum projection *pro)) {
     struct maptype *mt;
     mt=g_new(struct maptype, 1);
     mt->name=g_strdup(name);

--- a/navit/menu.c
+++ b/navit/menu.c
@@ -36,8 +36,7 @@ menu_add(struct menu *menu, char *name, enum menu_type type, struct callback *cb
     return this;
 }
 
-void
-menu_popup(struct menu *menu) {
+void menu_popup(struct menu *menu) {
     if (! menu || ! menu->meth.popup)
         return;
     (*menu->meth.popup)(menu->priv);

--- a/navit/messages.c
+++ b/navit/messages.c
@@ -33,8 +33,7 @@ struct messagelist {
     struct event_timeout *msg_cleanup_to;		/**< Idle event to clean up the messages */
 };
 
-int
-message_new(struct messagelist *this_, const char *message) {
+int message_new(struct messagelist *this_, const char *message) {
     struct message *msg;
 
     msg = g_new0(struct message, 1);
@@ -48,8 +47,7 @@ message_new(struct messagelist *this_, const char *message) {
     return msg->id;
 }
 
-int
-message_delete(struct messagelist *this_, int mid) {
+int message_delete(struct messagelist *this_, int mid) {
     struct message *msg,*last;;
 
     msg = this_->messages;
@@ -80,8 +78,7 @@ message_delete(struct messagelist *this_, int mid) {
     }
 }
 
-static void
-message_cleanup(struct messagelist *this_) {
+static void message_cleanup(struct messagelist *this_) {
     struct message *msg,*next,*prev=NULL;
     int i;
     time_t now;
@@ -137,8 +134,7 @@ struct messagelist
     return this;
 }
 
-void
-messagelist_init(struct messagelist *this_) {
+void messagelist_init(struct messagelist *this_) {
     if (!event_system())
         return;
     this_->msg_cleanup_cb = callback_new_1(callback_cast(message_cleanup), this_);

--- a/navit/navigation.c
+++ b/navit/navigation.c
@@ -374,8 +374,7 @@ static void navigation_flush(struct navigation *this_);
  * @param angle2 The second angle
  * @return The difference between the angles, see description
  */
-static int
-angle_delta(int angle1, int angle2) {
+static int angle_delta(int angle1, int angle2) {
     int delta=angle2-angle1;
     if (delta <= -180)
         delta+=360;
@@ -384,8 +383,7 @@ angle_delta(int angle1, int angle2) {
     return delta;
 }
 
-static int
-angle_median(int angle1, int angle2) {
+static int angle_median(int angle1, int angle2) {
     int delta=angle_delta(angle1, angle2);
     int ret=angle1+delta/2;
     if (ret < 0)
@@ -395,8 +393,7 @@ angle_median(int angle1, int angle2) {
     return ret;
 }
 
-static int
-angle_opposite(int angle) {
+static int angle_opposite(int angle) {
     return ((angle+180)%360);
 }
 
@@ -414,8 +411,7 @@ angle_opposite(int angle) {
  * @param new_name_systematic The systematic name of the second item to be checked
  * @return True if both old and new are on the same street
  */
-static int
-is_same_street2(char *old_name, char *old_name_systematic, char *new_name, char *new_name_systematic) {
+static int is_same_street2(char *old_name, char *old_name_systematic, char *new_name, char *new_name_systematic) {
     if (old_name && new_name && !strcmp(old_name, new_name)) {
         dbg(lvl_debug,"is_same_street: '%s' '%s' vs '%s' '%s' yes (1.)", old_name_systematic, new_name_systematic, old_name,
             new_name);
@@ -449,8 +445,7 @@ is_same_street2(char *old_name, char *old_name_systematic, char *new_name, char 
  * Note that way geometry (other than {@code angle2}) is not compared. If necessary, the caller needs to
  * make geometry-related comparisons separately.
  */
-static int
-is_same_way(struct navigation_way * w1, struct navigation_way * w2) {
+static int is_same_way(struct navigation_way * w1, struct navigation_way * w2) {
     if (!is_same_street2(w1->name, w1->name_systematic, w2->name, w2->name_systematic))
         return 0;
     if ((w1->angle2 == w2->angle2) && (w1->item.type == w2->item.type))
@@ -465,8 +460,7 @@ is_same_way(struct navigation_way * w1, struct navigation_way * w2) {
  *
  * @param list the list to be freed
  */
-static void
-free_list(struct street_destination *list) {
+static void free_list(struct street_destination *list) {
 
     if (list) {
         struct street_destination *clist;
@@ -491,8 +485,7 @@ free_list(struct street_destination *list) {
  * @param sep a char to be used as separator to split the raw_string
  * @return the number of entries in the list
  */
-static int
-split_string_to_list(struct navigation_way *way, char* raw_string, char sep) {
+static int split_string_to_list(struct navigation_way *way, char* raw_string, char sep) {
 
     struct street_destination *new_street_destination = NULL;
     struct street_destination *next_street_destination_remember = NULL;
@@ -537,8 +530,7 @@ split_string_to_list(struct navigation_way *way, char* raw_string, char sep) {
  *
  * If all items in the list have a zero rank, the first one will be returned.
  */
-static struct street_destination *
-get_bestranked(struct street_destination *street_destination) {
+static struct street_destination *get_bestranked(struct street_destination *street_destination) {
     struct street_destination *selected_street_destination;
 
     selected_street_destination = street_destination;
@@ -558,8 +550,7 @@ get_bestranked(struct street_destination *street_destination) {
  * @param command
  * @return 1 if successful, zero otherwise
  */
-static int
-set_highrank(struct street_destination *street_destination, struct navigation_command *command) {
+static int set_highrank(struct street_destination *street_destination, struct navigation_command *command) {
     struct street_destination *future_street_destination = NULL;
     struct navigation_command *next_command;
     char* destination_string;
@@ -599,8 +590,7 @@ set_highrank(struct street_destination *street_destination, struct navigation_co
  *         command items so that the destination name has a relevance over several announcements. If there is no 'winner'
  *         the entry is selected that is at top of the destination.
  */
-static char*
-select_announced_destinations(struct navigation_command *current_command) {
+static char* select_announced_destinations(struct navigation_command *current_command) {
     struct street_destination *current_destination =
             NULL;  /* the list pointer of the destination_names of the current command. */
     struct street_destination *search_destination =
@@ -715,8 +705,7 @@ char *nav_status_to_text(int status) {
 }
 
 
-int
-navigation_get_attr(struct navigation *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int navigation_get_attr(struct navigation *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     struct map_rect *mr;
     struct item *item;
     dbg(lvl_debug,"enter %s", attr_to_name(type));
@@ -760,8 +749,7 @@ navigation_get_attr(struct navigation *this_, enum attr_type type, struct attr *
     return 1;
 }
 
-static void
-navigation_set_turnaround(struct navigation *this_, int val) {
+static void navigation_set_turnaround(struct navigation *this_, int val) {
     if (this_->turn_around_count != val) {
         struct attr attr=ATTR_INT(turn_around_count, val);
         this_->turn_around_count=val;
@@ -769,8 +757,7 @@ navigation_set_turnaround(struct navigation *this_, int val) {
     }
 }
 
-int
-navigation_set_attr(struct navigation *this_, struct attr *attr) {
+int navigation_set_attr(struct navigation *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_speech:
         this_->speech=attr->u.speech;
@@ -818,8 +805,7 @@ navigation_new(struct attr *parent, struct attr **attrs) {
     return ret;
 }
 
-int
-navigation_set_announce(struct navigation *this_, enum item_type type, int *level) {
+int navigation_set_announce(struct navigation *this_, enum item_type type, int *level) {
     int i;
     if (type < route_item_first || type > route_item_last) {
         dbg(lvl_debug,"street type %d out of range [%d,%d]", type, route_item_first, route_item_last);
@@ -830,8 +816,7 @@ navigation_set_announce(struct navigation *this_, enum item_type type, int *leve
     return 1;
 }
 
-static enum announcement_level
-navigation_get_announce_level(struct navigation *this_, enum item_type type, int dist) {
+static enum announcement_level navigation_get_announce_level(struct navigation *this_, enum item_type type, int dist) {
     enum announcement_level level;
 
     if (type < route_item_first || type > route_item_last) {
@@ -847,9 +832,9 @@ navigation_get_announce_level(struct navigation *this_, enum item_type type, int
 
 static int is_way_allowed(struct navigation *nav, struct navigation_way *way, int mode);
 
-static enum announcement_level
-navigation_get_announce_level_cmd(struct navigation *this_, struct navigation_itm *itm, struct navigation_command *cmd,
-                                  int distance) {
+static enum announcement_level navigation_get_announce_level_cmd(struct navigation *this_, struct navigation_itm *itm,
+        struct navigation_command *cmd,
+        int distance) {
     enum announcement_level level2,level=navigation_get_announce_level(this_, itm->way.item.type, distance);
     if (this_->cmd_first->itm->prev) {
         level2=navigation_get_announce_level(this_, cmd->itm->prev->way.item.type, distance);
@@ -870,8 +855,7 @@ navigation_get_announce_level_cmd(struct navigation *this_, struct navigation_it
  *
  * @return The bearing in degrees, {@code 0 <= result < 360}.
  */
-static int
-road_angle(struct coord *c1, struct coord *c2, int dir) {
+static int road_angle(struct coord *c1, struct coord *c2, int dir) {
     int ret=transform_get_angle_delta(c1, c2, dir);
     dbg(lvl_debug, "road_angle(0x%x,0x%x - 0x%x,0x%x)=%d", c1->x, c1->y, c2->x, c2->y, ret);
     return ret;
@@ -923,8 +907,7 @@ static const char
     }
 }
 
-static int
-round_distance(int dist) {
+static int round_distance(int dist) {
     if (dist < 100) {
         dist=(dist+5)/10;
         return dist*10;
@@ -957,8 +940,7 @@ round_distance(int dist) {
 *   @param  dist       The distance to be processed
 *   @return distance   Simplified distance value
 */
-static int
-round_distance_reduced( int dist ) {
+static int round_distance_reduced( int dist ) {
     int factor = 1;
     if (dist > distances[LAST_DISTANCE]) {
         dist=(dist+500)/1000;
@@ -992,8 +974,7 @@ round_distance_reduced( int dist ) {
 *   @param is_length   1 for length statement, 0 for distance statement.
 *   @return            String with length/distance statement.
 */
-static char *
-get_distance_str(struct navigation *nav, int dist_meters, enum attr_type type, int is_length) {
+static char *get_distance_str(struct navigation *nav, int dist_meters, enum attr_type type, int is_length) {
     int imperial=0,vocabulary=1; /* default configuration */
 
     /* Get configuration */
@@ -1094,8 +1075,7 @@ get_distance_str(struct navigation *nav, int dist_meters, enum attr_type type, i
  * @param w The way to initialize. The {@code item}, {@code id_hi}, {@code id_lo} and {@code dir}
  * members of this struct must be set prior to calling this function.
  */
-static void
-navigation_way_init(struct navigation_way *w) {
+static void navigation_way_init(struct navigation_way *w) {
     struct coord cbuf[2];
     struct item *realitem;
     struct coord c;
@@ -1189,8 +1169,8 @@ navigation_way_init(struct navigation_way *w) {
  *
  * @return The delta, {@code -180 < delta <= 180}, or {@code invalid_angle} if an error occurred.
  */
-static int
-navigation_way_get_max_delta(struct navigation_way *w, enum projection pro, int angle, double dist, int dir) {
+static int navigation_way_get_max_delta(struct navigation_way *w, enum projection pro, int angle, double dist,
+                                        int dir) {
     double dist_left = dist; /* distance from last examined point */
     int ret = invalid_angle;
     int tmp_delta;
@@ -1270,8 +1250,7 @@ navigation_way_get_max_delta(struct navigation_way *w, enum projection pro, int 
  *
  * @param itm The item that should have its ways cleared
  */
-static void
-navigation_itm_ways_clear(struct navigation_itm *itm) {
+static void navigation_itm_ways_clear(struct navigation_itm *itm) {
     struct navigation_way *c,*n;
 
     c = itm->way.next;
@@ -1295,8 +1274,7 @@ navigation_itm_ways_clear(struct navigation_itm *itm) {
  * @param itm The item that should be updated
  * @param graph_map The route graph's map that these items are on
  */
-static void
-navigation_itm_ways_update(struct navigation_itm *itm, struct map *graph_map) {
+static void navigation_itm_ways_update(struct navigation_itm *itm, struct map *graph_map) {
     struct map_selection coord_sel;
     struct map_rect *g_rect; /* Contains a map rectangle from the route graph's map */
     struct item *i,*sitem;
@@ -1389,8 +1367,7 @@ navigation_itm_ways_update(struct navigation_itm *itm, struct map *graph_map) {
  * @param end The first navigation item to keep. If it is NULL or not found in the list, all items
  * will be destroyed.
  */
-static void
-navigation_destroy_itms_cmds(struct navigation *this_, struct navigation_itm *end) {
+static void navigation_destroy_itms_cmds(struct navigation *this_, struct navigation_itm *end) {
     struct navigation_itm *itm;
     struct navigation_command *cmd;
     dbg(lvl_info,"enter this_=%p this_->first=%p this_->cmd_first=%p end=%p", this_, this_->first, this_->cmd_first, end);
@@ -1429,8 +1406,7 @@ navigation_destroy_itms_cmds(struct navigation *this_, struct navigation_itm *en
     dbg(lvl_info,"ret this_->first=%p this_->cmd_first=%p",this_->first, this_->cmd_first);
 }
 
-static void
-navigation_itm_update(struct navigation_itm *itm, struct item *ritem) {
+static void navigation_itm_update(struct navigation_itm *itm, struct item *ritem) {
     struct attr length, time, speed;
 
     if (! item_attr_get(ritem, attr_length, &length)) {
@@ -1468,8 +1444,7 @@ navigation_itm_update(struct navigation_itm *itm, struct item *ritem) {
  * @param routeitem the routeitem from which to create a navigation item
  * @return the new navigation_itm (used nowhere)
  */
-static struct navigation_itm *
-navigation_itm_new(struct navigation *this_, struct item *routeitem) {
+static struct navigation_itm *navigation_itm_new(struct navigation *this_, struct item *routeitem) {
     struct navigation_itm *ret=g_new0(struct navigation_itm, 1);
     int i=0;
     struct item *streetitem;
@@ -1666,8 +1641,8 @@ navigation_itm_new(struct navigation *this_, struct item *routeitem) {
  * @param direction Set to < 0 to count turns to the left >= 0 for turns to the right
  * @return The number of possibilities to turn or -1 on error
  */
-static int
-count_possible_turns(struct navigation *nav, struct navigation_itm *from, struct navigation_itm *to, int direction) {
+static int count_possible_turns(struct navigation *nav, struct navigation_itm *from, struct navigation_itm *to,
+                                int direction) {
     int count;
     struct navigation_itm *curr;
     struct navigation_way *w;
@@ -1714,8 +1689,7 @@ count_possible_turns(struct navigation *nav, struct navigation_itm *from, struct
  * @param this_ The navigation whose destination / time should be calculated
  * @param incr Set this to true to only calculate the first item. See description.
  */
-static void
-calculate_dest_distance(struct navigation *this_, int incr) {
+static void calculate_dest_distance(struct navigation *this_, int incr) {
     int len=0, time=0, count=0;
     struct navigation_itm *next,*itm=this_->last;
     dbg(lvl_debug, "enter this_=%p, incr=%d", this_, incr);
@@ -1809,8 +1783,7 @@ static int maneuver_category(enum item_type type) {
 *
 */
 
-static int
-is_way_allowed(struct navigation *nav, struct navigation_way *way, int mode) {
+static int is_way_allowed(struct navigation *nav, struct navigation_way *way, int mode) {
     if (!nav->vehicleprofile || !way->flags)
         return 1;
     if (mode)
@@ -1833,8 +1806,7 @@ is_way_allowed(struct navigation *nav, struct navigation_way *way, int mode) {
  * @param extended Whether to consider ramps and service roads to be motorway-like
  * @return True for motorway-like, false otherwise
  */
-static int
-is_motorway_like(struct navigation_way *way, int extended) {
+static int is_motorway_like(struct navigation_way *way, int extended) {
     if ((way->item.type == type_highway_land) || (way->item.type == type_highway_city)
             || ((way->item.type == type_street_n_lanes) && (way->flags & AF_ONEWAYMASK)))
         return 1;
@@ -1849,8 +1821,7 @@ is_motorway_like(struct navigation_way *way, int extended) {
  * @param way The way to be examined
  * @return True for ramp, false otherwise
  */
-static int
-is_ramp(struct navigation_way *way) {
+static int is_ramp(struct navigation_way *way) {
     if (way->item.type == type_ramp)
         return 1;
     return 0;
@@ -1870,9 +1841,8 @@ is_ramp(struct navigation_way *way) {
  * for freeing up the buffer once it is no longer needed.
  * @return True if navit should guide the user, false otherwise
  */
-static int
-maneuver_required2 (struct navigation *nav, struct navigation_itm *old, struct navigation_itm *new,
-                    struct navigation_maneuver **maneuver) {
+static int maneuver_required2 (struct navigation *nav, struct navigation_itm *old, struct navigation_itm *new,
+                               struct navigation_maneuver **maneuver) {
     struct navigation_maneuver m; /* if the function returns true, this will be passed in the maneuver argument */
     struct navigation_itm
         *ni; /* temporary navigation item used for comparisons that examine previous or subsequent maneuvers */
@@ -2624,8 +2594,8 @@ static void navigation_analyze_roundabout(struct navigation *this_, struct navig
  *
  * @return The new command
  */
-static struct navigation_command *
-command_new(struct navigation *this_, struct navigation_itm *itm, struct navigation_maneuver *maneuver) {
+static struct navigation_command *command_new(struct navigation *this_, struct navigation_itm *itm,
+        struct navigation_maneuver *maneuver) {
     struct navigation_command *ret=g_new0(struct navigation_command, 1);
     struct navigation_way *w;	/* the way in which to turn. */
     int more_ways_for_strength = 0;	/* Counts the number of ways of the current node that turn
@@ -2810,8 +2780,7 @@ command_new(struct navigation *this_, struct navigation_itm *itm, struct navigat
  * @param this_ The navigation object for which to create turn instructions
  * @param route Not used
  */
-static void
-make_maneuvers(struct navigation *this_, struct route *route) {
+static void make_maneuvers(struct navigation *this_, struct route *route) {
     struct navigation_itm *itm, *last=NULL, *last_itm=NULL;
     struct navigation_maneuver *maneuver;
     itm=this_->first;
@@ -2832,8 +2801,7 @@ make_maneuvers(struct navigation *this_, struct route *route) {
     command_new(this_, last_itm, maneuver);
 }
 
-static int
-contains_suffix(char *name, char *suffix) {
+static int contains_suffix(char *name, char *suffix) {
     if (!suffix)
         return 0;
     if (strlen(name) < strlen(suffix))
@@ -2843,8 +2811,7 @@ contains_suffix(char *name, char *suffix) {
 
 
 
-static char *
-replace_suffix(char *name, char *search, char *replace) {
+static char *replace_suffix(char *name, char *search, char *replace) {
     int len=strlen(name)-strlen(search);
     char *ret=g_malloc(len+strlen(replace)+1);
     strncpy(ret, name, len);
@@ -2868,9 +2835,9 @@ replace_suffix(char *name, char *search, char *replace) {
  *             the {@code navigation_item} associated with the previous {@code navigation_command}
  * @param prefix A space will be added as a prefix to the string returned, or a null string for no prefix
  */
-static char *
-navigation_item_destination(struct navigation *nav, struct navigation_command *cmd, struct navigation_itm *next,
-                            char *prefix) {
+static char *navigation_item_destination(struct navigation *nav, struct navigation_command *cmd,
+        struct navigation_itm *next,
+        char *prefix) {
     char *ret  = NULL, *name1 = NULL, *sep = "", *name2 = "";
     char *name = NULL, *name_systematic=NULL;
     int i, gender = unknown;
@@ -3021,8 +2988,7 @@ navigation_item_destination(struct navigation *nav, struct navigation_command *c
  * @param street_destination_announce The name of the street following the maneuver. This argument
  * may be NULL, in which case the exit name will not be suppressed.
  */
-static char *
-navigation_cmd_get_exit_announce(struct navigation_command *this_, char *street_destination_announce) {
+static char *navigation_cmd_get_exit_announce(struct navigation_command *this_, char *street_destination_announce) {
     char * ret = NULL;
     char *folded_exit_label=NULL;
     char *folded_street_destination_announce=NULL;
@@ -3069,9 +3035,9 @@ navigation_cmd_get_exit_announce(struct navigation_command *this_, char *street_
  * @param connect Whether this is the second of two connected announcements, as in "turn left
  * in..., then turn right"
  */
-static char *
-show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd, enum attr_type type,
-              enum announcement_level level) {
+static char *show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd,
+                           enum attr_type type,
+                           enum announcement_level level) {
 
     int distance=itm->dest_length-cmd->itm->dest_length;
     char *d=NULL,*ret=NULL;
@@ -3492,9 +3458,8 @@ show_maneuver(struct navigation *nav, struct navigation_itm *itm, struct navigat
  *
  * @return An announcement that should be made
  */
-static char *
-show_next_maneuvers(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd,
-                    enum attr_type type) {
+static char *show_next_maneuvers(struct navigation *nav, struct navigation_itm *itm, struct navigation_command *cmd,
+                                 enum attr_type type) {
     int distance = itm->dest_length
                    -cmd->itm->dest_length; /* distance from e.g. current GPS position to next announced turn position */
     enum announcement_level level;
@@ -3554,8 +3519,7 @@ show_next_maneuvers(struct navigation *nav, struct navigation_itm *itm, struct n
     return ret;
 }
 
-static void
-navigation_call_callbacks(struct navigation *this_, int force_speech) {
+static void navigation_call_callbacks(struct navigation *this_, int force_speech) {
     int distance, level = 0;
     void *p=this_;
     if (!this_->cmd_first)
@@ -3628,8 +3592,7 @@ navigation_call_callbacks(struct navigation *this_, int force_speech) {
  * @param cancel If true, only cleanup (deallocation of objects) will be done and no maneuvers will be generated.
  * If false, maneuvers will be generated.
  */
-static void
-navigation_update_done(struct navigation *this_, int cancel) {
+static void navigation_update_done(struct navigation *this_, int cancel) {
     int incr = 0;
     struct map_rect *mr = this_->route_mr;
     struct attr nav_status;
@@ -3676,8 +3639,7 @@ navigation_update_done(struct navigation *this_, int cancel) {
  * {@code route_mr} member. After processing completes, the {@code route_mr} member will no longer
  * be valid.
  */
-static void
-navigation_update_idle(struct navigation *this_) {
+static void navigation_update_idle(struct navigation *this_) {
     int count = 100;            /* Maximum number of items retrieved in one run of this function.
 	                             * This should be set low enough for each pass to complete in less
 	                             * than a second even on low-performance devices. */
@@ -3746,8 +3708,7 @@ navigation_update_idle(struct navigation *this_) {
  * @param route The route
  * @param attr The route status attribute
  */
-static void
-navigation_update(struct navigation *this_, struct route *route, struct attr *attr) {
+static void navigation_update(struct navigation *this_, struct route *route, struct attr *attr) {
     struct map *map;
     struct attr vehicleprofile;
     struct attr nav_status;
@@ -3812,14 +3773,12 @@ navigation_update(struct navigation *this_, struct route *route, struct attr *at
     }
 }
 
-static void
-navigation_flush(struct navigation *this_) {
+static void navigation_flush(struct navigation *this_) {
     navigation_destroy_itms_cmds(this_, NULL);
 }
 
 
-void
-navigation_destroy(struct navigation *this_) {
+void navigation_destroy(struct navigation *this_) {
     navigation_flush(this_);
     item_hash_destroy(this_->hash);
     callback_list_destroy(this_->callback);
@@ -3851,8 +3810,7 @@ navigation_destroy(struct navigation *this_) {
  *
  * @return true on success, false on failure
  */
-int
-navigation_register_callback(struct navigation *this_, enum attr_type type, struct callback *cb) {
+int navigation_register_callback(struct navigation *this_, enum attr_type type, struct callback *cb) {
     struct attr attr_cbl;
 
     if (type == attr_navigation_speech)
@@ -3880,8 +3838,7 @@ navigation_register_callback(struct navigation *this_, enum attr_type type, stru
  * @param type The attribute type
  * @param cb The callback function
  */
-void
-navigation_unregister_callback(struct navigation *this_, enum attr_type type, struct callback *cb) {
+void navigation_unregister_callback(struct navigation *this_, enum attr_type type, struct callback *cb) {
     struct attr attr_cbl;
 
     if (type == attr_navigation_speech)
@@ -3936,8 +3893,7 @@ struct map_rect_priv {
     char *str;
 };
 
-static int
-navigation_map_item_coord_get(void *priv_data, struct coord *c, int count) {
+static int navigation_map_item_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *this=priv_data;
     if (this->ccount || ! count)
         return 0;
@@ -3946,15 +3902,13 @@ navigation_map_item_coord_get(void *priv_data, struct coord *c, int count) {
     return 1;
 }
 
-static void
-navigation_map_item_coord_rewind(void *priv_data) {
+static void navigation_map_item_coord_rewind(void *priv_data) {
     struct map_rect_priv *this=priv_data;
     this->ccount=0;
 }
 
 
-static int
-navigation_map_item_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int navigation_map_item_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *this_=priv_data;
     struct navigation_command *cmd=this_->cmd;
     struct navigation_maneuver *maneuver = NULL;
@@ -4171,8 +4125,7 @@ navigation_map_item_attr_get(void *priv_data, enum attr_type attr_type, struct a
     }
 }
 
-static void
-navigation_map_item_attr_rewind(void *priv_data) {
+static void navigation_map_item_attr_rewind(void *priv_data) {
     struct map_rect_priv *priv = priv_data;
     priv->debug_idx=0;
     priv->attr_next=attr_navigation_short;
@@ -4186,19 +4139,16 @@ static struct item_methods navigation_map_item_methods = {
 };
 
 
-static void
-navigation_map_destroy(struct map_priv *priv) {
+static void navigation_map_destroy(struct map_priv *priv) {
     g_free(priv);
 }
 
-static void
-navigation_map_rect_init(struct map_rect_priv *priv) {
+static void navigation_map_rect_init(struct map_rect_priv *priv) {
     priv->cmd_next=priv->nav->cmd_first;
     priv->cmd_itm_next=priv->itm_next=priv->nav->first;
 }
 
-static struct map_rect_priv *
-navigation_map_rect_new(struct map_priv *priv, struct map_selection *sel) {
+static struct map_rect_priv *navigation_map_rect_new(struct map_priv *priv, struct map_selection *sel) {
     struct navigation *nav=priv->navigation;
     struct map_rect_priv *ret=g_new0(struct map_rect_priv, 1);
     ret->nav=nav;
@@ -4211,8 +4161,7 @@ navigation_map_rect_new(struct map_priv *priv, struct map_selection *sel) {
     return ret;
 }
 
-static void
-navigation_map_rect_destroy(struct map_rect_priv *priv) {
+static void navigation_map_rect_destroy(struct map_rect_priv *priv) {
     g_free(priv->str);
     g_free(priv);
 }
@@ -4237,8 +4186,7 @@ navigation_map_rect_destroy(struct map_rect_priv *priv) {
  *
  * @return The item, or NULL if there are no more items in the map rectangle
  */
-static struct item *
-navigation_map_get_item(struct map_rect_priv *priv) {
+static struct item *navigation_map_get_item(struct map_rect_priv *priv) {
     struct item *ret=&priv->item;
     if (!priv->itm_next)
         return NULL;
@@ -4312,8 +4260,7 @@ navigation_map_get_item(struct map_rect_priv *priv) {
  *
  * @return The item, or NULL if an item with the ID specified was not found in the map rectangle
  */
-static struct item *
-navigation_map_get_item_byid(struct map_rect_priv *priv, int id_hi, int id_lo) {
+static struct item *navigation_map_get_item_byid(struct map_rect_priv *priv, int id_hi, int id_lo) {
     struct item *ret;
     navigation_map_rect_init(priv);
     while ((ret=navigation_map_get_item(priv))) {
@@ -4336,8 +4283,7 @@ static struct map_methods navigation_map_meth = {
     NULL,
 };
 
-static struct map_priv *
-navigation_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *navigation_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *ret;
     struct attr *navigation_attr;
 
@@ -4351,8 +4297,7 @@ navigation_map_new(struct map_methods *meth, struct attr **attrs, struct callbac
     return ret;
 }
 
-void
-navigation_set_route(struct navigation *this_, struct route *route) {
+void navigation_set_route(struct navigation *this_, struct route *route) {
     struct attr callback;
     if (!this_->route_cb)
         this_->route_cb=callback_new_attr_1(callback_cast(navigation_update), attr_route_status, this_);
@@ -4369,8 +4314,7 @@ navigation_set_route(struct navigation *this_, struct route *route) {
     }
 }
 
-void
-navigation_init(void) {
+void navigation_init(void) {
     plugin_register_category_map("navigation", navigation_map_new);
 }
 

--- a/navit/navit.c
+++ b/navit/navit.c
@@ -207,8 +207,7 @@ struct object_func navit_func;
 
 struct navit *global_navit;
 
-void
-navit_add_mapset(struct navit *this_, struct mapset *ms) {
+void navit_add_mapset(struct navit *this_, struct mapset *ms) {
     this_->mapsets = g_list_append(this_->mapsets, ms);
 }
 
@@ -237,8 +236,7 @@ navit_get_tracking(struct navit *this_) {
  * destination.txt, bookmark.txt, ...)
  *
  */
-char*
-navit_get_user_data_directory(int create) {
+char* navit_get_user_data_directory(int create) {
     char *dir;
     dir = getenv("NAVIT_USER_DATADIR");
     if (create && !file_exists(dir)) {
@@ -252,8 +250,7 @@ navit_get_user_data_directory(int create) {
 }
 
 
-void
-navit_draw_async(struct navit *this_, int async) {
+void navit_draw_async(struct navit *this_, int async) {
 
     if (this_->blocked) {
         this_->blocked |= 2;
@@ -264,27 +261,23 @@ navit_draw_async(struct navit *this_, int async) {
                   this_->graphics_flags|1);
 }
 
-void
-navit_draw(struct navit *this_) {
+void navit_draw(struct navit *this_) {
     if (this_->ready == 3)
         navit_draw_async(this_, 0);
 }
 
-int
-navit_get_ready(struct navit *this_) {
+int navit_get_ready(struct navit *this_) {
     return this_->ready;
 }
 
 
 
-void
-navit_draw_displaylist(struct navit *this_) {
+void navit_draw_displaylist(struct navit *this_) {
     if (this_->ready == 3)
         graphics_displaylist_draw(this_->gra, this_->displaylist, this_->trans, this_->layout_current, this_->graphics_flags|1);
 }
 
-static void
-navit_map_progress(struct navit *this_) {
+static void navit_map_progress(struct navit *this_) {
     struct map *map;
     struct mapset *ms;
     struct mapset_handle *msh;
@@ -310,8 +303,7 @@ navit_map_progress(struct navit *this_) {
     mapset_close(msh);
 }
 
-static void
-navit_redraw_route(struct navit *this_, struct route *route, struct attr *attr) {
+static void navit_redraw_route(struct navit *this_, struct route *route, struct attr *attr) {
     int updated;
     if (attr->type != attr_route_status)
         return;
@@ -329,8 +321,7 @@ navit_redraw_route(struct navit *this_, struct route *route, struct attr *attr) 
     navit_draw(this_);
 }
 
-void
-navit_handle_resize(struct navit *this_, int w, int h) {
+void navit_handle_resize(struct navit *this_, int w, int h) {
     struct map_selection sel;
     int callback=(this_->ready == 1);
     this_->ready |= 2;
@@ -348,26 +339,22 @@ navit_handle_resize(struct navit *this_, int w, int h) {
         navit_draw_async(this_, 1);
 }
 
-static void
-navit_resize(void *data, int w, int h) {
+static void navit_resize(void *data, int w, int h) {
     struct navit *this=data;
     if (!this->ignore_graphics_events)
         navit_handle_resize(this, w, h);
 }
 
-int
-navit_get_width(struct navit *this_) {
+int navit_get_width(struct navit *this_) {
     return this_->w;
 }
 
 
-int
-navit_get_height(struct navit *this_) {
+int navit_get_height(struct navit *this_) {
     return this_->h;
 }
 
-static void
-navit_popup(void *data) {
+static void navit_popup(void *data) {
     struct navit *this_=data;
     popup(this_, 1, &this_->pressed);
     this_->button_timeout=NULL;
@@ -389,21 +376,18 @@ navit_popup(void *data) {
  * @param this_ The navit instance
  * @return {@code true} if the caller should ignore the button event, {@code false} if it should handle it
  */
-int
-navit_ignore_button(struct navit *this_) {
+int navit_ignore_button(struct navit *this_) {
     if (this_->ignore_button)
         return 1;
     this_->ignore_button=1;
     return 0;
 }
 
-void
-navit_ignore_graphics_events(struct navit *this_, int ignore) {
+void navit_ignore_graphics_events(struct navit *this_, int ignore) {
     this_->ignore_graphics_events=ignore;
 }
 
-static int
-navit_restrict_to_range(int value, int min, int max) {
+static int navit_restrict_to_range(int value, int min, int max) {
     if (value>max) {
         value = max;
     }
@@ -413,8 +397,7 @@ navit_restrict_to_range(int value, int min, int max) {
     return value;
 }
 
-static void
-navit_restrict_map_center_to_world_boundingbox(struct transformation *tr, struct coord *new_center) {
+static void navit_restrict_map_center_to_world_boundingbox(struct transformation *tr, struct coord *new_center) {
     new_center->x = navit_restrict_to_range(new_center->x, WORLD_BOUNDINGBOX_MIN_X, WORLD_BOUNDINGBOX_MAX_X);
     new_center->y = navit_restrict_to_range(new_center->y, WORLD_BOUNDINGBOX_MIN_Y, WORLD_BOUNDINGBOX_MAX_Y);
 }
@@ -422,8 +405,7 @@ navit_restrict_map_center_to_world_boundingbox(struct transformation *tr, struct
 /**
  * @brief Change map center position by translating from "old" to "new".
  */
-static void
-update_transformation(struct transformation *tr, struct point *old, struct point *new) {
+static void update_transformation(struct transformation *tr, struct point *old, struct point *new) {
     /* Code for rotation was removed in rev. 5252; see Trac #1078. */
     struct coord coord_old,coord_new;
     struct coord center_new,*center_old;
@@ -439,16 +421,15 @@ update_transformation(struct transformation *tr, struct point *old, struct point
     transform_set_center(tr, &center_new);
 }
 
-void
-navit_set_timeout(struct navit *this_) {
+void navit_set_timeout(struct navit *this_) {
     struct attr follow;
     follow.type=attr_follow;
     follow.u.num=this_->center_timeout;
     navit_set_attr(this_, &follow);
 }
 
-int
-navit_handle_button(struct navit *this_, int pressed, int button, struct point *p, struct callback *popup_callback) {
+int navit_handle_button(struct navit *this_, int pressed, int button, struct point *p,
+                        struct callback *popup_callback) {
     int border=16;
 
     dbg(lvl_debug,"button %d %s (ignore: %d)",button,pressed?"pressed":"released",this_->ignore_button);
@@ -509,8 +490,7 @@ navit_handle_button(struct navit *this_, int pressed, int button, struct point *
     return 0;
 }
 
-static void
-navit_button(void *data, int pressed, int button, struct point *p) {
+static void navit_button(void *data, int pressed, int button, struct point *p) {
     struct navit *this=data;
     dbg(lvl_debug,"enter %d %d ignore %d",pressed,button,this->ignore_graphics_events);
     if (!this->ignore_graphics_events) {
@@ -521,8 +501,7 @@ navit_button(void *data, int pressed, int button, struct point *p) {
 }
 
 
-static void
-navit_motion_timeout(struct navit *this_) {
+static void navit_motion_timeout(struct navit *this_) {
     int dx, dy;
 
     if (this_->drag_bitmap) {
@@ -554,8 +533,7 @@ navit_motion_timeout(struct navit *this_) {
     return;
 }
 
-void
-navit_handle_motion(struct navit *this_, struct point *p) {
+void navit_handle_motion(struct navit *this_, struct point *p) {
     int dx, dy;
 
     if (this_->button_pressed && !this_->popped) {
@@ -576,15 +554,13 @@ navit_handle_motion(struct navit *this_, struct point *p) {
     }
 }
 
-static void
-navit_motion(void *data, struct point *p) {
+static void navit_motion(void *data, struct point *p) {
     struct navit *this=data;
     if (!this->ignore_graphics_events)
         navit_handle_motion(this, p);
 }
 
-static void
-navit_predraw(struct navit *this_) {
+static void navit_predraw(struct navit *this_) {
     GList *l;
     struct navit_vehicle *nv;
     transform_copy(this_->trans, this_->trans_cursor);
@@ -596,8 +572,7 @@ navit_predraw(struct navit *this_) {
     }
 }
 
-static void
-navit_scale(struct navit *this_, long scale, struct point *p, int draw) {
+static void navit_scale(struct navit *this_, long scale, struct point *p, int draw) {
     struct coord c1, c2, *center;
     if (scale < this_->zoom_min)
         scale=this_->zoom_min;
@@ -627,8 +602,7 @@ navit_scale(struct navit *this_, long scale, struct point *p, int draw) {
  * @param speed The vehicles speed in meters per second
  * @param dir The direction into which the vehicle moves
  */
-static void
-navit_autozoom(struct navit *this_, struct coord *center, int speed, int draw) {
+static void navit_autozoom(struct navit *this_, struct coord *center, int speed, int draw) {
     struct point pc;
     int distance,w,h;
     double new_scale;
@@ -679,8 +653,7 @@ navit_autozoom(struct navit *this_, struct coord *center, int speed, int draw) {
  * @param p The invariant point (if set to NULL, default to center)
  * @returns nothing
  */
-void
-navit_zoom_in(struct navit *this_, int factor, struct point *p) {
+void navit_zoom_in(struct navit *this_, int factor, struct point *p) {
     long scale=transform_get_scale(this_->trans)/factor;
     if(this_->autozoom_active) {
         this_->autozoom_paused = 10;
@@ -698,8 +671,7 @@ navit_zoom_in(struct navit *this_, int factor, struct point *p) {
  * @param p The invariant point (if set to NULL, default to center)
  * @returns nothing
  */
-void
-navit_zoom_out(struct navit *this_, int factor, struct point *p) {
+void navit_zoom_out(struct navit *this_, int factor, struct point *p) {
     long scale=transform_get_scale(this_->trans)*factor;
     if(this_->autozoom_active) {
         this_->autozoom_paused = 10;
@@ -707,8 +679,7 @@ navit_zoom_out(struct navit *this_, int factor, struct point *p) {
     navit_scale(this_, scale, p, 1);
 }
 
-void
-navit_zoom_in_cursor(struct navit *this_, int factor) {
+void navit_zoom_in_cursor(struct navit *this_, int factor) {
     struct point p;
     if (this_->vehicle && this_->vehicle->follow_curr <= 1 && navit_get_cursor_pnt(this_, &p, 0, NULL)) {
         navit_zoom_in(this_, factor, &p);
@@ -717,8 +688,7 @@ navit_zoom_in_cursor(struct navit *this_, int factor) {
         navit_zoom_in(this_, factor, NULL);
 }
 
-void
-navit_zoom_out_cursor(struct navit *this_, int factor) {
+void navit_zoom_out_cursor(struct navit *this_, int factor) {
     struct point p;
     if (this_->vehicle && this_->vehicle->follow_curr <= 1 && navit_get_cursor_pnt(this_, &p, 0, NULL)) {
         navit_zoom_out(this_, 2, &p);
@@ -727,22 +697,19 @@ navit_zoom_out_cursor(struct navit *this_, int factor) {
         navit_zoom_out(this_, 2, NULL);
 }
 
-static int
-navit_cmd_zoom_in(struct navit *this_) {
+static int navit_cmd_zoom_in(struct navit *this_) {
 
     navit_zoom_in_cursor(this_, 2);
     return 0;
 }
 
-static int
-navit_cmd_zoom_out(struct navit *this_) {
+static int navit_cmd_zoom_out(struct navit *this_) {
     navit_zoom_out_cursor(this_, 2);
     return 0;
 }
 
 
-static void
-navit_cmd_say(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_say(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     if (in && in[0] && ATTR_IS_STRING(in[0]->type) && in[0]->u.str)
         navit_say(this, in[0]->u.str);
 }
@@ -760,8 +727,8 @@ static GHashTable *cmd_attr_var_hash = NULL;
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_set_int_var(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_set_int_var(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                  int *valid) {
     char*key;
     struct attr*val;
     if(!cmd_int_var_hash) {
@@ -788,8 +755,8 @@ navit_cmd_set_int_var(struct navit *this, char *function, struct attr **in, stru
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_set_attr_var(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_set_attr_var(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     char*key;
     struct attr*val;
     if(!cmd_attr_var_hash) {
@@ -818,8 +785,8 @@ navit_cmd_set_attr_var(struct navit *this, char *function, struct attr **in, str
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_toggle_layer(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_toggle_layer(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     if (in && in[0] && ATTR_IS_STRING(in[0]->type) && in[0]->u.str) {
         if(this->layout_current && this->layout_current->layers) {
             GList* layers = this->layout_current->layers;
@@ -846,8 +813,8 @@ navit_cmd_toggle_layer(struct navit *this, char *function, struct attr **in, str
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_map_add_curr_pos(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_map_add_curr_pos(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                       int *valid) {
     struct attr **list = g_new0(struct attr *,2);
     struct attr*val = g_new0(struct attr,1);
     struct mapset* ms;
@@ -936,8 +903,8 @@ navit_cmd_map_add_curr_pos(struct navit *this, char *function, struct attr **in,
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_map_item_set_attr(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_map_item_set_attr(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                        int *valid) {
     if (
         in && in[0] && ATTR_IS_STRING(in[0]->type) && in[0]->u.str  &&//map name
         in[1] && ATTR_IS_ITEM(in[1]->type)   && in[2]->u.item &&//item
@@ -1001,8 +968,8 @@ navit_cmd_map_item_set_attr(struct navit *this, char *function, struct attr **in
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_get_attr_var(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_get_attr_var(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     struct attr **list = g_new0(struct attr *,2);
     list[1] = NULL;
     *out = list;
@@ -1037,8 +1004,8 @@ navit_cmd_get_attr_var(struct navit *this, char *function, struct attr **in, str
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_get_int_var(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_get_int_var(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                  int *valid) {
     struct attr **list = g_new0(struct attr *,2);
     list[1] = NULL;
     *out = list;
@@ -1074,8 +1041,7 @@ GList *cmd_int_var_stack = NULL;
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_push_int(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_push_int(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     if (in && in[0] && ATTR_IS_NUMERIC(in[0]->type)) {
         struct attr*val = g_new(struct attr,1);
         attr_dup_content(in[0],val);
@@ -1093,8 +1059,7 @@ navit_cmd_push_int(struct navit *this, char *function, struct attr **in, struct 
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_pop_int(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_pop_int(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     struct attr **list = g_new0(struct attr *,2);
     if(!cmd_int_var_stack) {
         struct attr*val = g_new0(struct attr,1);
@@ -1119,8 +1084,8 @@ navit_cmd_pop_int(struct navit *this, char *function, struct attr **in, struct a
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_int_stack_size(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_int_stack_size(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                     int *valid) {
     struct attr **list;
     struct attr *attr  = g_new0(struct attr,1);
     attr->type  = attr_type_int_begin;
@@ -1136,8 +1101,7 @@ navit_cmd_int_stack_size(struct navit *this, char *function, struct attr **in, s
     cmd_int_var_stack = g_list_remove_link(cmd_int_var_stack,cmd_int_var_stack);
 }
 
-static struct attr **
-navit_get_coord(struct navit *this, struct attr **in, struct pcoord *pc) {
+static struct attr ** navit_get_coord(struct navit *this, struct attr **in, struct pcoord *pc) {
     if (!in)
         return NULL;
     if (!in[0])
@@ -1170,8 +1134,8 @@ navit_get_coord(struct navit *this, struct attr **in, struct pcoord *pc) {
     return in;
 }
 
-static void
-navit_cmd_set_destination(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_set_destination(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                      int *valid) {
     struct pcoord pc;
     char *description=NULL;
     in=navit_get_coord(this, in, &pc);
@@ -1183,22 +1147,21 @@ navit_cmd_set_destination(struct navit *this, char *function, struct attr **in, 
 }
 
 
-static void
-navit_cmd_route_remove_next_waypoint(struct navit *this, char *function, struct attr **in, struct attr ***out,
-                                     int *valid) {
+static void navit_cmd_route_remove_next_waypoint(struct navit *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     navit_remove_waypoint(this);
 }
 
 
-static void
-navit_cmd_route_remove_last_waypoint(struct navit *this, char *function, struct attr **in, struct attr ***out,
-                                     int *valid) {
+static void navit_cmd_route_remove_last_waypoint(struct navit *this, char *function, struct attr **in,
+        struct attr ***out,
+        int *valid) {
     navit_remove_nth_waypoint(this, navit_get_destination_count(this)-1);
 }
 
 
-static void
-navit_cmd_set_center(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_set_center(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     struct pcoord pc;
     int set_timeout=0;
     in=navit_get_coord(this, in, &pc);
@@ -1210,8 +1173,8 @@ navit_cmd_set_center(struct navit *this, char *function, struct attr **in, struc
 }
 
 
-static void
-navit_cmd_set_position(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_set_position(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     struct pcoord pc;
     in=navit_get_coord(this, in, &pc);
     if (!in)
@@ -1220,8 +1183,8 @@ navit_cmd_set_position(struct navit *this, char *function, struct attr **in, str
 }
 
 
-static void
-navit_cmd_fmt_coordinates(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_fmt_coordinates(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                      int *valid) {
     struct attr attr;
     attr.type=attr_type_string_begin;
     attr.u.str="Fix me";
@@ -1240,8 +1203,7 @@ navit_cmd_fmt_coordinates(struct navit *this, char *function, struct attr **in, 
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_strjoin(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_strjoin(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     struct attr attr;
     gchar *ret, *sep;
     int i;
@@ -1276,8 +1238,7 @@ navit_cmd_strjoin(struct navit *this, char *function, struct attr **in, struct a
  * @param valid unused
  * @returns nothing
  */
-static void
-navit_cmd_spawn(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void navit_cmd_spawn(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
     int i,j, nparms, nvalid;
     char ** argv=NULL;
     struct spawn_process_info *pi;
@@ -1355,8 +1316,7 @@ static struct command_table commands[] = {
     {"switch_layout_day_night",command_cast(navit_cmd_switch_layout_day_night)},
 };
 
-void
-navit_command_add_table(struct navit*this_, struct command_table *commands, int count) {
+void navit_command_add_table(struct navit*this_, struct command_table *commands, int count) {
     command_add_table(this_->attr_cbl, commands, count, this_);
 }
 
@@ -1421,8 +1381,7 @@ navit_new(struct attr *parent, struct attr **attrs) {
     return this_;
 }
 
-static int
-navit_set_gui(struct navit *this_, struct gui *gui) {
+static int navit_set_gui(struct navit *this_, struct gui *gui) {
     if (this_->gui)
         return 0;
     this_->gui=gui;
@@ -1437,8 +1396,7 @@ navit_set_gui(struct navit *this_, struct gui *gui) {
     return 1;
 }
 
-void
-navit_add_message(struct navit *this_, const char *message) {
+void navit_add_message(struct navit *this_, const char *message) {
     message_new(this_->messages, message);
 }
 
@@ -1447,8 +1405,7 @@ struct message
     return message_get(this_->messages);
 }
 
-static int
-navit_set_graphics(struct navit *this_, struct graphics *gra) {
+static int navit_set_graphics(struct navit *this_, struct graphics *gra) {
     if (this_->gra)
         return 0;
     this_->gra=gra;
@@ -1473,13 +1430,11 @@ navit_get_vehicleprofile(struct navit *this_) {
     return this_->vehicleprofile;
 }
 
-GList *
-navit_get_vehicleprofiles(struct navit *this_) {
+GList *navit_get_vehicleprofiles(struct navit *this_) {
     return this_->vehicleprofiles;
 }
 
-static void
-navit_projection_set(struct navit *this_, enum projection pro, int draw) {
+static void navit_projection_set(struct navit *this_, enum projection pro, int draw) {
     struct coord_geo g;
     struct coord *c;
 
@@ -1491,8 +1446,7 @@ navit_projection_set(struct navit *this_, enum projection pro, int draw) {
         navit_draw(this_);
 }
 
-static void
-navit_mark_navigation_stopped(char *former_destination_file) {
+static void navit_mark_navigation_stopped(char *former_destination_file) {
     FILE *f;
     f=fopen(former_destination_file, "a");
     if (f) {
@@ -1513,8 +1467,7 @@ navit_mark_navigation_stopped(char *former_destination_file) {
  * @param async Set to 1 to do route calculation asynchronously
  * @return nothing
  */
-void
-navit_set_destination(struct navit *this_, struct pcoord *c, const char *description, int async) {
+void navit_set_destination(struct navit *this_, struct pcoord *c, const char *description, int async) {
     char *destination_file;
     destination_file = bookmarks_get_destination_file(TRUE);
     if (c) {
@@ -1570,8 +1523,7 @@ navit_set_destination(struct navit *this_, struct pcoord *c, const char *descrip
  * @param description A label which allows the user to later identify this destination in the former destinations selection
  * @returns nothing
  */
-void
-navit_add_destination_description(struct navit *this_, struct pcoord *c, const char *description) {
+void navit_add_destination_description(struct navit *this_, struct pcoord *c, const char *description) {
     char *destination_file;
     if (c) {
         destination_file = bookmarks_get_destination_file(TRUE);
@@ -1591,8 +1543,7 @@ navit_add_destination_description(struct navit *this_, struct pcoord *c, const c
  * @param async If routing should be done asynchronously
  * @returns nothing
  */
-void
-navit_set_destinations(struct navit *this_, struct pcoord *c, int count, const char *description, int async) {
+void navit_set_destinations(struct navit *this_, struct pcoord *c, int count, const char *description, int async) {
     char *destination_file;
     if (c && count) {
         this_->destination=c[count-1];
@@ -1613,30 +1564,26 @@ navit_set_destinations(struct navit *this_, struct pcoord *c, int count, const c
     }
 }
 
-int
-navit_get_destinations(struct navit *this_, struct pcoord *pc, int count) {
+int navit_get_destinations(struct navit *this_, struct pcoord *pc, int count) {
     if(!this_->route)
         return 0;
     return route_get_destinations(this_->route, pc, count);
 
 }
 
-int
-navit_get_destination_count(struct navit *this_) {
+int navit_get_destination_count(struct navit *this_) {
     if(!this_->route)
         return 0;
     return route_get_destination_count(this_->route);
 }
 
-char*
-navit_get_destination_description(struct navit *this_, int n) {
+char* navit_get_destination_description(struct navit *this_, int n) {
     if(!this_->route)
         return NULL;
     return route_get_destination_description(this_->route, n);
 }
 
-void
-navit_remove_nth_waypoint(struct navit *this_, int n) {
+void navit_remove_nth_waypoint(struct navit *this_, int n) {
     if(!this_->route)
         return;
     if (route_get_destination_count(this_->route)>1) {
@@ -1646,8 +1593,7 @@ navit_remove_nth_waypoint(struct navit *this_, int n) {
     }
 }
 
-void
-navit_remove_waypoint(struct navit *this_) {
+void navit_remove_waypoint(struct navit *this_) {
     if(!this_->route)
         return;
     if (route_get_destination_count(this_->route)>1) {
@@ -1665,8 +1611,7 @@ navit_remove_waypoint(struct navit *this_) {
  * @param this_ The navit struct whose route should be checked.
  * @return True if the route is set, false otherwise.
  */
-int
-navit_check_route(struct navit *this_) {
+int navit_check_route(struct navit *this_) {
     if (this_->route) {
         return route_get_path_set(this_->route);
     }
@@ -1674,8 +1619,7 @@ navit_check_route(struct navit *this_) {
     return 0;
 }
 
-static int
-navit_former_destinations_active(struct navit *this_) {
+static int navit_former_destinations_active(struct navit *this_) {
     char *destination_file_name = bookmarks_get_destination_file(FALSE);
     FILE *destination_file;
     int active=0;
@@ -1721,8 +1665,7 @@ struct map* read_former_destinations_from_file() {
     return m;
 }
 
-static void
-navit_add_former_destinations_from_file(struct navit *this_) {
+static void navit_add_former_destinations_from_file(struct navit *this_) {
     struct item *item;
     int i,valid=0,count=0,maxcount=1;
     struct coord *c=g_new(struct coord, maxcount);
@@ -1765,8 +1708,7 @@ navit_add_former_destinations_from_file(struct navit *this_) {
 }
 
 
-void
-navit_textfile_debug_log(struct navit *this_, const char *fmt, ...) {
+void navit_textfile_debug_log(struct navit *this_, const char *fmt, ...) {
     va_list ap;
     char *str1,*str2;
     va_start(ap, fmt);
@@ -1781,8 +1723,7 @@ navit_textfile_debug_log(struct navit *this_, const char *fmt, ...) {
     va_end(ap);
 }
 
-void
-navit_textfile_debug_log_at(struct navit *this_, struct pcoord *pc, const char *fmt, ...) {
+void navit_textfile_debug_log_at(struct navit *this_, struct pcoord *pc, const char *fmt, ...) {
     va_list ap;
     char *str1,*str2;
     va_start(ap, fmt);
@@ -1796,8 +1737,7 @@ navit_textfile_debug_log_at(struct navit *this_, struct pcoord *pc, const char *
     va_end(ap);
 }
 
-void
-navit_say(struct navit *this_, const char *text) {
+void navit_say(struct navit *this_, const char *text) {
     struct attr attr;
     if(this_->speech) {
         if (!speech_get_attr(this_->speech, attr_active, &attr, NULL))
@@ -1812,8 +1752,7 @@ navit_say(struct navit *this_, const char *text) {
  * @brief Toggles the navigation announcer for navit
  * @param this_ The navit object
  */
-static void
-navit_cmd_announcer_toggle(struct navit *this_) {
+static void navit_cmd_announcer_toggle(struct navit *this_) {
     struct attr attr, speechattr;
 
     // search for the speech attribute
@@ -1837,8 +1776,7 @@ navit_cmd_announcer_toggle(struct navit *this_) {
     callback_list_call_attr_1(this_->attr_cbl, attr_speech, this_);
 }
 
-void
-navit_speak(struct navit *this_) {
+void navit_speak(struct navit *this_) {
     struct navigation *nav=this_->navigation;
     struct map *map=NULL;
     struct map_rect *mr=NULL;
@@ -1868,8 +1806,7 @@ navit_speak(struct navit *this_) {
     }
 }
 
-static void
-navit_window_roadbook_update(struct navit *this_) {
+static void navit_window_roadbook_update(struct navit *this_) {
     struct navigation *nav=this_->navigation;
     struct map *map=NULL;
     struct map_rect *mr=NULL;
@@ -1967,16 +1904,14 @@ navit_window_roadbook_update(struct navit *this_) {
     datawindow_mode(this_->roadbook_window, 0);
 }
 
-void
-navit_window_roadbook_destroy(struct navit *this_) {
+void navit_window_roadbook_destroy(struct navit *this_) {
     dbg(lvl_debug, "enter");
     navigation_unregister_callback(this_->navigation, attr_navigation_long, this_->roadbook_callback);
     callback_destroy(this_->roadbook_callback);
     this_->roadbook_window=NULL;
     this_->roadbook_callback=NULL;
 }
-void
-navit_window_roadbook_new(struct navit *this_) {
+void navit_window_roadbook_new(struct navit *this_) {
     if (!this_->gui || this_->roadbook_callback || this_->roadbook_window) {
         return;
     }
@@ -1988,8 +1923,7 @@ navit_window_roadbook_new(struct navit *this_) {
     navit_window_roadbook_update(this_);
 }
 
-void
-navit_init(struct navit *this_) {
+void navit_init(struct navit *this_) {
     struct mapset *ms;
     struct map *map;
     int callback;
@@ -2123,8 +2057,7 @@ navit_init(struct navit *this_) {
         callback_list_call_attr_1(this_->attr_cbl, attr_graphics_ready, this_);
 }
 
-void
-navit_zoom_to_rect(struct navit *this_, struct coord_rect *r) {
+void navit_zoom_to_rect(struct navit *this_, struct coord_rect *r) {
     struct coord c;
     int w,h,scale=16;
 
@@ -2153,8 +2086,7 @@ navit_zoom_to_rect(struct navit *this_, struct coord_rect *r) {
         navit_draw_async(this_,0);
 }
 
-void
-navit_zoom_to_route(struct navit *this_, int orientation) {
+void navit_zoom_to_route(struct navit *this_, int orientation) {
     struct map *map;
     struct map_rect *mr=NULL;
     struct item *item;
@@ -2190,8 +2122,7 @@ navit_zoom_to_route(struct navit *this_, int orientation) {
     navit_zoom_to_rect(this_, &r);
 }
 
-static void
-navit_cmd_zoom_to_route(struct navit *this) {
+static void navit_cmd_zoom_to_route(struct navit *this) {
     navit_zoom_to_route(this, 0);
 }
 
@@ -2203,8 +2134,7 @@ navit_cmd_zoom_to_route(struct navit *this) {
  * @param center The point where to center the map, including its projection
  * @returns nothing
  */
-void
-navit_set_center(struct navit *this_, struct pcoord *center, int set_timeout) {
+void navit_set_center(struct navit *this_, struct pcoord *center, int set_timeout) {
     struct coord *c=transform_center(this_->trans);
     struct coord c1,c2;
     enum projection pro = transform_get_projection(this_->trans);
@@ -2223,8 +2153,7 @@ navit_set_center(struct navit *this_, struct pcoord *center, int set_timeout) {
         navit_draw(this_);
 }
 
-static void
-navit_set_center_coord_screen(struct navit *this_, struct coord *c, struct point *p, int set_timeout) {
+static void navit_set_center_coord_screen(struct navit *this_, struct coord *c, struct point *p, int set_timeout) {
     int width, height;
     struct point po;
     transform_set_center(this_->trans, c);
@@ -2242,8 +2171,7 @@ navit_set_center_coord_screen(struct navit *this_, struct coord *c, struct point
  * @param this_ A navit instance
  * @author Ralph Sennhauser (10/2009)
  */
-static void
-navit_set_cursors(struct navit *this_) {
+static void navit_set_cursors(struct navit *this_) {
     struct attr name;
     struct navit_vehicle *nv;
     struct cursor *c;
@@ -2281,8 +2209,7 @@ navit_set_cursors(struct navit *this_) {
  *
  * @return Always 1
  */
-static int
-navit_get_cursor_pnt(struct navit *this_, struct point *p, int keep_orientation, int *dir) {
+static int navit_get_cursor_pnt(struct navit *this_, struct point *p, int keep_orientation, int *dir) {
     int width, height;
     struct navit_vehicle *nv=this_->vehicle;
     struct padding *padding = NULL;
@@ -2360,8 +2287,7 @@ navit_get_cursor_pnt(struct navit *this_, struct point *p, int keep_orientation,
  * @param keep_orientation Whether to maintain the current map orientation. If false, the map will be rotated
  * so that the bearing of the vehicle is up.
  */
-void
-navit_set_center_cursor(struct navit *this_, int autozoom, int keep_orientation) {
+void navit_set_center_cursor(struct navit *this_, int autozoom, int keep_orientation) {
     int dir;
     struct point pn;
     struct navit_vehicle *nv=this_->vehicle;
@@ -2383,8 +2309,7 @@ navit_set_center_cursor(struct navit *this_, int autozoom, int keep_orientation)
  *
  *@param this_ The navit object
  */
-static void
-navit_set_center_cursor_draw(struct navit *this_) {
+static void navit_set_center_cursor_draw(struct navit *this_) {
     navit_set_center_cursor(this_,1,0);
     if (this_->ready == 3)
         navit_draw_async(this_, 1);
@@ -2398,13 +2323,11 @@ navit_set_center_cursor_draw(struct navit *this_) {
  *
  *@param this_ The navit object
  */
-static void
-navit_cmd_set_center_cursor(struct navit *this_) {
+static void navit_cmd_set_center_cursor(struct navit *this_) {
     navit_set_center_cursor_draw(this_);
 }
 
-void
-navit_set_center_screen(struct navit *this_, struct point *p, int set_timeout) {
+void navit_set_center_screen(struct navit *this_, struct point *p, int set_timeout) {
     struct coord c;
     struct pcoord pc;
     transform_reverse(this_->trans, p, &c);
@@ -2414,8 +2337,7 @@ navit_set_center_screen(struct navit *this_, struct point *p, int set_timeout) {
     navit_set_center(this_, &pc, set_timeout);
 }
 
-static int
-navit_set_attr_do(struct navit *this_, struct attr *attr, int init) {
+static int navit_set_attr_do(struct navit *this_, struct attr *attr, int init) {
     int dir=0, orient_old=0, attr_updated=0;
     struct coord co;
     long zoom;
@@ -2632,13 +2554,11 @@ navit_set_attr_do(struct navit *this_, struct attr *attr, int init) {
     return 1;
 }
 
-int
-navit_set_attr(struct navit *this_, struct attr *attr) {
+int navit_set_attr(struct navit *this_, struct attr *attr) {
     return navit_set_attr_do(this_, attr, 0);
 }
 
-int
-navit_get_attr(struct navit *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int navit_get_attr(struct navit *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     struct message *msg;
     struct coord *c;
     int len,offset;
@@ -2845,8 +2765,7 @@ navit_get_attr(struct navit *this_, enum attr_type type, struct attr *attr, stru
     return ret;
 }
 
-static int
-navit_add_log(struct navit *this_, struct log *log) {
+static int navit_add_log(struct navit *this_, struct log *log) {
     struct attr type_attr;
     if (!log_get_attr(log, attr_type, &type_attr, NULL))
         return 0;
@@ -2861,8 +2780,7 @@ navit_add_log(struct navit *this_, struct log *log) {
     return 0;
 }
 
-static int
-navit_add_layout(struct navit *this_, struct layout *layout) {
+static int navit_add_layout(struct navit *this_, struct layout *layout) {
     struct attr active;
     this_->layouts = g_list_append(this_->layouts, layout);
     layout_get_attr(layout, attr_active, &active, NULL);
@@ -2873,8 +2791,7 @@ navit_add_layout(struct navit *this_, struct layout *layout) {
     return 0;
 }
 
-int
-navit_add_attr(struct navit *this_, struct attr *attr) {
+int navit_add_attr(struct navit *this_, struct attr *attr) {
     int ret=1;
     switch (attr->type) {
     case attr_callback:
@@ -2936,8 +2853,7 @@ navit_add_attr(struct navit *this_, struct attr *attr) {
     return ret;
 }
 
-int
-navit_remove_attr(struct navit *this_, struct attr *attr) {
+int navit_remove_attr(struct navit *this_, struct attr *attr) {
     int ret=1;
     switch (attr->type) {
     case attr_callback:
@@ -2958,23 +2874,19 @@ navit_attr_iter_new(void) {
     return g_new0(struct attr_iter, 1);
 }
 
-void
-navit_attr_iter_destroy(struct attr_iter *iter) {
+void navit_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
-void
-navit_add_callback(struct navit *this_, struct callback *cb) {
+void navit_add_callback(struct navit *this_, struct callback *cb) {
     callback_list_add(this_->attr_cbl, cb);
 }
 
-void
-navit_remove_callback(struct navit *this_, struct callback *cb) {
+void navit_remove_callback(struct navit *this_, struct callback *cb) {
     callback_list_remove(this_->attr_cbl, cb);
 }
 
-static int
-coord_not_set(struct coord c) {
+static int coord_not_set(struct coord c) {
     return !(c.x || c.y);
 }
 
@@ -2987,8 +2899,7 @@ coord_not_set(struct coord c) {
  * @returns nothing
  */
 
-static void
-navit_vehicle_draw(struct navit *this_, struct navit_vehicle *nv, struct point *pnt) {
+static void navit_vehicle_draw(struct navit *this_, struct navit_vehicle *nv, struct point *pnt) {
     struct point cursor_pnt;
     enum projection pro;
 
@@ -3026,8 +2937,7 @@ navit_vehicle_draw(struct navit *this_, struct navit_vehicle *nv, struct point *
  * @param this_ The navit object
  * @param nv The {@code navit_vehicle} which reported a new position
  */
-static void
-navit_vehicle_update_position(struct navit *this_, struct navit_vehicle *nv) {
+static void navit_vehicle_update_position(struct navit *this_, struct navit_vehicle *nv) {
     struct attr attr_valid, attr_dir, attr_speed, attr_pos;
     struct pcoord cursor_pc;
     struct point cursor_pnt, *pnt=&cursor_pnt;
@@ -3143,8 +3053,7 @@ navit_vehicle_update_position(struct navit *this_, struct navit_vehicle *nv) {
  * @param nv The {@code navit_vehicle} which reported a new status attribute
  * @param type The type of attribute with has changed
  */
-static void
-navit_vehicle_update_status(struct navit *this_, struct navit_vehicle *nv, enum attr_type type) {
+static void navit_vehicle_update_status(struct navit *this_, struct navit_vehicle *nv, enum attr_type type) {
     if (this_->vehicle != nv)
         return;
     switch(type) {
@@ -3166,8 +3075,7 @@ navit_vehicle_update_status(struct navit *this_, struct navit_vehicle *nv, enum 
  * @returns nothing
  */
 
-void
-navit_set_position(struct navit *this_, struct pcoord *c) {
+void navit_set_position(struct navit *this_, struct pcoord *c) {
     if (this_->route) {
         route_set_position(this_->route, c);
         callback_list_call_attr_0(this_->attr_cbl, attr_position);
@@ -3176,8 +3084,7 @@ navit_set_position(struct navit *this_, struct pcoord *c) {
         navit_draw(this_);
 }
 
-static int
-navit_set_vehicleprofile(struct navit *this_, struct vehicleprofile *vp) {
+static int navit_set_vehicleprofile(struct navit *this_, struct vehicleprofile *vp) {
     if (this_->vehicleprofile == vp)
         return 0;
     this_->vehicleprofile=vp;
@@ -3186,8 +3093,7 @@ navit_set_vehicleprofile(struct navit *this_, struct vehicleprofile *vp) {
     return 1;
 }
 
-int
-navit_set_vehicleprofile_name(struct navit *this_, char *name) {
+int navit_set_vehicleprofile_name(struct navit *this_, char *name) {
     struct attr attr;
     GList *l;
     l=this_->vehicleprofiles;
@@ -3203,8 +3109,7 @@ navit_set_vehicleprofile_name(struct navit *this_, char *name) {
     return 0;
 }
 
-static void
-navit_set_vehicle(struct navit *this_, struct navit_vehicle *nv) {
+static void navit_set_vehicle(struct navit *this_, struct navit_vehicle *nv) {
     struct attr attr;
     this_->vehicle=nv;
     if (nv && vehicle_get_attr(nv->vehicle, attr_profilename, &attr, NULL)) {
@@ -3236,8 +3141,7 @@ navit_set_vehicle(struct navit *this_, struct navit_vehicle *nv) {
  * @param v The vehicle to register
  * @return True for success
  */
-static int
-navit_add_vehicle(struct navit *this_, struct vehicle *v) {
+static int navit_add_vehicle(struct navit *this_, struct vehicle *v) {
     struct navit_vehicle *nv=g_new0(struct navit_vehicle, 1);
     struct attr follow, active, animate;
     nv->vehicle=v;
@@ -3299,8 +3203,7 @@ navit_get_displaylist(struct navit *this_) {
 }
 
 /*todo : make it switch to nightlayout when we are in a tunnel */
-void
-navit_layout_switch(struct navit *n) {
+void navit_layout_switch(struct navit *n) {
 
     int currTs=0;
     struct attr iso8601_attr,geo_attr,valid_attr,layout_attr;
@@ -3443,8 +3346,7 @@ void navit_cmd_switch_layout_day_night(struct navit *this_, char *function, stru
     return;
 }
 
-int
-navit_set_vehicle_by_name(struct navit *n,const char *name) {
+int navit_set_vehicle_by_name(struct navit *n,const char *name) {
     struct vehicle *v;
     struct attr_iter *iter;
     struct attr vehicle_attr, name_attr;
@@ -3466,8 +3368,7 @@ navit_set_vehicle_by_name(struct navit *n,const char *name) {
     return 0;
 }
 
-int
-navit_set_layout_by_name(struct navit *n,const char *name) {
+int navit_set_layout_by_name(struct navit *n,const char *name) {
     struct layout *l;
     struct attr_iter iter;
     struct attr layout_attr;
@@ -3499,8 +3400,7 @@ navit_set_layout_by_name(struct navit *n,const char *name) {
     return 0;
 }
 
-void
-navit_disable_suspend() {
+void navit_disable_suspend() {
     gui_disable_suspend(global_navit->gui);
     callback_list_call_attr_0(global_navit->attr_cbl,attr_unsuspend);
 }
@@ -3523,8 +3423,7 @@ navit_disable_suspend() {
  *
  * @return {@code true} if a redraw operation was triggered, {@code false} if not
  */
-int
-navit_block(struct navit *this_, int block) {
+int navit_block(struct navit *this_, int block) {
     if (block > 0) {
         this_->blocked |= 1;
         if (graphics_draw_cancel(this_->gra, this_->displaylist))
@@ -3547,8 +3446,7 @@ int navit_get_blocked(struct navit *this_) {
     return this_->blocked;
 }
 
-void
-navit_destroy(struct navit *this_) {
+void navit_destroy(struct navit *this_) {
     dbg(lvl_debug,"enter %p",this_);
     graphics_draw_cancel(this_->gra, this_->displaylist);
     callback_list_call_attr_1(this_->attr_cbl, attr_destroy, this_);

--- a/navit/navit_nls.c
+++ b/navit/navit_nls.c
@@ -16,8 +16,7 @@
 static GList *textdomains;
 #endif
 
-char *
-navit_nls_add_textdomain(const char *package, const char *dir) {
+char *navit_nls_add_textdomain(const char *package, const char *dir) {
 #ifdef USE_NATIVE_LANGUAGE_SUPPORT
     char *ret=bindtextdomain(package, dir);
     bind_textdomain_codeset(package, "UTF-8");
@@ -28,8 +27,7 @@ navit_nls_add_textdomain(const char *package, const char *dir) {
 #endif
 }
 
-void
-navit_nls_remove_textdomain(const char *package) {
+void navit_nls_remove_textdomain(const char *package) {
 #ifdef USE_NATIVE_LANGUAGE_SUPPORT
     GList *i=textdomains;
     while (i) {
@@ -43,8 +41,7 @@ navit_nls_remove_textdomain(const char *package) {
 #endif
 }
 
-const char *
-navit_nls_gettext(const char *msgid) {
+const char *navit_nls_gettext(const char *msgid) {
 #ifdef USE_NATIVE_LANGUAGE_SUPPORT
     GList *i=textdomains;
     while (i) {
@@ -57,8 +54,7 @@ navit_nls_gettext(const char *msgid) {
     return msgid;
 }
 
-const char *
-navit_nls_ngettext(const char *msgid, const char *msgid_plural, unsigned long int n) {
+const char *navit_nls_ngettext(const char *msgid, const char *msgid_plural, unsigned long int n) {
 #ifdef USE_NATIVE_LANGUAGE_SUPPORT
     GList *i=textdomains;
     while (i) {
@@ -75,8 +71,7 @@ navit_nls_ngettext(const char *msgid, const char *msgid_plural, unsigned long in
     }
 }
 
-void
-navit_nls_main_init(void) {
+void navit_nls_main_init(void) {
 #ifdef USE_NATIVE_LANGUAGE_SUPPORT
 #ifdef FORCE_LOCALE
 #define STRINGIFY2(x) #x

--- a/navit/osd.c
+++ b/navit/osd.c
@@ -37,8 +37,7 @@ struct osd {
     struct osd_priv *priv;
 };
 
-int
-osd_set_methods(struct osd_methods *in, int in_size, struct osd_methods *out) {
+int osd_set_methods(struct osd_methods *in, int in_size, struct osd_methods *out) {
     return navit_object_set_methods(in, in_size, out, sizeof(struct osd_methods));
 }
 
@@ -74,8 +73,7 @@ osd_new(struct attr *parent, struct attr **attrs) {
     return o;
 }
 
-int
-osd_get_attr(struct osd *osd, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int osd_get_attr(struct osd *osd, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     int ret=0;
     if(osd && osd->meth.get_attr)
         /* values for ret: -1: Not possible, 0: Ignored by driver, 1 valid */
@@ -87,8 +85,7 @@ osd_get_attr(struct osd *osd, enum attr_type type, struct attr *attr, struct att
     return navit_object_get_attr((struct navit_object *)osd, type, attr, iter);
 }
 
-int
-osd_set_attr(struct osd *osd, struct attr* attr) {
+int osd_set_attr(struct osd *osd, struct attr* attr) {
     int ret=0;
     if(osd && osd->meth.set_attr)
         /* values for ret: -1: Not possible, 0: Ignored by driver, 1 set and store, 2 set, don't store */
@@ -100,8 +97,7 @@ osd_set_attr(struct osd *osd, struct attr* attr) {
     return navit_object_set_attr((struct navit_object *)osd, attr);
 }
 
-static void
-osd_destroy(struct osd *osd) {
+static void osd_destroy(struct osd *osd) {
     if (!osd)
         return;
     if (osd->meth.destroy)
@@ -110,8 +106,7 @@ osd_destroy(struct osd *osd) {
     g_free(osd);
 }
 
-void
-osd_wrap_point(struct point *p, struct navit *nav) {
+void osd_wrap_point(struct point *p, struct navit *nav) {
     if (p->x < 0)
         p->x += navit_get_width(nav);
     if (p->y < 0)
@@ -119,8 +114,7 @@ osd_wrap_point(struct point *p, struct navit *nav) {
 
 }
 
-static void
-osd_evaluate_command(struct osd_item *this, struct navit *nav) {
+static void osd_evaluate_command(struct osd_item *this, struct navit *nav) {
     struct attr navit;
     navit.type=attr_navit;
     navit.u.navit=nav;
@@ -128,8 +122,7 @@ osd_evaluate_command(struct osd_item *this, struct navit *nav) {
     command_evaluate(&navit, this->command);
 }
 
-void
-osd_std_click(struct osd_item *this, struct navit *nav, int pressed, int button, struct point *p) {
+void osd_std_click(struct osd_item *this, struct navit *nav, int pressed, int button, struct point *p) {
     int click_is_outside_item;
     struct point bp = this->p;
     if (!this->command || !this->command[0])
@@ -149,8 +142,7 @@ osd_std_click(struct osd_item *this, struct navit *nav, int pressed, int button,
         osd_evaluate_command(this, nav);
 }
 
-void
-osd_std_resize(struct osd_item *item) {
+void osd_std_resize(struct osd_item *item) {
     graphics_overlay_resize(item->gr, &item->p, item->w, item->h, 1);
 }
 
@@ -175,8 +167,7 @@ osd_std_resize(struct osd_item *item) {
  * @param w Available screen width in pixels
  * @param h Available screen height in pixels
  */
-void
-osd_std_calculate_sizes(struct osd_item *item, int w, int h) {
+void osd_std_calculate_sizes(struct osd_item *item, int w, int h) {
     struct padding *padding = NULL;
 
     if (item->gr) {
@@ -228,8 +219,7 @@ osd_std_calculate_sizes(struct osd_item *item, int w, int h) {
  * @param h Available screen height in pixels (the height that corresponds to
  * 100%)
  */
-static void
-osd_std_calculate_sizes_and_redraw(struct osd_item *item, struct osd_priv *priv, int w, int h) {
+static void osd_std_calculate_sizes_and_redraw(struct osd_item *item, struct osd_priv *priv, int w, int h) {
     struct attr vehicle_attr;
 
     osd_std_calculate_sizes(item, w, h);
@@ -244,8 +234,7 @@ osd_std_calculate_sizes_and_redraw(struct osd_item *item, struct osd_priv *priv,
     }
 }
 
-static void
-osd_std_keypress(struct osd_item *item, struct navit *nav, char *key) {
+static void osd_std_keypress(struct osd_item *item, struct navit *nav, char *key) {
 #if 0
     int i;
     dbg(lvl_debug,"key=%s",key);
@@ -272,8 +261,7 @@ osd_std_keypress(struct osd_item *item, struct navit *nav, char *key) {
  * @param item The OSD item to reconfigure
  * @param cs The command to evaluate
  */
-static void
-osd_std_reconfigure(struct osd_item *item, struct command_saved *cs) {
+static void osd_std_reconfigure(struct osd_item *item, struct command_saved *cs) {
     char *err = NULL;	/* Error description */
 
     dbg(lvl_debug, "enter, item=%p, cs=%p", item, cs);
@@ -288,8 +276,7 @@ osd_std_reconfigure(struct osd_item *item, struct command_saved *cs) {
     }
 }
 
-void
-osd_set_std_attr(struct attr **attrs, struct osd_item *item, int flags) {
+void osd_set_std_attr(struct attr **attrs, struct osd_item *item, int flags) {
     struct attr *attr;
     item->flags=flags;
     item->osd_configuration=-1;
@@ -367,8 +354,7 @@ osd_set_std_attr(struct attr **attrs, struct osd_item *item, int flags) {
         item->font_name = g_strdup(attr->u.str);
 
 }
-void
-osd_std_config(struct osd_item *item, struct navit *navit) {
+void osd_std_config(struct osd_item *item, struct navit *navit) {
     struct attr attr;
     char *err = NULL;	/* Error description */
 
@@ -394,16 +380,14 @@ osd_std_config(struct osd_item *item, struct navit *navit) {
         graphics_overlay_disable(item->gr, !item->configured);
 }
 
-void
-osd_set_std_config(struct navit *nav, struct osd_item *item) {
+void osd_set_std_config(struct navit *nav, struct osd_item *item) {
     dbg(lvl_debug, "enter, item=%p", item);
     item->cb = callback_new_attr_2(callback_cast(osd_std_config), attr_osd_configuration, item, nav);
     navit_add_callback(nav, item->cb);
     osd_std_config(item, nav);
 }
 
-void
-osd_set_keypress(struct navit *nav, struct osd_item *item) {
+void osd_set_keypress(struct navit *nav, struct osd_item *item) {
     struct graphics *navit_gr = navit_get_graphics(nav);
     dbg(lvl_info,"accesskey %s",item->accesskey);
     if (item->accesskey) {
@@ -422,8 +406,7 @@ osd_set_keypress(struct navit *nav, struct osd_item *item) {
  * @param item The OSD item
  * @param priv The `struct osd_priv` for the OSD item
  */
-void
-osd_set_std_graphic(struct navit *nav, struct osd_item *item, struct osd_priv *priv) {
+void osd_set_std_graphic(struct navit *nav, struct osd_item *item, struct osd_priv *priv) {
     struct graphics *navit_gr;
     int w, h;
     struct padding *padding = NULL;
@@ -471,8 +454,7 @@ osd_set_std_graphic(struct navit *nav, struct osd_item *item, struct osd_priv *p
     osd_set_keypress(nav, item);
 }
 
-void
-osd_fill_with_bgcolor(struct osd_item *item) {
+void osd_fill_with_bgcolor(struct osd_item *item) {
     struct point p[1];
     graphics_draw_mode(item->gr, draw_mode_begin);
     p[0].x=0;

--- a/navit/osd/core/osd_core.c
+++ b/navit/osd/core/osd_core.c
@@ -107,9 +107,8 @@ struct compass {
  * @param[in,out] p An array of points to rotate
  * @param count The number of points stored inside @p p
  */
-static void
-transform_rotate(struct point *center, int angle, struct point *p,
-                 int count) {
+static void transform_rotate(struct point *center, int angle, struct point *p,
+                             int count) {
     int i, x, y;
     double dx, dy;
     for (i = 0; i < count; i++) {
@@ -131,9 +130,8 @@ transform_rotate(struct point *center, int angle, struct point *p,
  * @param[in,out] p An array of points to move
  * @param count The number of points stored inside @p p
  */
-static void
-transform_move(int dx, int dy, struct point *p,
-               int count) {
+static void transform_move(int dx, int dy, struct point *p,
+                           int count) {
     int i;
     for (i = 0; i < count; i++) {
         p->x += dx;
@@ -152,9 +150,9 @@ transform_move(int dx, int dy, struct point *p,
  * @param r The radius of the compass (around the center point @p p)
  * @param dir The direction the compass points to (0 being up, value is in degrees counter-clockwise)
  */
-static void
-draw_compass(struct graphics *gr, struct graphics_gc *gc_n, struct graphics_gc *gc_s, struct point *p, int r,
-             int dir) {
+static void draw_compass(struct graphics *gr, struct graphics_gc *gc_n, struct graphics_gc *gc_s, struct point *p,
+                         int r,
+                         int dir) {
     struct point ph[3];
     int wh[3] = { 1, 1, 1 };	/* Width of each line of the polygon to draw */
     int l = r * 0.25;
@@ -187,9 +185,8 @@ draw_compass(struct graphics *gr, struct graphics_gc *gc_n, struct graphics_gc *
  * @param r The radius of the compass (around the center point @p p)
  * @param dir The direction the arrow points to (0 being up, value is in degrees counter-clockwise)
  */
-static void
-draw_handle(struct graphics *gr, struct graphics_gc *gc, struct point *p, int r,
-            int dir) {
+static void draw_handle(struct graphics *gr, struct graphics_gc *gc, struct point *p, int r,
+                        int dir) {
     struct point ph[6];
     int l = r * 0.4;
     int s = l * 0.4;
@@ -245,8 +242,7 @@ draw_handle(struct graphics *gr, struct graphics_gc *gc, struct point *p, int r,
  * * @param sep separator character to be inserted between distance value and unit
  * * @returns a pointer to a string containing the formatted distance
  * */
-static char *
-format_distance(double distance, char *sep, int imperial) {
+static char *format_distance(double distance, char *sep, int imperial) {
     if (imperial) {
         distance *= FEET_PER_METER;
         if(distance <= 500) {
@@ -277,8 +273,7 @@ format_distance(double distance, char *sep, int imperial) {
  * * @param days days
  * * @returns a pointer to a string containing the formatted time
  * */
-static char *
-format_time(struct tm *tm, int days) {
+static char *format_time(struct tm *tm, int days) {
     if (days)
         return g_strdup_printf("%d+%02d:%02d", days, tm->tm_hour, tm->tm_min);
     else
@@ -292,8 +287,7 @@ format_time(struct tm *tm, int days) {
  * * @param sep separator character to be inserted between speed value and unit
  * * @returns a pointer to a string containing the formatted speed
  * */
-static char *
-format_speed(double speed, char *sep, char *format, int imperial) {
+static char *format_speed(double speed, char *sep, char *format, int imperial) {
     char *unit="km/h";
     if (imperial) {
         speed = speed*1000*FEET_PER_METER/FEET_PER_MILE;
@@ -310,8 +304,7 @@ format_speed(double speed, char *sep, char *format, int imperial) {
     return g_strdup("");
 }
 
-static char *
-format_float_0(double num) {
+static char *format_float_0(double num) {
     return g_strdup_printf("%.0f", num);
 }
 
@@ -440,8 +433,7 @@ static void osd_route_guard_draw(struct osd_priv_common *opc, struct navit *nav,
     graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
 }
 
-static void
-osd_route_guard_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_route_guard_init(struct osd_priv_common *opc, struct navit *nav) {
     struct color red_color= {0xffff,0x0000,0x0000,0xffff};
     struct route_guard *this = (struct route_guard *)opc->data;
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -500,15 +492,13 @@ osd_route_guard_init(struct osd_priv_common *opc, struct navit *nav) {
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_route_guard_draw), attr_position_coord_geo, opc));
 }
 
-static void
-osd_route_guard_destroy(struct osd_priv_common *opc) {
+static void osd_route_guard_destroy(struct osd_priv_common *opc) {
     struct route_guard *this = (struct route_guard *)opc->data;
     g_free(this->coords);
 }
 
-static struct osd_priv *
-osd_route_guard_new(struct navit *nav, struct osd_methods *meth,
-                    struct attr **attrs) {
+static struct osd_priv *osd_route_guard_new(struct navit *nav, struct osd_methods *meth,
+        struct attr **attrs) {
     struct route_guard *this = g_new0(struct route_guard, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -593,8 +583,8 @@ struct odometer {
     double acceleration;
 };
 
-static void
-osd_cmd_odometer_reset(struct navit *this, char *function, struct attr **in, struct attr ***out, int *valid) {
+static void osd_cmd_odometer_reset(struct navit *this, char *function, struct attr **in, struct attr ***out,
+                                   int *valid) {
     if (in && in[0] && ATTR_IS_STRING(in[0]->type) && in[0]->u.str) {
         GList* list = odometer_list;
         while(list) {
@@ -607,8 +597,7 @@ osd_cmd_odometer_reset(struct navit *this, char *function, struct attr **in, str
     }
 }
 
-static char*
-str_replace(char*output, char*input, char*pattern, char*replacement) {
+static char* str_replace(char*output, char*input, char*pattern, char*replacement) {
     char *pos;
     char *pos2;
     if (!output || !input || !pattern || !replacement) {
@@ -936,8 +925,7 @@ static void osd_odometer_draw(struct osd_priv_common *opc, struct navit *nav, st
 }
 
 
-static void
-osd_odometer_reset(struct osd_priv_common *opc, int flags) {
+static void osd_odometer_reset(struct osd_priv_common *opc, int flags) {
     struct odometer *this = (struct odometer *)opc->data;
 
     if(!this->bDisableReset || (flags & 1)) {
@@ -952,8 +940,8 @@ osd_odometer_reset(struct osd_priv_common *opc, int flags) {
     }
 }
 
-static void
-osd_odometer_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button, struct point *p) {
+static void osd_odometer_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button,
+                               struct point *p) {
     struct odometer *this = (struct odometer *)opc->data;
 
     struct point bp = opc->osd_item.p;
@@ -994,8 +982,7 @@ osd_odometer_click(struct osd_priv_common *opc, struct navit *nav, int pressed, 
 }
 
 
-static int
-osd_odometer_save(struct navit* nav) {
+static int osd_odometer_save(struct navit* nav) {
     //save odometers that are persistent(ie have name)
     FILE*f;
     GList* list = odometer_list;
@@ -1018,8 +1005,7 @@ osd_odometer_save(struct navit* nav) {
 }
 
 
-static void
-osd_odometer_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_odometer_init(struct osd_priv_common *opc, struct navit *nav) {
     struct odometer *this = (struct odometer *)opc->data;
 
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -1048,17 +1034,15 @@ osd_odometer_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_odometer_draw(opc, nav, NULL);
 }
 
-static void
-osd_odometer_destroy(struct navit* nav) {
+static void osd_odometer_destroy(struct navit* nav) {
     if(!odometers_saved) {
         odometers_saved = 1;
         osd_odometer_save(NULL);
     }
 }
 
-static struct osd_priv *
-osd_odometer_new(struct navit *nav, struct osd_methods *meth,
-                 struct attr **attrs) {
+static struct osd_priv *osd_odometer_new(struct navit *nav, struct osd_methods *meth,
+        struct attr **attrs) {
     FILE* f;
     char* fn;
 
@@ -1178,9 +1162,8 @@ struct cmd_interface {
     int bReserved;
 };
 
-static void
-osd_cmd_interface_draw(struct osd_priv_common *opc, struct navit *nav,
-                       struct vehicle *v) {
+static void osd_cmd_interface_draw(struct osd_priv_common *opc, struct navit *nav,
+                                   struct vehicle *v) {
     struct cmd_interface *this = (struct cmd_interface *)opc->data;
 
     struct point p;
@@ -1217,8 +1200,7 @@ osd_cmd_interface_draw(struct osd_priv_common *opc, struct navit *nav,
 
 
 
-static void
-osd_cmd_interface_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_cmd_interface_init(struct osd_priv_common *opc, struct navit *nav) {
     struct cmd_interface *this = (struct cmd_interface *)opc->data;
 
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -1239,8 +1221,7 @@ osd_cmd_interface_init(struct osd_priv_common *opc, struct navit *nav) {
     this->text = g_strdup("");
 }
 
-static int
-osd_cmd_interface_set_attr(struct osd_priv_common *opc, struct attr* attr) {
+static int osd_cmd_interface_set_attr(struct osd_priv_common *opc, struct attr* attr) {
     struct cmd_interface *this_ = (struct cmd_interface *)opc->data;
 
     if(NULL==attr || NULL==this_) {
@@ -1276,9 +1257,8 @@ osd_cmd_interface_set_attr(struct osd_priv_common *opc, struct attr* attr) {
 }
 
 
-static struct osd_priv *
-osd_cmd_interface_new(struct navit *nav, struct osd_methods *meth,
-                      struct attr **attrs) {
+static struct osd_priv *osd_cmd_interface_new(struct navit *nav, struct osd_methods *meth,
+        struct attr **attrs) {
     struct cmd_interface *this = g_new0(struct cmd_interface, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -1330,9 +1310,8 @@ struct stopwatch {
     time_t last_click_time;     //time of last click (for double click handling)
 };
 
-static void
-osd_stopwatch_draw(struct osd_priv_common *opc, struct navit *nav,
-                   struct vehicle *v) {
+static void osd_stopwatch_draw(struct osd_priv_common *opc, struct navit *nav,
+                               struct vehicle *v) {
     struct stopwatch *this = (struct stopwatch *)opc->data;
 
     struct graphics_gc *curr_color;
@@ -1369,8 +1348,8 @@ osd_stopwatch_draw(struct osd_priv_common *opc, struct navit *nav,
 }
 
 
-static void
-osd_stopwatch_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button, struct point *p) {
+static void osd_stopwatch_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button,
+                                struct point *p) {
     struct stopwatch *this = (struct stopwatch *)opc->data;
 
     struct point bp = opc->osd_item.p;
@@ -1409,8 +1388,7 @@ osd_stopwatch_click(struct osd_priv_common *opc, struct navit *nav, int pressed,
 }
 
 
-static void
-osd_stopwatch_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_stopwatch_init(struct osd_priv_common *opc, struct navit *nav) {
     struct stopwatch *this = (struct stopwatch *)opc->data;
 
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -1433,9 +1411,8 @@ osd_stopwatch_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_stopwatch_draw(opc, nav, NULL);
 }
 
-static struct osd_priv *
-osd_stopwatch_new(struct navit *nav, struct osd_methods *meth,
-                  struct attr **attrs) {
+static struct osd_priv *osd_stopwatch_new(struct navit *nav, struct osd_methods *meth,
+        struct attr **attrs) {
     struct stopwatch *this = g_new0(struct stopwatch, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -1478,9 +1455,8 @@ osd_stopwatch_new(struct navit *nav, struct osd_methods *meth,
  * @param nav The global navit object
  * @param v The current vehicle
  */
-static void
-osd_compass_draw(struct osd_priv_common *opc, struct navit *nav,
-                 struct vehicle *v) {
+static void osd_compass_draw(struct osd_priv_common *opc, struct navit *nav,
+                             struct vehicle *v) {
     struct compass *this = (struct compass *)opc->data;
 
     struct point p,bbox[4];
@@ -1529,8 +1505,7 @@ osd_compass_draw(struct osd_priv_common *opc, struct navit *nav,
 
 
 
-static void
-osd_compass_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_compass_init(struct osd_priv_common *opc, struct navit *nav) {
     struct compass *this = (struct compass *)opc->data;
 
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -1555,9 +1530,8 @@ osd_compass_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_compass_draw(opc, nav, NULL);
 }
 
-static struct osd_priv *
-osd_compass_new(struct navit *nav, struct osd_methods *meth,
-                struct attr **attrs) {
+static struct osd_priv *osd_compass_new(struct navit *nav, struct osd_methods *meth,
+                                        struct attr **attrs) {
     struct compass *this = g_new0(struct compass, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -1612,16 +1586,14 @@ struct osd_button {
  * @param opc The OSD item
  * @param img The image displayed by the item
  */
-static void
-osd_button_adjust_sizes(struct osd_priv_common *opc, struct graphics_image *img) {
+static void osd_button_adjust_sizes(struct osd_priv_common *opc, struct graphics_image *img) {
     if(opc->osd_item.rel_w==ATTR_REL_RELSHIFT)
         opc->osd_item.w=img->width;
     if(opc->osd_item.rel_h==ATTR_REL_RELSHIFT)
         opc->osd_item.h=img->height;
 }
 
-static void
-osd_button_draw(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_button_draw(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_button *this = (struct osd_button *)opc->data;
 
     // FIXME: Do we need this check?
@@ -1663,8 +1635,7 @@ osd_button_draw(struct osd_priv_common *opc, struct navit *nav) {
     }
 }
 
-static void
-osd_button_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_button_init(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_button *this = (struct osd_button *)opc->data;
 
     struct graphics *gra = navit_get_graphics(nav);
@@ -1710,15 +1681,13 @@ osd_button_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_button_draw(opc,nav);
 }
 
-static char *
-osd_button_icon_path(struct osd_button *this_, char *src) {
+static char *osd_button_icon_path(struct osd_button *this_, char *src) {
     if (!this_->src_dir)
         return graphics_icon_path(src);
     return g_strdup_printf("%s%s%s", this_->src_dir, G_DIR_SEPARATOR_S, src);
 }
 
-int
-osd_button_set_attr(struct osd_priv_common *opc, struct attr* attr) {
+int osd_button_set_attr(struct osd_priv_common *opc, struct attr* attr) {
     struct osd_button *this_ = (struct osd_button *)opc->data;
 
     if(NULL==attr || NULL==this_) {
@@ -1753,9 +1722,8 @@ osd_button_set_attr(struct osd_priv_common *opc, struct attr* attr) {
 
 
 
-static struct osd_priv *
-osd_button_new(struct navit *nav, struct osd_methods *meth,
-               struct attr **attrs) {
+static struct osd_priv *osd_button_new(struct navit *nav, struct osd_methods *meth,
+                                       struct attr **attrs) {
     struct osd_button *this = g_new0(struct osd_button, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -1808,8 +1776,7 @@ error:
     return NULL;
 }
 
-static void
-osd_image_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_image_init(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_button *this = (struct osd_button *)opc->data;
 
     struct graphics *gra = navit_get_graphics(nav);
@@ -1840,9 +1807,8 @@ osd_image_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_button_draw(opc,nav);
 }
 
-static struct osd_priv *
-osd_image_new(struct navit *nav, struct osd_methods *meth,
-              struct attr **attrs) {
+static struct osd_priv *osd_image_new(struct navit *nav, struct osd_methods *meth,
+                                      struct attr **attrs) {
     struct osd_button *this = g_new0(struct osd_button, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -2083,9 +2049,8 @@ struct nav_next_turn {
     int level;
 };
 
-static void
-osd_nav_next_turn_draw(struct osd_priv_common *opc, struct navit *navit,
-                       struct vehicle *v) {
+static void osd_nav_next_turn_draw(struct osd_priv_common *opc, struct navit *navit,
+                                   struct vehicle *v) {
     struct nav_next_turn *this = (struct nav_next_turn *)opc->data;
 
     struct point p;
@@ -2167,17 +2132,15 @@ osd_nav_next_turn_draw(struct osd_priv_common *opc, struct navit *navit,
     }
 }
 
-static void
-osd_nav_next_turn_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_nav_next_turn_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_nav_next_turn_draw), attr_position_coord_geo, opc));
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_std_click), attr_button, &opc->osd_item));
     osd_nav_next_turn_draw(opc, nav, NULL);
 }
 
-static struct osd_priv *
-osd_nav_next_turn_new(struct navit *nav, struct osd_methods *meth,
-                      struct attr **attrs) {
+static struct osd_priv *osd_nav_next_turn_new(struct navit *nav, struct osd_methods *meth,
+        struct attr **attrs) {
     struct nav_next_turn *this = g_new0(struct nav_next_turn, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -2235,8 +2198,7 @@ struct nav_toggle_announcer {
     int icon_h, icon_w, active, last_state;
 };
 
-static void
-osd_nav_toggle_announcer_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
+static void osd_nav_toggle_announcer_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
     struct nav_toggle_announcer *this = (struct nav_toggle_announcer *)opc->data;
 
     struct point p;
@@ -2292,8 +2254,7 @@ osd_nav_toggle_announcer_draw(struct osd_priv_common *opc, struct navit *navit, 
     }
 }
 
-static void
-osd_nav_toggle_announcer_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_nav_toggle_announcer_init(struct osd_priv_common *opc, struct navit *nav) {
     struct nav_toggle_announcer *this = (struct nav_toggle_announcer *)opc->data;
 
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -2303,8 +2264,7 @@ osd_nav_toggle_announcer_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_nav_toggle_announcer_draw(opc, nav, NULL);
 }
 
-static struct osd_priv *
-osd_nav_toggle_announcer_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
+static struct osd_priv *osd_nav_toggle_announcer_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
     struct nav_toggle_announcer *this = g_new0(struct nav_toggle_announcer, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -2369,16 +2329,14 @@ struct osd_speed_cam {
     char *text;                 //text of label attribute for this osd
 };
 
-static double
-angle_diff(int firstAngle,int secondAngle) {
+static double angle_diff(int firstAngle,int secondAngle) {
     double difference = secondAngle - firstAngle;
     while (difference < -180) difference += 360;
     while (difference > 180) difference -= 360;
     return difference;
 }
 
-static void
-osd_speed_cam_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
+static void osd_speed_cam_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
     struct osd_speed_cam *this_ = (struct osd_speed_cam *)opc->data;
 
     struct attr position_attr,vehicle_attr,imperial_attr;
@@ -2558,8 +2516,7 @@ osd_speed_cam_draw(struct osd_priv_common *opc, struct navit *navit, struct vehi
     }
 }
 
-static void
-osd_speed_cam_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_speed_cam_init(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_speed_cam *this = (struct osd_speed_cam *)opc->data;
 
     struct color red_color= {0xffff,0x0000,0x0000,0xffff};
@@ -2584,8 +2541,7 @@ osd_speed_cam_init(struct osd_priv_common *opc, struct navit *nav) {
 
 }
 
-static struct osd_priv *
-osd_speed_cam_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
+static struct osd_priv *osd_speed_cam_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
 
     struct color default_color= {0xffff,0xa5a5,0x0000,0xffff};
 
@@ -2653,8 +2609,7 @@ struct osd_speed_warner {
     struct callback *click_cb;
 };
 
-static void
-osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
+static void osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
     struct osd_speed_warner *this = (struct osd_speed_warner *)opc->data;
 
     struct point p,bbox[4];
@@ -2760,8 +2715,8 @@ osd_speed_warner_draw(struct osd_priv_common *opc, struct navit *navit, struct v
     graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
 }
 
-static void
-osd_speed_warner_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button, struct point *p) {
+static void osd_speed_warner_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button,
+                                   struct point *p) {
     struct osd_speed_warner *this = (struct osd_speed_warner *)opc->data;
 
     struct point bp = opc->osd_item.p;
@@ -2781,8 +2736,7 @@ osd_speed_warner_click(struct osd_priv_common *opc, struct navit *nav, int press
 }
 
 
-static void
-osd_speed_warner_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_speed_warner_init(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_speed_warner *this = (struct osd_speed_warner *)opc->data;
 
     struct color red_color= {0xffff,0,0,0xffff};
@@ -2846,8 +2800,7 @@ osd_speed_warner_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_speed_warner_draw(opc, nav, NULL);
 }
 
-static struct osd_priv *
-osd_speed_warner_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
+static struct osd_priv *osd_speed_warner_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
     struct osd_speed_warner *this=g_new0(struct osd_speed_warner, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -2930,8 +2883,7 @@ struct osd_text {
  * @param imperial True to convert values to imperial, false to return metric values
  * @returns The formatted value
  */
-static char *
-osd_text_format_attr(struct attr *attr, char *format, int imperial) {
+static char *osd_text_format_attr(struct attr *attr, char *format, int imperial) {
     struct tm tm, text_tm, text_tm0;
     time_t textt;
     int days=0;
@@ -3065,8 +3017,7 @@ osd_text_format_attr(struct attr *attr, char *format, int imperial) {
  * fails (index with missing closed bracket or passing a null pointer as index argument when an index
  * was encountered), the return value is NULL
  */
-static char *
-osd_text_split(char *in, char **index) {
+static char *osd_text_split(char *in, char **index) {
     char *pos;
     int len;
     if (index)
@@ -3097,8 +3048,7 @@ osd_text_split(char *in, char **index) {
     return NULL;
 }
 
-static void
-osd_text_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
+static void osd_text_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *v) {
     struct osd_text *this = (struct osd_text *)opc->data;
     struct point p, p2[4];
     char *str,*last,*next,*value,*absbegin;
@@ -3330,8 +3280,7 @@ osd_text_draw(struct osd_priv_common *opc, struct navit *navit, struct vehicle *
  * element of a new list
  * @returns The new {@code osd_text_item}
  */
-static struct osd_text_item *
-oti_new(struct osd_text_item * parent) {
+static struct osd_text_item *oti_new(struct osd_text_item * parent) {
     struct osd_text_item *this;
     this=g_new0(struct osd_text_item, 1);
     this->prev=parent;
@@ -3356,8 +3305,7 @@ oti_new(struct osd_text_item * parent) {
  * receive a pointer to a list of {@code osd_text_item} structures.
  * @param nav The navit structure
  */
-static void
-osd_text_prepare(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_text_prepare(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_text *this = (struct osd_text *)opc->data;
 
     char *absbegin,*str,*start,*end,*key,*subkey,*index;
@@ -3442,8 +3390,7 @@ osd_text_prepare(struct osd_priv_common *opc, struct navit *nav) {
 
 }
 
-static void
-osd_text_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_text_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_std_click), attr_button, &opc->osd_item));
     osd_text_prepare(opc,nav);
@@ -3451,8 +3398,7 @@ osd_text_init(struct osd_priv_common *opc, struct navit *nav) {
 
 }
 
-static int
-osd_text_set_attr(struct osd_priv_common *opc, struct attr* attr) {
+static int osd_text_set_attr(struct osd_priv_common *opc, struct attr* attr) {
     struct osd_text *this_ = (struct osd_text *)opc->data;
 
     if(NULL==attr || NULL==this_) {
@@ -3482,9 +3428,8 @@ osd_text_set_attr(struct osd_priv_common *opc, struct attr* attr) {
 }
 
 
-static struct osd_priv *
-osd_text_new(struct navit *nav, struct osd_methods *meth,
-             struct attr **attrs) {
+static struct osd_priv *osd_text_new(struct navit *nav, struct osd_methods *meth,
+                                     struct attr **attrs) {
     struct osd_text *this = g_new0(struct osd_text, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -3523,9 +3468,8 @@ struct gps_status {
     int strength;
 };
 
-static void
-osd_gps_status_draw(struct osd_priv_common *opc, struct navit *navit,
-                    struct vehicle *v) {
+static void osd_gps_status_draw(struct osd_priv_common *opc, struct navit *navit,
+                                struct vehicle *v) {
     struct gps_status *this = (struct gps_status *)opc->data;
 
     struct point p;
@@ -3583,8 +3527,7 @@ osd_gps_status_draw(struct osd_priv_common *opc, struct navit *navit,
     }
 }
 
-static void
-osd_gps_status_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_gps_status_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_gps_status_draw), attr_position_coord_geo, opc));
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_gps_status_draw), attr_position_fix_type, opc));
@@ -3593,9 +3536,8 @@ osd_gps_status_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_gps_status_draw(opc, nav, NULL);
 }
 
-static struct osd_priv *
-osd_gps_status_new(struct navit *nav, struct osd_methods *meth,
-                   struct attr **attrs) {
+static struct osd_priv *osd_gps_status_new(struct navit *nav, struct osd_methods *meth,
+        struct attr **attrs) {
     struct gps_status *this = g_new0(struct gps_status, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -3648,8 +3590,7 @@ struct volume {
     struct callback *click_cb;
 };
 
-static void
-osd_volume_draw(struct osd_priv_common *opc, struct navit *navit) {
+static void osd_volume_draw(struct osd_priv_common *opc, struct navit *navit) {
     struct volume *this = (struct volume *)opc->data;
 
     struct point p;
@@ -3671,8 +3612,7 @@ osd_volume_draw(struct osd_priv_common *opc, struct navit *navit) {
     graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
 }
 
-static void
-osd_volume_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button, struct point *p) {
+static void osd_volume_click(struct osd_priv_common *opc, struct navit *nav, int pressed, int button, struct point *p) {
     struct volume *this = (struct volume *)opc->data;
 
     struct point bp = opc->osd_item.p;
@@ -3692,8 +3632,7 @@ osd_volume_click(struct osd_priv_common *opc, struct navit *nav, int pressed, in
         osd_volume_draw(opc, nav);
     }
 }
-static void
-osd_volume_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_volume_init(struct osd_priv_common *opc, struct navit *nav) {
     struct volume *this = (struct volume *)opc->data;
 
     osd_set_std_graphic(nav, &opc->osd_item, (struct osd_priv *)opc);
@@ -3701,9 +3640,8 @@ osd_volume_init(struct osd_priv_common *opc, struct navit *nav) {
     osd_volume_draw(opc, nav);
 }
 
-static struct osd_priv *
-osd_volume_new(struct navit *nav, struct osd_methods *meth,
-               struct attr **attrs) {
+static struct osd_priv *osd_volume_new(struct navit *nav, struct osd_methods *meth,
+                                       struct attr **attrs) {
     struct volume *this = g_new0(struct volume, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -3754,8 +3692,7 @@ struct osd_scale {
     struct graphics_gc *black;
 };
 
-static int
-round_to_nice_value(double value) {
+static int round_to_nice_value(double value) {
     double nearest_power_of10,mantissa;
     nearest_power_of10=pow(10,floor(log10(value)));
     mantissa=value/nearest_power_of10;
@@ -3768,8 +3705,7 @@ round_to_nice_value(double value) {
     return mantissa*nearest_power_of10;
 }
 
-static void
-osd_scale_draw(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_scale_draw(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_scale *this = (struct osd_scale *)opc->data;
 
     struct point item_pos,scale_line_start,scale_line_end;
@@ -3844,8 +3780,7 @@ osd_scale_draw(struct osd_priv_common *opc, struct navit *nav) {
         graphics_draw_mode(opc->osd_item.gr, draw_mode_end);
 }
 
-static void
-osd_scale_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_scale_init(struct osd_priv_common *opc, struct navit *nav) {
     struct osd_scale *this = (struct osd_scale *)opc->data;
 
     struct graphics *gra = navit_get_graphics(nav);
@@ -3872,9 +3807,8 @@ osd_scale_init(struct osd_priv_common *opc, struct navit *nav) {
         osd_scale_draw(opc, nav);
 }
 
-static struct osd_priv *
-osd_scale_new(struct navit *nav, struct osd_methods *meth,
-              struct attr **attrs) {
+static struct osd_priv *osd_scale_new(struct navit *nav, struct osd_methods *meth,
+                                      struct attr **attrs) {
     struct osd_scale *this = g_new0(struct osd_scale, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     struct attr *attr;
@@ -3903,8 +3837,7 @@ struct auxmap {
     struct navit *nav;
 };
 
-static void
-osd_auxmap_draw(struct osd_priv_common *opc) {
+static void osd_auxmap_draw(struct osd_priv_common *opc) {
     struct auxmap *this = (struct auxmap *)opc->data;
 
     int d=10;
@@ -3942,8 +3875,7 @@ osd_auxmap_draw(struct osd_priv_common *opc) {
 
 }
 
-static void
-osd_auxmap_init(struct osd_priv_common *opc, struct navit *nav) {
+static void osd_auxmap_init(struct osd_priv_common *opc, struct navit *nav) {
     struct auxmap *this = (struct auxmap *)opc->data;
 
     struct graphics *gra;
@@ -3982,8 +3914,7 @@ osd_auxmap_init(struct osd_priv_common *opc, struct navit *nav) {
 #endif
 }
 
-static struct osd_priv *
-osd_auxmap_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
+static struct osd_priv *osd_auxmap_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
     struct auxmap *this = g_new0(struct auxmap, 1);
     struct osd_priv_common *opc = g_new0(struct osd_priv_common,1);
     opc->data = (void*)this;
@@ -4002,8 +3933,7 @@ osd_auxmap_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs)
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_osd("compass", osd_compass_new);
     plugin_register_category_osd("navigation_next_turn", osd_nav_next_turn_new);
     plugin_register_category_osd("button", osd_button_new);

--- a/navit/param.c
+++ b/navit/param.c
@@ -22,8 +22,7 @@
 #include <stdlib.h>
 #include "param.h"
 
-void
-param_add_string(const char *name, const char *value, struct param_list **param, int *count) {
+void param_add_string(const char *name, const char *value, struct param_list **param, int *count) {
     char *param_name;
     char *param_value;
     if (*count > 0) {
@@ -40,23 +39,20 @@ param_add_string(const char *name, const char *value, struct param_list **param,
 
 }
 
-void
-param_add_dec(const char *name, unsigned long value, struct param_list **param, int *count) {
+void param_add_dec(const char *name, unsigned long value, struct param_list **param, int *count) {
     char buffer[1024];
     sprintf(buffer, "%ld", value);
     param_add_string(name, buffer, param, count);
 }
 
 
-void
-param_add_hex(const char *name, unsigned long value, struct param_list **param, int *count) {
+void param_add_hex(const char *name, unsigned long value, struct param_list **param, int *count) {
     char buffer[1024];
     sprintf(buffer, "0x%lx", value);
     param_add_string(name, buffer, param, count);
 }
 
-void
-param_add_hex_sig(const char *name, long value, struct param_list **param, int *count) {
+void param_add_hex_sig(const char *name, long value, struct param_list **param, int *count) {
     char buffer[1024];
     if (value < 0)
         sprintf(buffer, "-0x%lx", -value);

--- a/navit/phrase.c
+++ b/navit/phrase.c
@@ -25,8 +25,7 @@
 #include "speech.h"
 #include "phrase.h"
 
-void
-phrase_route_calc(void *speech) {
+void phrase_route_calc(void *speech) {
 #if 0
     if (! speech)
         return;
@@ -34,8 +33,7 @@ phrase_route_calc(void *speech) {
 #endif
 }
 
-void
-phrase_route_calculated(void *speech, void *route) {
+void phrase_route_calculated(void *speech, void *route) {
 #if 0
     struct tm *eta;
 #endif

--- a/navit/plugin.c
+++ b/navit/plugin.c
@@ -50,8 +50,7 @@
 typedef void * GModule;
 #define G_MODULE_BIND_LOCAL 1
 #define G_MODULE_BIND_LAZY 2
-static int
-g_module_supported(void) {
+static int g_module_supported(void) {
     return 1;
 }
 
@@ -60,8 +59,7 @@ g_module_supported(void) {
 static DWORD last_error;
 static char errormsg[64];
 
-static void *
-g_module_open(char *name, int flags) {
+static void *g_module_open(char *name, int flags) {
     HINSTANCE handle;
     int len=MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, name, -1, 0, 0);
     wchar_t filename[len];
@@ -73,14 +71,12 @@ g_module_open(char *name, int flags) {
     return handle;
 }
 
-static char *
-g_module_error(void) {
+static char *g_module_error(void) {
     sprintf(errormsg,"dll error %d",(int)last_error);
     return errormsg;
 }
 
-static int
-g_module_symbol(GModule *handle, char *symbol, gpointer *addr) {
+static int g_module_symbol(GModule *handle, char *symbol, gpointer *addr) {
 #ifdef HAVE_API_WIN32_CE
     int len=MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, symbol, -1, 0, 0);
     wchar_t wsymbol[len+1];
@@ -95,32 +91,27 @@ g_module_symbol(GModule *handle, char *symbol, gpointer *addr) {
     return 0;
 }
 
-static void
-g_module_close(GModule *handle) {
+static void g_module_close(GModule *handle) {
     FreeLibrary((HANDLE)handle);
 }
 
 #else
-static void *
-g_module_open(char *name, int flags) {
+static void *g_module_open(char *name, int flags) {
     return dlopen(name,
                   (flags & G_MODULE_BIND_LAZY ? RTLD_LAZY : RTLD_NOW) |
                   (flags & G_MODULE_BIND_LOCAL ? RTLD_LOCAL : RTLD_GLOBAL));
 }
 
-static char *
-g_module_error(void) {
+static char *g_module_error(void) {
     return dlerror();
 }
 
-static int
-g_module_symbol(GModule *handle, char *symbol, gpointer *addr) {
+static int g_module_symbol(GModule *handle, char *symbol, gpointer *addr) {
     *addr=dlsym(handle, symbol);
     return (*addr != NULL);
 }
 
-static void
-g_module_close(GModule *handle) {
+static void g_module_close(GModule *handle) {
     dlclose(handle);
 }
 #endif
@@ -143,8 +134,7 @@ struct plugins {
     GList *list;
 } *pls;
 
-static struct plugin *
-plugin_new_from_path(char *plugin) {
+static struct plugin *plugin_new_from_path(char *plugin) {
 #ifdef USE_PLUGINS
     struct plugin *ret;
     if (! g_module_supported()) {
@@ -158,8 +148,7 @@ plugin_new_from_path(char *plugin) {
 #endif
 }
 
-int
-plugin_load(struct plugin *pl) {
+int plugin_load(struct plugin *pl) {
 #ifdef USE_PLUGINS
     gpointer init;
 
@@ -189,53 +178,44 @@ plugin_load(struct plugin *pl) {
 #endif
 }
 
-char *
-plugin_get_name(struct plugin *pl) {
+char *plugin_get_name(struct plugin *pl) {
     return pl->name;
 }
 
-int
-plugin_get_active(struct plugin *pl) {
+int plugin_get_active(struct plugin *pl) {
     return pl->active;
 }
 
-void
-plugin_set_active(struct plugin *pl, int active) {
+void plugin_set_active(struct plugin *pl, int active) {
     pl->active=active;
 }
 
-void
-plugin_set_lazy(struct plugin *pl, int lazy) {
+void plugin_set_lazy(struct plugin *pl, int lazy) {
     pl->lazy=lazy;
 }
 
 #ifdef USE_PLUGINS
-static int
-plugin_get_ondemand(struct plugin *pl) {
+static int plugin_get_ondemand(struct plugin *pl) {
     return pl->ondemand;
 }
 #endif
 
-static void
-plugin_set_ondemand(struct plugin *pl, int ondemand) {
+static void plugin_set_ondemand(struct plugin *pl, int ondemand) {
     pl->ondemand=ondemand;
 }
 
-void
-plugin_call_init(struct plugin *pl) {
+void plugin_call_init(struct plugin *pl) {
     pl->init();
 }
 
-void
-plugin_unload(struct plugin *pl) {
+void plugin_unload(struct plugin *pl) {
 #ifdef USE_PLUGINS
     g_module_close(pl->mod);
     pl->mod=NULL;
 #endif
 }
 
-void
-plugin_destroy(struct plugin *pl) {
+void plugin_destroy(struct plugin *pl) {
     g_free(pl);
 }
 
@@ -320,8 +300,7 @@ plugin_new(struct attr *parent, struct attr **attrs) {
 #endif
 }
 
-void
-plugins_init(struct plugins *pls) {
+void plugins_init(struct plugins *pls) {
 #ifdef USE_PLUGINS
     struct plugin *pl;
     GList *l;
@@ -345,8 +324,7 @@ plugins_init(struct plugins *pls) {
 #endif
 }
 
-void
-plugins_destroy(struct plugins *pls) {
+void plugins_destroy(struct plugins *pls) {
     GList *l;
     struct plugin *pl;
 
@@ -361,8 +339,7 @@ plugins_destroy(struct plugins *pls) {
     g_free(pls);
 }
 
-static void *
-find_by_name(enum plugin_category category, const char *name) {
+static void *find_by_name(enum plugin_category category, const char *name) {
     GList *name_list=plugin_categories[category];
     while (name_list) {
         struct name_val *nv=name_list->data;
@@ -373,8 +350,7 @@ find_by_name(enum plugin_category category, const char *name) {
     return NULL;
 }
 
-void *
-plugin_get_category(enum plugin_category category, const char *category_name, const char *name) {
+void *plugin_get_category(enum plugin_category category, const char *category_name, const char *name) {
     GList *plugin_list;
     struct plugin *pl;
     char *mod_name, *filename=NULL, *corename=NULL;

--- a/navit/plugin/j1850/j1850.c
+++ b/navit/plugin/j1850/j1850.c
@@ -126,8 +126,7 @@ void write_to_serial_port(unsigned char *cmd, int device) {
  * taken. The buffer is then cleared and we start over.
  *
  */
-static void
-j1850_idle(struct j1850 *j1850) {
+static void j1850_idle(struct j1850 *j1850) {
     int n;             // used to keep track of the numbers of char read from the device
     int value;         // used to convert the ascii char to an int
     char buf = '\0';   // the buffer where we store the char read from the device
@@ -267,9 +266,8 @@ j1850_idle(struct j1850 *j1850) {
  * Draws the j1850 OSD. Currently it only displays the last parsed message
  *
  */
-static void
-osd_j1850_draw(struct j1850 *this, struct navit *nav,
-               struct vehicle *v) {
+static void osd_j1850_draw(struct j1850 *this, struct navit *nav,
+                           struct vehicle *v) {
     osd_std_draw(&this->osd_item);
 
     struct point p, bbox[4];
@@ -294,8 +292,7 @@ osd_j1850_draw(struct j1850 *this, struct navit *nav,
  * Initialize the j1850 OSD
  *
  */
-static void
-osd_j1850_init(struct j1850 *this, struct navit *nav) {
+static void osd_j1850_init(struct j1850 *this, struct navit *nav) {
 
     struct color c;
     osd_set_std_graphic(nav, &this->osd_item, (struct osd_priv *)this);
@@ -381,8 +378,7 @@ void send_and_read(unsigned char *cmd, int USB) {
  * Opens the serial port and saves state to the j1850 object
  *
  */
-void
-j1850_init_serial_port(struct j1850 *j1850) {
+void j1850_init_serial_port(struct j1850 *j1850) {
     j1850->callback=callback_new_1(callback_cast(j1850_idle), j1850);
     // Fixme : we should read the device path from the config file
     j1850->device = open( "/dev/ttyUSB0", O_RDWR| O_NOCTTY );
@@ -446,9 +442,8 @@ j1850_init_serial_port(struct j1850 *j1850) {
  * Creates the j1850 OSD and set some default properties
  *
  */
-static struct osd_priv *
-osd_j1850_new(struct navit *nav, struct osd_methods *meth,
-              struct attr **attrs) {
+static struct osd_priv *osd_j1850_new(struct navit *nav, struct osd_methods *meth,
+                                      struct attr **attrs) {
     struct j1850 *this=g_new0(struct j1850, 1);
     this->nav=nav;
     time_t current_time = time(NULL);
@@ -480,8 +475,7 @@ osd_j1850_new(struct navit *nav, struct osd_methods *meth,
  * The plugin entry point
  *
  */
-void
-plugin_init(void) {
+void plugin_init(void) {
     struct attr callback,navit;
     struct attr_iter *iter;
 

--- a/navit/plugin/pedestrian/pedestrian.c
+++ b/navit/plugin/pedestrian/pedestrian.c
@@ -83,8 +83,7 @@ struct rocket {
     struct event_idle *idle;
 };
 
-static void
-pedestrian_rocket_idle(struct rocket *rocket) {
+static void pedestrian_rocket_idle(struct rocket *rocket) {
     struct attr follow;
     follow.type=attr_follow;
     follow.u.num=100;
@@ -112,8 +111,7 @@ pedestrian_rocket_idle(struct rocket *rocket) {
     navit_set_attr(rocket->navit, &follow);
 }
 
-static void
-pedestrian_cmd_pedestrian_rocket(struct rocket *rocket) {
+static void pedestrian_cmd_pedestrian_rocket(struct rocket *rocket) {
     struct attr attr;
     int max=0;
 #if 0
@@ -180,8 +178,7 @@ static struct command_table commands[] = {
 
 
 
-static void
-osd_rocket_init(struct navit *nav) {
+static void osd_rocket_init(struct navit *nav) {
     struct rocket *rocket=g_new0(struct rocket, 1);
     struct attr attr;
     rocket->navit=nav;
@@ -198,8 +195,7 @@ struct marker {
     struct cursor *cursor;
 };
 
-static void
-osd_marker_draw(struct marker *this, struct navit *nav) {
+static void osd_marker_draw(struct marker *this, struct navit *nav) {
 #if 0
     struct attr graphics;
     struct point p;
@@ -213,8 +209,7 @@ osd_marker_draw(struct marker *this, struct navit *nav) {
 
 }
 
-static void
-osd_marker_init(struct marker *this, struct navit *nav) {
+static void osd_marker_init(struct marker *this, struct navit *nav) {
     struct attr cursor;
     struct attr itemgra,polygon,polygoncoord1,polygoncoord2,polygoncoord3;
     struct attr *color=attr_new_from_text("color","#ff0000");
@@ -293,9 +288,8 @@ osd_marker_init(struct marker *this, struct navit *nav) {
     osd_marker_draw(this, nav);
 }
 
-static struct osd_priv *
-osd_marker_new(struct navit *nav, struct osd_methods *meth,
-               struct attr **attrs) {
+static struct osd_priv *osd_marker_new(struct navit *nav, struct osd_methods *meth,
+                                       struct attr **attrs) {
     struct marker *this = g_new0(struct marker, 1);
     navit_add_callback(nav, callback_new_attr_1(callback_cast(osd_marker_init), attr_navit, this));
     return (struct osd_priv *) this;
@@ -330,8 +324,7 @@ struct map_rect_priv {
     int lseg_done_base;
 };
 
-static int
-map_route_occluded_bbox(struct map *map, struct coord_rect *bbox) {
+static int map_route_occluded_bbox(struct map *map, struct coord_rect *bbox) {
     struct coord c[128];
     struct coord_rect r;
     int i,first=1,ccount;
@@ -360,8 +353,7 @@ static struct building {
     struct building *next;
 } *buildings;
 
-static void
-map_route_occluded_buildings_free(void) {
+static void map_route_occluded_buildings_free(void) {
     struct building *next,*b=buildings;
     while (b) {
         street_data_free(b->sd);
@@ -372,8 +364,7 @@ map_route_occluded_buildings_free(void) {
     buildings=NULL;
 }
 
-static void
-map_route_occluded_get_buildings(struct mapset *mapset, struct coord_rect *r) {
+static void map_route_occluded_get_buildings(struct mapset *mapset, struct coord_rect *r) {
     struct mapset_handle *msh=mapset_open(mapset);
     struct map *map;
     struct map_selection sel;
@@ -420,8 +411,7 @@ FILE *debug,*debug2;
 
 /* < 0 left, > 0 right */
 
-static int
-side(struct coord *l0, struct coord *l1, struct coord *p) {
+static int side(struct coord *l0, struct coord *l1, struct coord *p) {
     int dxl=l1->x-l0->x;
     int dyl=l1->y-l0->y;
     int dxp=p->x-l0->x;
@@ -430,8 +420,7 @@ side(struct coord *l0, struct coord *l1, struct coord *p) {
     return dxp*dyl-dyp*dxl;
 }
 
-static void
-map_route_occluded_check_buildings(struct coord *c0) {
+static void map_route_occluded_check_buildings(struct coord *c0) {
     struct building *b=buildings;
     dbg(lvl_debug,"enter");
     int i,count;
@@ -480,8 +469,7 @@ map_route_occluded_check_buildings(struct coord *c0) {
 #endif
 }
 
-static int
-intersect(struct coord *p1, struct coord *p2, struct coord *p3, struct coord *p4, struct coord *i) {
+static int intersect(struct coord *p1, struct coord *p2, struct coord *p3, struct coord *p4, struct coord *i) {
     double num=(p4->x-p3->x)*(p1->y-p3->y)-(p4->y-p3->y)*(p1->x-p3->x);
     double den=(p4->y-p3->y)*(p2->x-p1->x)-(p4->x-p3->x)*(p2->y-p1->y);
     if (num < 0 && den < 0) {
@@ -513,8 +501,7 @@ intersect(struct coord *p1, struct coord *p2, struct coord *p3, struct coord *p4
 
 /* #define DEBUG_VISIBLE */
 
-static int
-is_visible_line(struct coord *c0, struct coord *c1, struct coord *c2) {
+static int is_visible_line(struct coord *c0, struct coord *c1, struct coord *c2) {
     int res,ret=0;
     struct building *b=buildings;
     struct coord cn;
@@ -606,8 +593,7 @@ is_visible_line(struct coord *c0, struct coord *c1, struct coord *c2) {
     return ret;
 }
 
-static void
-map_route_occluded_coord_rewind(void *priv_data) {
+static void map_route_occluded_coord_rewind(void *priv_data) {
     struct map_rect_priv *mr = priv_data;
     dbg(lvl_debug,"enter");
     mr->idx=mr->idx_base;
@@ -620,22 +606,19 @@ map_route_occluded_coord_rewind(void *priv_data) {
     item_coord_rewind(mr->route_item);
 }
 
-static void
-map_route_occluded_attr_rewind(void *priv_data) {
+static void map_route_occluded_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr=priv_data;
     dbg(lvl_debug,"enter");
     item_attr_rewind(mr->route_item);
 }
 
-static int
-map_route_occluded_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int map_route_occluded_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr=priv_data;
     dbg(lvl_debug,"enter");
     return item_attr_get(mr->route_item, attr_type, attr);
 }
 
-static int
-coord_next(struct map_rect_priv *mr, struct coord *c) {
+static int coord_next(struct map_rect_priv *mr, struct coord *c) {
     if (mr->idx >= mr->sd->count)
         return 1;
     *c=mr->sd->c[mr->idx++];
@@ -643,8 +626,7 @@ coord_next(struct map_rect_priv *mr, struct coord *c) {
 }
 
 #define DEBUG_COORD_GET
-static int
-map_route_occluded_coord_get(void *priv_data, struct coord *c, int count) {
+static int map_route_occluded_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr=priv_data;
     struct coord l0,l1;
     int vis,ret=0;
@@ -810,15 +792,13 @@ static struct item_methods methods_route_occluded_item = {
     map_route_occluded_attr_get,
 };
 
-static void
-map_route_occluded_destroy(struct map_priv *priv) {
+static void map_route_occluded_destroy(struct map_priv *priv) {
     g_free(priv);
 }
 
 static int no_recurse;
 
-static struct map_rect_priv *
-map_route_occluded_rect_new(struct map_priv *priv, struct map_selection *sel) {
+static struct map_rect_priv *map_route_occluded_rect_new(struct map_priv *priv, struct map_selection *sel) {
     struct map_rect_priv * mr;
     struct attr route;
     struct attr route_map;
@@ -860,8 +840,7 @@ map_route_occluded_rect_new(struct map_priv *priv, struct map_selection *sel) {
 }
 
 
-static void
-map_route_occluded_rect_destroy(struct map_rect_priv *mr) {
+static void map_route_occluded_rect_destroy(struct map_rect_priv *mr) {
     map_rect_destroy(mr->route_map_rect);
     street_data_free(mr->sd);
     g_free(mr);
@@ -885,8 +864,7 @@ map_route_occluded_rect_destroy(struct map_rect_priv *mr) {
 #endif
 }
 
-static struct item *
-map_route_occluded_get_item(struct map_rect_priv *mr) {
+static struct item *map_route_occluded_get_item(struct map_rect_priv *mr) {
     dbg(lvl_debug,"enter last=%d",mr->last);
     while (!mr->last) {
         struct coord c[128];
@@ -915,8 +893,7 @@ map_route_occluded_get_item(struct map_rect_priv *mr) {
     return &mr->item;
 }
 
-static struct item *
-map_route_occluded_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *map_route_occluded_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     struct item *ret=NULL;
     while (id_lo-- > 0)
         ret=map_route_occluded_get_item(mr);
@@ -937,8 +914,7 @@ static struct map_methods map_route_occluded_methods = {
 };
 
 
-static struct map_priv *
-map_route_occluded_new(struct map_methods *meth, struct attr **attrs) {
+static struct map_priv *map_route_occluded_new(struct map_methods *meth, struct attr **attrs) {
     struct map_priv *ret;
     struct attr *navit;
     dbg(lvl_debug,"enter");
@@ -952,8 +928,7 @@ map_route_occluded_new(struct map_methods *meth, struct attr **attrs) {
     return ret;
 }
 
-static void
-pedestrian_graphics_resize(struct graphics *gra, int w, int h) {
+static void pedestrian_graphics_resize(struct graphics *gra, int w, int h) {
 #ifndef HAVE_API_ANDROID
     static int done;
     if (!done) {
@@ -969,8 +944,7 @@ pedestrian_graphics_resize(struct graphics *gra, int w, int h) {
 }
 
 
-static void
-pedestrian_draw_arrow(struct graphics *gra, char *name, int x, int y) {
+static void pedestrian_draw_arrow(struct graphics *gra, char *name, int x, int y) {
     char *src=graphics_icon_path(name);
     struct graphics_image *img=graphics_image_new(gra, src);
     struct graphics_gc *gc=graphics_gc_new(gra);
@@ -985,8 +959,7 @@ pedestrian_draw_arrow(struct graphics *gra, char *name, int x, int y) {
     g_free(src);
 }
 
-static void
-pedestrian_draw_arrows(struct graphics *gra) {
+static void pedestrian_draw_arrows(struct graphics *gra) {
     struct attr route, route_map;
     struct map_rect *route_map_rect;
     struct item *item;
@@ -1028,8 +1001,7 @@ pedestrian_draw_arrows(struct graphics *gra) {
     map_rect_destroy(route_map_rect);
 }
 
-static void
-pedestrian_graphics_postdraw(struct graphics *gra) {
+static void pedestrian_graphics_postdraw(struct graphics *gra) {
 #if 0
     struct graphics_gc * gc = graphics_gc_new(gra);
     struct point p;
@@ -1049,8 +1021,7 @@ struct tilt_data {
     char buffer[32];
 };
 
-void
-pedestrian_write_tilt(int fd, int axis) {
+void pedestrian_write_tilt(int fd, int axis) {
     char *buffer="01";
     int ret;
 
@@ -1061,8 +1032,7 @@ pedestrian_write_tilt(int fd, int axis) {
 }
 
 
-void
-pedestrian_read_tilt(int fd, struct navit *nav, struct tilt_data *data) {
+void pedestrian_read_tilt(int fd, struct navit *nav, struct tilt_data *data) {
     int val,ret,maxlen=3;
     ret=read(fd, data->buffer+data->len, maxlen-data->len);
     if (ret > 0) {
@@ -1090,13 +1060,11 @@ pedestrian_read_tilt(int fd, struct navit *nav, struct tilt_data *data) {
     }
 }
 
-void
-pedestrian_write_tilt_timer(int fd, struct tilt_data *data) {
+void pedestrian_write_tilt_timer(int fd, struct tilt_data *data) {
     pedestrian_write_tilt(fd, data->axis);
 }
 
-void
-pedestrian_setup_tilt(struct navit *nav) {
+void pedestrian_setup_tilt(struct navit *nav) {
     int fd,on=1;
     struct termios t;
     struct callback *cb,*cbt;
@@ -1127,8 +1095,7 @@ pedestrian_setup_tilt(struct navit *nav) {
 
 float sensors[2][3];
 
-static void
-android_sensors(struct navit *nav, int sensor, float *x, float *y, float *z) {
+static void android_sensors(struct navit *nav, int sensor, float *x, float *y, float *z) {
     float yaw=0,pitch=0;
     struct attr attr;
     sensors[sensor-1][0]=*x;
@@ -1206,8 +1173,7 @@ android_sensors(struct navit *nav, int sensor, float *x, float *y, float *z) {
 }
 #endif
 
-static void
-pedestrian_log(char **logstr) {
+static void pedestrian_log(char **logstr) {
 #ifdef HAVE_API_ANDROID
     char *tag=g_strdup_printf(
                   "\t\t<navit:compass:x>%f</navit:compass:x>\n"
@@ -1223,8 +1189,7 @@ pedestrian_log(char **logstr) {
 }
 
 #ifdef DEMO
-static void
-vehicle_changed(struct vehicle *v, struct transformation *trans) {
+static void vehicle_changed(struct vehicle *v, struct transformation *trans) {
     struct attr attr;
     if (vehicle_get_attr(v, attr_position_direction, &attr, NULL)) {
         int dir=(int)(*attr.u.numd);
@@ -1236,8 +1201,7 @@ vehicle_changed(struct vehicle *v, struct transformation *trans) {
 #endif
 
 
-static void
-pedestrian_navit_init(struct navit *nav) {
+static void pedestrian_navit_init(struct navit *nav) {
     struct attr route;
     struct attr route_map;
     struct attr map;
@@ -1357,8 +1321,7 @@ pedestrian_navit_init(struct navit *nav) {
 
 }
 
-static void
-pedestrian_navit(struct navit *nav, int add) {
+static void pedestrian_navit(struct navit *nav, int add) {
     dbg(lvl_debug,"enter");
     struct attr callback;
     if (add) {
@@ -1368,8 +1331,7 @@ pedestrian_navit(struct navit *nav, int add) {
     }
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     struct attr callback,navit;
     struct attr_iter *iter;
 #ifdef HAVE_API_ANDROID

--- a/navit/popup.c
+++ b/navit/popup.c
@@ -44,8 +44,7 @@
 #include "bookmarks.h"
 
 #if 0
-static void
-popup_set_no_passing(struct popup_item *item, void *param) {
+static void popup_set_no_passing(struct popup_item *item, void *param) {
 #if 0
     struct display_list *l=param;
     struct segment *seg=(struct segment *)(l->data);
@@ -63,8 +62,7 @@ popup_set_no_passing(struct popup_item *item, void *param) {
 
 #endif
 
-static void
-popup_traffic_distortion(struct item *item, char *attr) {
+static void popup_traffic_distortion(struct item *item, char *attr) {
     /* add the configuration directory to the name of the file to use */
     char *dist_filename = g_strjoin(NULL, navit_get_user_data_directory(TRUE),
                                     "/distortion.txt", NULL);
@@ -90,28 +88,24 @@ popup_traffic_distortion(struct item *item, char *attr) {
 } /* end: popup_traffic_distortion(..) */
 
 
-static void
-popup_traffic_distortion_blocked(struct item *item) {
+static void popup_traffic_distortion_blocked(struct item *item) {
     dbg(lvl_debug,"item=%p",item);
     popup_traffic_distortion(item, "maxspeed=0");
 }
 
-static void
-popup_traffic_distortion_speed(struct item *item, int maxspeed) {
+static void popup_traffic_distortion_speed(struct item *item, int maxspeed) {
     char buffer[256];
     sprintf(buffer,"maxspeed=%d",maxspeed);
     popup_traffic_distortion(item,buffer);
 }
 
-static void
-popup_traffic_distortion_delay(struct item *item, int delay) {
+static void popup_traffic_distortion_delay(struct item *item, int delay) {
     char buffer[256];
     sprintf(buffer,"delay=%d",delay*600);
     popup_traffic_distortion(item,buffer);
 }
 
-static void
-popup_set_destination(struct navit *nav, struct pcoord *pc) {
+static void popup_set_destination(struct navit *nav, struct pcoord *pc) {
     struct coord c;
     struct coord_geo g;
     char buffer[1024];
@@ -125,8 +119,7 @@ popup_set_destination(struct navit *nav, struct pcoord *pc) {
 }
 
 
-void
-popup_set_visitbefore(struct navit *nav, struct pcoord *pc,int visitbefore) {
+void popup_set_visitbefore(struct navit *nav, struct pcoord *pc,int visitbefore) {
     struct pcoord *dst;
     char buffer[1024];
     int i, dstcount_new;
@@ -144,8 +137,7 @@ popup_set_visitbefore(struct navit *nav, struct pcoord *pc,int visitbefore) {
 
 
 
-static void
-popup_set_bookmark(struct navit *nav, struct pcoord *pc) {
+static void popup_set_bookmark(struct navit *nav, struct pcoord *pc) {
     struct attr attr;
     struct coord c;
     struct coord_geo g;
@@ -165,15 +157,13 @@ popup_set_bookmark(struct navit *nav, struct pcoord *pc) {
 
 extern void *vehicle;
 
-static void
-popup_set_position(struct navit *nav, struct pcoord *pc) {
+static void popup_set_position(struct navit *nav, struct pcoord *pc) {
     dbg(lvl_debug,"%p %p", nav, pc);
     navit_set_position(nav, pc);
 }
 
 #if 0
-static void
-popup_break_crossing(struct display_list *l) {
+static void popup_break_crossing(struct display_list *l) {
     struct segment *seg=(struct segment *)(l->data);
     struct street_str *str=(struct street_str *)(seg->data[0]);
     char log[256];
@@ -190,8 +180,7 @@ popup_break_crossing(struct display_list *l) {
 
 #define popup_printf(menu, type, ...) popup_printf_cb(menu, type, NULL, __VA_ARGS__)
 
-static void *
-popup_printf_cb(void *menu, enum menu_type type, struct callback *cb, const char *fmt, ...) {
+static void *popup_printf_cb(void *menu, enum menu_type type, struct callback *cb, const char *fmt, ...) {
     gchar *str,*us;
     int usc=0;
     va_list ap;
@@ -227,8 +216,7 @@ popup_printf_cb(void *menu, enum menu_type type, struct callback *cb, const char
 
 
 
-static void
-popup_show_visitbefore(struct navit *nav,struct pcoord *pc, void *menu) {
+static void popup_show_visitbefore(struct navit *nav,struct pcoord *pc, void *menu) {
     void *menuvisitbefore;
     char buffer[100];
     int i, dstcount;
@@ -243,8 +231,7 @@ popup_show_visitbefore(struct navit *nav,struct pcoord *pc, void *menu) {
     }
 }
 
-static void
-popup_show_attr_val(struct map *map, void *menu, struct attr *attr) {
+static void popup_show_attr_val(struct map *map, void *menu, struct attr *attr) {
     char *attr_name=attr_to_name(attr->type);
     char *str;
 
@@ -254,8 +241,7 @@ popup_show_attr_val(struct map *map, void *menu, struct attr *attr) {
 }
 
 #if 0
-static void
-popup_show_attr(void *menu, struct item *item, enum attr_type attr_type) {
+static void popup_show_attr(void *menu, struct item *item, enum attr_type attr_type) {
     struct attr attr;
     memset(&attr, 0, sizeof(attr));
     attr.type=attr_type;
@@ -264,8 +250,7 @@ popup_show_attr(void *menu, struct item *item, enum attr_type attr_type) {
 }
 #endif
 
-static void
-popup_show_attrs(struct map *map, void *menu, struct item *item) {
+static void popup_show_attrs(struct map *map, void *menu, struct item *item) {
 #if 0
     popup_show_attr(menu, item, attr_debug);
     popup_show_attr(menu, item, attr_address);
@@ -286,8 +271,7 @@ popup_show_attrs(struct map *map, void *menu, struct item *item) {
 #endif
 }
 
-static void
-popup_item_dump(struct item *item) {
+static void popup_item_dump(struct item *item) {
     struct map_rect *mr;
     mr=map_rect_new(item->map,NULL);
     item=map_rect_get_item_byid(mr, item->id_hi, item->id_lo);
@@ -297,8 +281,7 @@ popup_item_dump(struct item *item) {
 }
 
 
-static void
-popup_show_item(struct navit *nav, void *popup, struct displayitem *di) {
+static void popup_show_item(struct navit *nav, void *popup, struct displayitem *di) {
     struct map_rect *mr;
     void *menu, *menu_item, *menu_dist;
     char *label;
@@ -374,8 +357,7 @@ popup_show_item(struct navit *nav, void *popup, struct displayitem *di) {
     }
 }
 
-static void
-popup_display(struct navit *nav, void *popup, struct point *p) {
+static void popup_display(struct navit *nav, void *popup, struct point *p) {
     struct displaylist_handle *dlh;
     struct displaylist *display;
     struct displayitem *di;
@@ -392,8 +374,7 @@ popup_display(struct navit *nav, void *popup, struct point *p) {
 
 static struct pcoord c;
 
-void
-popup(struct navit *nav, int button, struct point *p) {
+void popup(struct navit *nav, int button, struct point *p) {
     void *popup,*men;
     char buffer[1024];
     struct coord_geo g;

--- a/navit/profile.c
+++ b/navit/profile.c
@@ -53,8 +53,7 @@
  * parameters as varargs. May be NULL; then no message is printed, and all timers with the
  * same or higher level are reset.
  */
-void
-profile_timer(int level, const char *module, const char *function, const char *fmt, ...) {
+void profile_timer(int level, const char *module, const char *function, const char *fmt, ...) {
 #ifndef _MSC_VER
     va_list ap;
     static struct timeval last[PROFILE_LEVEL_MAX+1];

--- a/navit/profile_option.c
+++ b/navit/profile_option.c
@@ -26,8 +26,7 @@ struct profile_option {
     NAVIT_OBJECT
 };
 
-static struct profile_option *
-profile_option_new(struct attr *parent, struct attr **attrs) {
+static struct profile_option *profile_option_new(struct attr *parent, struct attr **attrs) {
     struct profile_option *po=g_new0(struct profile_option, 1);
     po->func=&profile_option_func;
     navit_object_ref((struct navit_object *)po);
@@ -36,8 +35,7 @@ profile_option_new(struct attr *parent, struct attr **attrs) {
     return po;
 }
 
-static void
-profile_option_destroy(struct profile_option *po) {
+static void profile_option_destroy(struct profile_option *po) {
     attr_list_free(po->attrs);
     g_free(po);
 }

--- a/navit/projection.c
+++ b/navit/projection.c
@@ -36,8 +36,7 @@ struct projection_name projection_names[]= {
     {projection_utm, "utm"},
 };
 
-static int
-utmref_letter(char l) {
+static int utmref_letter(char l) {
     if (l < 'a' || l == 'i' || l == 'o')
         return -1;
     if (l < 'i')
@@ -56,8 +55,7 @@ utmref_letter(char l) {
  * @utm_offset Only for UTM projections: Used to return the offset for the UTM projection
  * @returns projection, or projection_none if no projection could be determined
  */
-enum projection
-projection_from_name(const char *name, struct coord *utm_offset) {
+enum projection projection_from_name(const char *name, struct coord *utm_offset) {
     int i;
     int zone,baserow;
     char ns,zone_field,square_x,square_y;
@@ -97,8 +95,7 @@ projection_from_name(const char *name, struct coord *utm_offset) {
     return projection_none;
 }
 
-char *
-projection_to_name(enum projection proj) {
+char *projection_to_name(enum projection proj) {
     int i;
 
     for (i=0 ; i < sizeof(projection_names)/sizeof(struct projection_name) ; i++) {

--- a/navit/roadprofile.c
+++ b/navit/roadprofile.c
@@ -23,8 +23,7 @@
 #include "xmlconfig.h"
 #include "roadprofile.h"
 
-static void
-roadprofile_set_attr_do(struct roadprofile *this, struct attr *attr) {
+static void roadprofile_set_attr_do(struct roadprofile *this, struct attr *attr) {
     switch (attr->type) {
     case attr_speed:
         this->speed=attr->u.num;
@@ -54,26 +53,22 @@ roadprofile_new(struct attr *parent, struct attr **attrs) {
     return this_;
 }
 
-int
-roadprofile_get_attr(struct roadprofile *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int roadprofile_get_attr(struct roadprofile *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     return attr_generic_get_attr(this_->attrs, NULL, type, attr, iter);
 }
 
-int
-roadprofile_set_attr(struct roadprofile *this_, struct attr *attr) {
+int roadprofile_set_attr(struct roadprofile *this_, struct attr *attr) {
     roadprofile_set_attr_do(this_, attr);
     this_->attrs=attr_generic_set_attr(this_->attrs, attr);
     return 1;
 }
 
-int
-roadprofile_add_attr(struct roadprofile *this_, struct attr *attr) {
+int roadprofile_add_attr(struct roadprofile *this_, struct attr *attr) {
     this_->attrs=attr_generic_add_attr(this_->attrs, attr);
     return 1;
 }
 
-int
-roadprofile_remove_attr(struct roadprofile *this_, struct attr *attr) {
+int roadprofile_remove_attr(struct roadprofile *this_, struct attr *attr) {
     this_->attrs=attr_generic_remove_attr(this_->attrs, attr);
     return 1;
 }
@@ -83,13 +78,11 @@ roadprofile_attr_iter_new(void) {
     return (struct attr_iter *)g_new0(void *,1);
 }
 
-void
-roadprofile_attr_iter_destroy(struct attr_iter *iter) {
+void roadprofile_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
-static struct roadprofile *
-roadprofile_dup(struct roadprofile *this_) {
+static struct roadprofile *roadprofile_dup(struct roadprofile *this_) {
     struct roadprofile *ret=g_new(struct roadprofile, 1);
     *ret=*this_;
     ret->refcount=1;
@@ -97,8 +90,7 @@ roadprofile_dup(struct roadprofile *this_) {
     return ret;
 }
 
-static void
-roadprofile_destroy(struct roadprofile *this_) {
+static void roadprofile_destroy(struct roadprofile *this_) {
     attr_list_free(this_->attrs);
     g_free(this_);
 }

--- a/navit/route.c
+++ b/navit/route.c
@@ -350,8 +350,7 @@ static enum projection route_projection(struct route *route) {
  * @param p The route graph point to create the iterator from
  * @return A new iterator.
  */
-static struct route_graph_point_iterator
-rp_iterator_new(struct route_graph_point *p) {
+static struct route_graph_point_iterator rp_iterator_new(struct route_graph_point *p) {
     struct route_graph_point_iterator it;
 
     it.p = p;
@@ -401,8 +400,7 @@ static struct route_graph_segment
  * @param it The route graph point iterator to be checked
  * @return 1 if the last segment returned comes from the end of the route graph point, 0 otherwise
  */
-static int
-rp_iterator_end(struct route_graph_point_iterator *it) {
+static int rp_iterator_end(struct route_graph_point_iterator *it) {
     if (it->end && (it->next != it->p->end)) {
         return 1;
     } else {
@@ -410,8 +408,7 @@ rp_iterator_end(struct route_graph_point_iterator *it) {
     }
 }
 
-static void
-route_path_get_distances(struct route_path *path, struct coord *c, int count, int *distances) {
+static void route_path_get_distances(struct route_path *path, struct coord *c, int count, int *distances) {
     int i;
     for (i = 0 ; i < count ; i++)
         distances[i]=INT_MAX;
@@ -433,8 +430,7 @@ route_path_get_distances(struct route_path *path, struct coord *c, int count, in
     }
 }
 
-void
-route_get_distances(struct route *this, struct coord *c, int count, int *distances) {
+void route_get_distances(struct route *this, struct coord *c, int count, int *distances) {
     return route_path_get_distances(this->path2, c, count, distances);
 }
 
@@ -443,8 +439,7 @@ route_get_distances(struct route *this, struct coord *c, int count, int *distanc
  *
  * @param this The route_path to be destroyed
  */
-static void
-route_path_destroy(struct route_path *this, int recurse) {
+static void route_path_destroy(struct route_path *this, int recurse) {
     struct route_path_segment *c,*n;
     struct route_path *next;
     while (this) {
@@ -523,8 +518,8 @@ route_dup(struct route *orig) {
  * @param origin Used internally, set to NULL
  * @return 1 If a roundabout was detected, 0 otherwise
  */
-static int
-route_check_roundabout(struct route_graph_segment *seg, int level, int direction, struct route_graph_segment *origin) {
+static int route_check_roundabout(struct route_graph_segment *seg, int level, int direction,
+                                  struct route_graph_segment *origin) {
     struct route_graph_point_iterator it,it2;
     struct route_graph_segment *cur;
     int count=0;
@@ -592,8 +587,7 @@ route_check_roundabout(struct route_graph_segment *seg, int level, int direction
  * @param this The route to set the mapset for
  * @param ms The mapset to set for this route
  */
-void
-route_set_mapset(struct route *this, struct mapset *ms) {
+void route_set_mapset(struct route *this, struct mapset *ms) {
     this->ms=ms;
 }
 
@@ -604,8 +598,7 @@ route_set_mapset(struct route *this, struct mapset *ms) {
  * @param prof The vehicle profile
  */
 
-void
-route_set_profile(struct route *this, struct vehicleprofile *prof) {
+void route_set_profile(struct route *this, struct vehicleprofile *prof) {
     if (this->vehicleprofile != prof) {
         int dest_count = g_list_length(this->destinations);
         struct pcoord *pc;
@@ -659,8 +652,7 @@ route_get_dst(struct route *this) {
  * @param this The route to check
  * @return True if the path is calculated, false if not
  */
-int
-route_get_path_set(struct route *this) {
+int route_get_path_set(struct route *this) {
     return this->path2 != NULL;
 }
 
@@ -675,8 +667,7 @@ route_get_path_set(struct route *this) {
  * @param item The item to search for
  * @return True if the item was found, false if the item was not found or the route was not calculated
  */
-int
-route_contains(struct route *this, struct item *item) {
+int route_contains(struct route *this, struct item *item) {
     if (! this->path2 || !this->path2->path_hash)
         return 0;
     if (item_hash_lookup(this->path2->path_hash, item))
@@ -687,8 +678,7 @@ route_contains(struct route *this, struct item *item) {
 
 }
 
-static struct route_info *
-route_next_destination(struct route *this) {
+static struct route_info *route_next_destination(struct route *this) {
     if (!this->destinations)
         return NULL;
     return this->destinations->data;
@@ -700,8 +690,7 @@ route_next_destination(struct route *this) {
  * @param this The route to be checked
  * @return True if the destination is "reached", false otherwise.
  */
-int
-route_destination_reached(struct route *this) {
+int route_destination_reached(struct route *this) {
     struct street_data *sd = NULL;
     enum projection pro;
     struct route_info *dst=route_next_destination(this);
@@ -751,8 +740,7 @@ route_destination_reached(struct route *this) {
  * @param this The route object
  * @return The previous destination or current position, see description
  */
-static struct route_info *
-route_previous_destination(struct route *this) {
+static struct route_info *route_previous_destination(struct route *this) {
     GList *l=g_list_find(this->destinations, this->current_dst);
     if (!l)
         return this->pos;
@@ -775,8 +763,7 @@ route_previous_destination(struct route *this) {
  * @param new_graph FIXME Whether the route graph has been rebuilt from scratch
  */
 /* FIXME Should we rename this function to route_graph_flood_done, in order to avoid confusion? */
-static void
-route_path_update_done(struct route *this, int new_graph) {
+static void route_path_update_done(struct route *this, int new_graph) {
     struct route_path *oldpath=this->path2;
     struct attr route_status;
     struct route_info *prev_dst; /* previous destination or current position */
@@ -854,8 +841,7 @@ route_path_update_done(struct route *this, int new_graph) {
  * @param this The route to update
  * @param flags Flags to control the behavior of this function, see description
  */
-static void
-route_path_update_flags(struct route *this, enum route_path_flags flags) {
+static void route_path_update_flags(struct route *this, enum route_path_flags flags) {
     dbg(lvl_debug,"enter %d", flags);
     this->flags = flags;
     if (! this->pos || ! this->destinations) {
@@ -899,8 +885,7 @@ route_path_update_flags(struct route *this, enum route_path_flags flags) {
  * @param cancel If true, cancel navigation, clear route graph and route path
  * @param async If true, perform processing asynchronously
  */
-static void
-route_path_update(struct route *this, int cancel, int async) {
+static void route_path_update(struct route *this, int cancel, int async) {
     enum route_path_flags flags=(cancel ? route_path_flag_cancel:0)|(async ? route_path_flag_async:0);
     route_path_update_flags(this, flags);
 }
@@ -912,8 +897,7 @@ route_path_update(struct route *this, int cancel, int async) {
  * @param ri The route_info to calculate the distances for
  * @param pro The projection used for this route
  */
-static void
-route_info_distances(struct route_info *ri, enum projection pro) {
+static void route_info_distances(struct route_info *ri, enum projection pro) {
     int npos=ri->pos+1;
     struct street_data *sd=ri->street;
     /* 0 1 2 X 3 4 5 6 pos=2 npos=3 count=7 0,1,2 3,4,5,6*/
@@ -937,8 +921,7 @@ route_info_distances(struct route_info *ri, enum projection pro) {
  * @param flags Flags to use for building the graph
  */
 
-static int
-route_set_position_flags(struct route *this, struct pcoord *pos, enum route_path_flags flags) {
+static int route_set_position_flags(struct route *this, struct pcoord *pos, enum route_path_flags flags) {
     if (this->pos)
         route_info_free(this->pos);
     this->pos=NULL;
@@ -963,8 +946,7 @@ route_set_position_flags(struct route *this, struct pcoord *pos, enum route_path
  * @param this The route to set the position of
  * @param pos Coordinates to set as position
  */
-void
-route_set_position(struct route *this, struct pcoord *pos) {
+void route_set_position(struct route *this, struct pcoord *pos) {
     route_set_position_flags(this, pos, route_path_flag_async);
 }
 
@@ -974,8 +956,7 @@ route_set_position(struct route *this, struct pcoord *pos) {
  * @param this The route to set the current position of
  * @param tracking The tracking to get the coordinates from
  */
-void
-route_set_position_from_tracking(struct route *this, struct tracking *tracking, enum projection pro) {
+void route_set_position_from_tracking(struct route *this, struct tracking *tracking, enum projection pro) {
     struct coord *c;
     struct route_info *ret;
     struct street_data *sd;
@@ -1064,8 +1045,8 @@ route_rect(int order, struct coord *c1, struct coord *c2, int rel, int abs) {
 /**
  * @brief Appends a map selection to the selection list. Selection list may be NULL.
  */
-static struct map_selection *
-route_rect_add(struct map_selection *sel, int order, struct coord *c1, struct coord *c2, int rel, int abs) {
+static struct map_selection *route_rect_add(struct map_selection *sel, int order, struct coord *c1, struct coord *c2,
+        int rel, int abs) {
     struct map_selection *ret;
     ret=route_rect(order, c1, c2, rel, abs);
     ret->next=sel;
@@ -1082,8 +1063,7 @@ route_rect_add(struct map_selection *sel, int order, struct coord *c1, struct co
  * @param count number of route points
  * @param proifle vehicleprofile
  */
-static struct map_selection *
-route_calc_selection(struct coord *c, int count, struct vehicleprofile *profile) {
+static struct map_selection *route_calc_selection(struct coord *c, int count, struct vehicleprofile *profile) {
     struct map_selection *ret=NULL;
     int i;
     struct coord_rect r;
@@ -1123,8 +1103,7 @@ route_calc_selection(struct coord *c, int count, struct vehicleprofile *profile)
  *
  * @param sel Start of the list to be destroyed
  */
-static void
-route_free_selection(struct map_selection *sel) {
+static void route_free_selection(struct map_selection *sel) {
     struct map_selection *next;
     while (sel) {
         next=sel->next;
@@ -1134,8 +1113,7 @@ route_free_selection(struct map_selection *sel) {
 }
 
 
-static void
-route_clear_destinations(struct route *this_) {
+static void route_clear_destinations(struct route *this_) {
     g_list_foreach(this_->destinations, (GFunc)route_info_free, NULL);
     g_list_free(this_->destinations);
     this_->destinations=NULL;
@@ -1154,8 +1132,7 @@ route_clear_destinations(struct route *this_) {
  * @param async If set, do routing asynchronously
  */
 
-void
-route_set_destinations(struct route *this, struct pcoord *dst, int count, int async) {
+void route_set_destinations(struct route *this, struct pcoord *dst, int count, int async) {
     struct attr route_status;
     struct route_info *dsti;
     int i;
@@ -1188,8 +1165,7 @@ route_set_destinations(struct route *this, struct pcoord *dst, int count, int as
     profile(0,"end");
 }
 
-int
-route_get_destinations(struct route *this, struct pcoord *pc, int count) {
+int route_get_destinations(struct route *this, struct pcoord *pc, int count) {
     int ret=0;
     GList *l=this->destinations;
     while (l && ret < count) {
@@ -1210,8 +1186,7 @@ route_get_destinations(struct route *this, struct pcoord *pc, int count) {
  * @param this The route instance
  * @return destination count for the route
  */
-int
-route_get_destination_count(struct route *this) {
+int route_get_destination_count(struct route *this) {
     return g_list_length(this->destinations);
 }
 
@@ -1222,8 +1197,7 @@ route_get_destination_count(struct route *this) {
  * @param n The nth waypoint
  * @return The description
  */
-char*
-route_get_destination_description(struct route *this, int n) {
+char* route_get_destination_description(struct route *this, int n) {
     struct route_info *dst;
     struct map_rect *mr=NULL;
     struct item *item;
@@ -1280,8 +1254,7 @@ route_get_destination_description(struct route *this, int n) {
  * @param async Set to 1 to do route calculation asynchronously
  * @return nothing
  */
-void
-route_set_destination(struct route *this, struct pcoord *dst, int async) {
+void route_set_destination(struct route *this, struct pcoord *dst, int async) {
     route_set_destinations(this, dst, dst?1:0, async);
 }
 
@@ -1295,8 +1268,7 @@ route_set_destination(struct route *this, struct pcoord *dst, int async) {
  * @param dst Coordinates of the new waypoint
  * @param async: If set, do routing asynchronously
  */
-void
-route_append_destination(struct route *this, struct pcoord *dst, int async) {
+void route_append_destination(struct route *this, struct pcoord *dst, int async) {
     if (dst) {
         struct route_info *dsti;
         dsti=route_find_nearest_street(this->vehicleprofile, this->ms, &dst[0]);
@@ -1321,8 +1293,7 @@ route_append_destination(struct route *this, struct pcoord *dst, int async) {
  * @param n The waypoint to remove
  * @return nothing
  */
-void
-route_remove_nth_waypoint(struct route *this, int n) {
+void route_remove_nth_waypoint(struct route *this, int n) {
     struct route_info *ri=g_list_nth_data(this->destinations, n);
     this->destinations=g_list_remove(this->destinations,ri);
     route_info_free(ri);
@@ -1333,8 +1304,7 @@ route_remove_nth_waypoint(struct route *this, int n) {
     route_path_update(this, 1, 1);
 }
 
-void
-route_remove_waypoint(struct route *this) {
+void route_remove_waypoint(struct route *this) {
     if (this->path2) {
         struct route_path *path = this->path2;
         struct route_info *ri = this->destinations->data;
@@ -1363,8 +1333,8 @@ route_remove_waypoint(struct route *this) {
  * or {@code NULL} to return the first point
  * @return The point at the specified coordinates or NULL if not found
  */
-static struct route_graph_point *
-route_graph_get_point_next(struct route_graph *this, struct coord *c, struct route_graph_point *last) {
+static struct route_graph_point *route_graph_get_point_next(struct route_graph *this, struct coord *c,
+        struct route_graph_point *last) {
     struct route_graph_point *p;
     int seen=0,hashval=HASHCOORD(c);
     p=this->hash[hashval];
@@ -1387,8 +1357,7 @@ route_graph_get_point_next(struct route_graph *this, struct coord *c, struct rou
  * @param c Coordinates to search for
  * @return The point at the specified coordinates or NULL if not found
  */
-static struct route_graph_point *
-route_graph_get_point(struct route_graph *this, struct coord *c) {
+static struct route_graph_point *route_graph_get_point(struct route_graph *this, struct coord *c) {
     return route_graph_get_point_next(this, c, NULL);
 }
 
@@ -1399,8 +1368,7 @@ route_graph_get_point(struct route_graph *this, struct coord *c) {
  * @param c Coordinates to search for
  * @return The point at the specified coordinates or NULL if not found
  */
-static struct route_graph_point *
-route_graph_get_point_last(struct route_graph *this, struct coord *c) {
+static struct route_graph_point *route_graph_get_point_last(struct route_graph *this, struct coord *c) {
     struct route_graph_point *p,*ret=NULL;
     int hashval=HASHCOORD(c);
     p=this->hash[hashval];
@@ -1422,8 +1390,7 @@ route_graph_get_point_last(struct route_graph *this, struct coord *c) {
  * @return The point created
  */
 
-static struct route_graph_point *
-route_graph_point_new(struct route_graph *this, struct coord *f) {
+static struct route_graph_point *route_graph_point_new(struct route_graph *this, struct coord *f) {
     int hashval;
     struct route_graph_point *p;
 
@@ -1451,8 +1418,7 @@ route_graph_point_new(struct route_graph *this, struct coord *f) {
  * @param f The coordinates at which the point should be inserted
  * @return The point inserted or NULL on failure
  */
-static struct route_graph_point *
-route_graph_add_point(struct route_graph *this, struct coord *f) {
+static struct route_graph_point *route_graph_add_point(struct route_graph *this, struct coord *f) {
     struct route_graph_point *p;
 
     p=route_graph_get_point(this,f);
@@ -1466,8 +1432,7 @@ route_graph_add_point(struct route_graph *this, struct coord *f) {
  *
  * @param this The route graph to delete all points from
  */
-static void
-route_graph_free_points(struct route_graph *this) {
+static void route_graph_free_points(struct route_graph *this) {
     struct route_graph_point *curr,*next;
     int i;
     for (i = 0 ; i < HASH_SIZE ; i++) {
@@ -1494,8 +1459,7 @@ route_graph_free_points(struct route_graph *this) {
  *
  * @param this The route graph to reset
  */
-static void
-route_graph_reset(struct route_graph *this) {
+static void route_graph_reset(struct route_graph *this) {
     struct route_graph_point *curr;
     int i;
     for (i = 0 ; i < HASH_SIZE ; i++) {
@@ -1519,8 +1483,7 @@ route_graph_reset(struct route_graph *this) {
  * @param type Type of the field that should be returned
  * @return A pointer to a field of a certain type, or NULL if no such field is present
  */
-static void *
-route_segment_data_field_pos(struct route_segment_data *seg, enum attr_type type) {
+static void *route_segment_data_field_pos(struct route_segment_data *seg, enum attr_type type) {
     unsigned char *ptr;
 
     ptr = ((unsigned char*)seg) + sizeof(struct route_segment_data);
@@ -1554,8 +1517,7 @@ route_segment_data_field_pos(struct route_segment_data *seg, enum attr_type type
  * @param flags The flags of the route_segment_data
  */
 
-static int
-route_segment_data_size(int flags) {
+static int route_segment_data_size(int flags) {
     int ret=sizeof(struct route_segment_data);
     if (flags & AF_SPEED_LIMIT)
         ret+=sizeof(int);
@@ -1578,8 +1540,7 @@ route_segment_data_size(int flags) {
  * @param start The starting point of the segment
  * @param data The data for the segment
  */
-static int
-route_graph_segment_is_duplicate(struct route_graph_point *start, struct route_graph_segment_data *data) {
+static int route_graph_segment_is_duplicate(struct route_graph_point *start, struct route_graph_segment_data *data) {
     struct route_graph_segment *s;
     s=start->start;
     while (s) {
@@ -1608,9 +1569,8 @@ route_graph_segment_is_duplicate(struct route_graph_point *start, struct route_g
  * @param offset If the item passed in "item" is segmented (i.e. divided into several segments), this indicates the position of this segment within the item
  * @param maxspeed The maximum speed allowed on this segment in km/h. -1 if not known.
  */
-static void
-route_graph_add_segment(struct route_graph *this, struct route_graph_point *start,
-                        struct route_graph_point *end, struct route_graph_segment_data *data) {
+static void route_graph_add_segment(struct route_graph *this, struct route_graph_point *start,
+                                    struct route_graph_point *end, struct route_graph_segment_data *data) {
     struct route_graph_segment *s;
     int size;
 
@@ -1698,9 +1658,8 @@ static int get_item_seg_coords(struct item *i, struct coord *c, int max,
  * @param offset Offset of the segment within the item to remove. If the item is not segmented this should be 1.
  * @return The segment removed
  */
-static struct route_path_segment *
-route_extract_segment_from_path(struct route_path *path, struct item *item,
-                                int offset) {
+static struct route_path_segment *route_extract_segment_from_path(struct route_path *path, struct item *item,
+        int offset) {
     int soffset;
     struct route_path_segment *sp = NULL, *s;
     s = path->path;
@@ -1734,8 +1693,7 @@ route_extract_segment_from_path(struct route_path *path, struct item *item,
  * @param this The path to add the segment to
  * @param segment The segment to add
  */
-static void
-route_path_add_segment(struct route_path *this, struct route_path_segment *segment) {
+static void route_path_add_segment(struct route_path *this, struct route_path_segment *segment) {
     if (!this->path)
         this->path=segment;
     if (this->path_last)
@@ -1753,8 +1711,7 @@ route_path_add_segment(struct route_path *this, struct route_path_segment *segme
  * @param end coordinate to add to the end of the item. If none should be added, make this NULL.
  * @param len The length of the item
  */
-static void
-route_path_add_line(struct route_path *this, struct coord *start, struct coord *end, int len) {
+static void route_path_add_line(struct route_path *this, struct coord *start, struct coord *end, int len) {
     int ccnt=2;
     struct route_path_segment *segment;
     int seg_size,seg_dat_size;
@@ -1790,9 +1747,9 @@ route_path_add_line(struct route_path *this, struct coord *start, struct coord *
  * @param dst  Information about end point if this is the last segment
  */
 
-static int
-route_path_add_item_from_graph(struct route_path *this, struct route_path *oldpath, struct route_graph_segment *rgs,
-                               int dir, struct route_info *pos, struct route_info *dst) {
+static int route_path_add_item_from_graph(struct route_path *this, struct route_path *oldpath,
+        struct route_graph_segment *rgs,
+        int dir, struct route_info *pos, struct route_info *dst) {
     struct route_path_segment *segment=NULL;
     int i, ccnt, extra=0, ret=0;
     struct coord *c,*cd,ca[2048];
@@ -1908,8 +1865,7 @@ linkold:
  *
  * @param this The graph to destroy all segments from
  */
-static void
-route_graph_free_segments(struct route_graph *this) {
+static void route_graph_free_segments(struct route_graph *this) {
     struct route_graph_segment *curr,*next;
     int size;
     curr=this->route_segments;
@@ -1927,8 +1883,7 @@ route_graph_free_segments(struct route_graph *this) {
  *
  * @param this The route graph to be destroyed
  */
-static void
-route_graph_destroy(struct route_graph *this) {
+static void route_graph_destroy(struct route_graph *this) {
     if (this) {
         route_graph_build_done(this, 1);
         route_graph_free_points(this);
@@ -1961,9 +1916,8 @@ route_graph_destroy(struct route_graph *this) {
  * @param dist A traffic distortion if applicable, or {@code NULL}
  * @return The estimated speed in km/h, or 0 if the segment is impassable
  */
-static int
-route_seg_speed(struct vehicleprofile *profile, struct route_segment_data *over,
-                struct route_traffic_distortion *dist) {
+static int route_seg_speed(struct vehicleprofile *profile, struct route_segment_data *over,
+                           struct route_traffic_distortion *dist) {
     struct roadprofile *roadprofile=vehicleprofile_get_roadprofile(profile, over->item.type);
     int speed,maxspeed;
     if (!roadprofile || !roadprofile->route_weight)
@@ -2014,8 +1968,8 @@ route_seg_speed(struct vehicleprofile *profile, struct route_segment_data *over,
  * @return The time needed in tenths of seconds
  */
 
-static int
-route_time_seg(struct vehicleprofile *profile, struct route_segment_data *over, struct route_traffic_distortion *dist) {
+static int route_time_seg(struct vehicleprofile *profile, struct route_segment_data *over,
+                          struct route_traffic_distortion *dist) {
     int speed=route_seg_speed(profile, over, dist);
     if (!speed)
         return INT_MAX;
@@ -2030,8 +1984,7 @@ route_time_seg(struct vehicleprofile *profile, struct route_segment_data *over, 
  *
  * @return true if a traffic distortion was found, 0 if not
  */
-static int
-route_get_traffic_distortion(struct route_graph_segment *seg, struct route_traffic_distortion *ret) {
+static int route_get_traffic_distortion(struct route_graph_segment *seg, struct route_traffic_distortion *ret) {
     struct route_graph_point *start=seg->start;
     struct route_graph_point *end=seg->end;
     struct route_graph_segment *tmp,*found=NULL;
@@ -2058,8 +2011,7 @@ route_get_traffic_distortion(struct route_graph_segment *seg, struct route_traff
     return 0;
 }
 
-static int
-route_through_traffic_allowed(struct vehicleprofile *profile, struct route_graph_segment *seg) {
+static int route_through_traffic_allowed(struct vehicleprofile *profile, struct route_graph_segment *seg) {
     return (seg->data.flags & AF_THROUGH_TRAFFIC_LIMIT) == 0;
 }
 
@@ -2082,9 +2034,9 @@ route_through_traffic_allowed(struct vehicleprofile *profile, struct route_graph
  * @return The "cost" needed to travel along the segment
  */
 
-static int
-route_value_seg(struct vehicleprofile *profile, struct route_graph_point *from, struct route_graph_segment *over,
-                int dir) {
+static int route_value_seg(struct vehicleprofile *profile, struct route_graph_point *from,
+                           struct route_graph_segment *over,
+                           int dir) {
     int ret;
     struct route_traffic_distortion dist,*distp=NULL;
     if ((over->data.flags & (dir >= 0 ? profile->flags_forward_mask : profile->flags_reverse_mask)) != profile->flags)
@@ -2116,8 +2068,7 @@ route_value_seg(struct vehicleprofile *profile, struct route_graph_point *from, 
  * @param s2 The second segment
  * @return true if both segments match, false if not
  */
-static int
-route_graph_segment_match(struct route_graph_segment *s1, struct route_graph_segment *s2) {
+static int route_graph_segment_match(struct route_graph_segment *s1, struct route_graph_segment *s2) {
     if (!s1 || !s2)
         return 0;
     return (s1->start->c.x == s2->start->c.x && s1->start->c.y == s2->start->c.y &&
@@ -2135,8 +2086,7 @@ route_graph_segment_match(struct route_graph_segment *s1, struct route_graph_seg
  * @param seg The segment to which the traffic distortion applies
  * @param delay Delay in tenths of a second, or 0 to clear an existing traffic distortion
  */
-static void
-route_graph_set_traffic_distortion(struct route_graph *this, struct route_graph_segment *seg, int delay) {
+static void route_graph_set_traffic_distortion(struct route_graph *this, struct route_graph_segment *seg, int delay) {
     struct route_graph_point *start=NULL;
     struct route_graph_segment *s;
 
@@ -2170,8 +2120,7 @@ route_graph_set_traffic_distortion(struct route_graph *this, struct route_graph_
  * @param this The route graph to add to
  * @param item The item to add, must be of {@code type_traffic_distortion}
  */
-static void
-route_process_traffic_distortion(struct route_graph *this, struct item *item) {
+static void route_process_traffic_distortion(struct route_graph *this, struct item *item) {
     struct route_graph_point *s_pnt,*e_pnt;
     struct coord c,l;
     struct attr delay_attr, maxspeed_attr;
@@ -2207,8 +2156,7 @@ route_process_traffic_distortion(struct route_graph *this, struct item *item) {
  * @param this The route graph to add to
  * @param item The item to add
  */
-static void
-route_process_turn_restriction(struct route_graph *this, struct item *item) {
+static void route_process_turn_restriction(struct route_graph *this, struct item *item) {
     struct route_graph_point *pnt[4];
     struct coord c[5];
     int i,count;
@@ -2250,8 +2198,7 @@ route_process_turn_restriction(struct route_graph *this, struct item *item) {
  * @param item The item to add
  * @param profile		The vehicle profile currently in use
  */
-static void
-route_process_street_graph(struct route_graph *this, struct item *item, struct vehicleprofile *profile) {
+static void route_process_street_graph(struct route_graph *this, struct item *item, struct vehicleprofile *profile) {
 #ifdef AVOID_FLOAT
     int len=0;
 #else
@@ -2371,8 +2318,8 @@ route_process_street_graph(struct route_graph *this, struct item *item, struct v
  *
  * @return The route graph segment, or {@code NULL} if none was found.
  */
-static struct route_graph_segment *
-route_graph_get_segment(struct route_graph *graph, struct street_data *sd, struct route_graph_segment *last) {
+static struct route_graph_segment *route_graph_get_segment(struct route_graph *graph, struct street_data *sd,
+        struct route_graph_segment *last) {
     struct route_graph_point *start=NULL;
     struct route_graph_segment *s;
     int seen=0;
@@ -2412,9 +2359,8 @@ route_graph_get_segment(struct route_graph *graph, struct street_data *sd, struc
  * and how their costs are calculated.
  * @param cb The callback function to call when flooding is complete
  */
-static void
-route_graph_flood(struct route_graph *this, struct route_info *dst, struct vehicleprofile *profile,
-                  struct callback *cb) {
+static void route_graph_flood(struct route_graph *this, struct route_info *dst, struct vehicleprofile *profile,
+                              struct callback *cb) {
     struct route_graph_point *p_min;
     struct route_graph_segment *s=NULL;
     int min,new,val;
@@ -2530,8 +2476,8 @@ route_graph_flood(struct route_graph *this, struct route_info *dst, struct vehic
  * @param dir Not used
  * @return The new path
  */
-static struct route_path *
-route_path_new_offroad(struct route_graph *this, struct route_info *pos, struct route_info *dst) {
+static struct route_path *route_path_new_offroad(struct route_graph *this, struct route_info *pos,
+        struct route_info *dst) {
     struct route_path *ret;
 
     ret=g_new0(struct route_path, 1);
@@ -2612,9 +2558,9 @@ route_get_coord_dist(struct route *this_, int dist) {
  * @param preferences The routing preferences
  * @return The new route path
  */
-static struct route_path *
-route_path_new(struct route_graph *this, struct route_path *oldpath, struct route_info *pos, struct route_info *dst,
-               struct vehicleprofile *profile) {
+static struct route_path *route_path_new(struct route_graph *this, struct route_path *oldpath, struct route_info *pos,
+        struct route_info *dst,
+        struct vehicleprofile *profile) {
     struct route_graph_segment *s=NULL,*s1=NULL,*s2=NULL; /* candidate segments for cheapest path */
     struct route_graph_point *start; /* point at which the next segment starts, i.e. up to which the path is complete */
     struct route_info *posinfo, *dstinfo; /* same as pos and dst, but NULL if not part of current segment */
@@ -2722,8 +2668,7 @@ route_path_new(struct route_graph *this, struct route_path *oldpath, struct rout
     return ret;
 }
 
-static int
-route_graph_build_next_map(struct route_graph *rg) {
+static int route_graph_build_next_map(struct route_graph *rg) {
     do {
         rg->m=mapset_next(rg->h, 2);
         if (! rg->m)
@@ -2736,8 +2681,8 @@ route_graph_build_next_map(struct route_graph *rg) {
 }
 
 
-static int
-is_turn_allowed(struct route_graph_point *p, struct route_graph_segment *from, struct route_graph_segment *to) {
+static int is_turn_allowed(struct route_graph_point *p, struct route_graph_segment *from,
+                           struct route_graph_segment *to) {
     struct route_graph_point *prev,*next;
     struct route_graph_segment *tmp1,*tmp2;
     if (item_is_equal(from->data.item, to->data.item))
@@ -2791,9 +2736,9 @@ is_turn_allowed(struct route_graph_point *p, struct route_graph_segment *from, s
     return 1;
 }
 
-static void
-route_graph_clone_segment(struct route_graph *this, struct route_graph_segment *s, struct route_graph_point *start,
-                          struct route_graph_point *end, int flags) {
+static void route_graph_clone_segment(struct route_graph *this, struct route_graph_segment *s,
+                                      struct route_graph_point *start,
+                                      struct route_graph_point *end, int flags) {
     struct route_graph_segment_data data;
     data.item=&s->data.item;
     data.offset=1;
@@ -2810,9 +2755,8 @@ route_graph_clone_segment(struct route_graph *this, struct route_graph_segment *
     route_graph_add_segment(this, start, end, &data);
 }
 
-static void
-route_graph_process_restriction_segment(struct route_graph *this, struct route_graph_point *p,
-                                        struct route_graph_segment *s, int dir) {
+static void route_graph_process_restriction_segment(struct route_graph *this, struct route_graph_point *p,
+        struct route_graph_segment *s, int dir) {
     struct route_graph_segment *tmp;
     struct route_graph_point *pn;
     struct coord c=p->c;
@@ -2859,8 +2803,7 @@ route_graph_process_restriction_segment(struct route_graph *this, struct route_g
     }
 }
 
-static void
-route_graph_process_restriction_point(struct route_graph *this, struct route_graph_point *p) {
+static void route_graph_process_restriction_point(struct route_graph *this, struct route_graph_point *p) {
     struct route_graph_segment *tmp;
     tmp=p->start;
     dbg(lvl_debug,"node 0x%x,0x%x",p->c.x,p->c.y);
@@ -2880,8 +2823,7 @@ route_graph_process_restriction_point(struct route_graph *this, struct route_gra
     p->flags |= RP_TURN_RESTRICTION_RESOLVED;
 }
 
-static void
-route_graph_process_restrictions(struct route_graph *this) {
+static void route_graph_process_restrictions(struct route_graph *this) {
     struct route_graph_point *curr;
     int i;
     dbg(lvl_debug,"enter");
@@ -2904,8 +2846,7 @@ route_graph_process_restrictions(struct route_graph *this) {
  * @param rg Points to the route graph
  * @param cancel True if the process was aborted before completing, false if it completed normally
  */
-static void
-route_graph_build_done(struct route_graph *rg, int cancel) {
+static void route_graph_build_done(struct route_graph *rg, int cancel) {
     dbg(lvl_debug,"cancel=%d",cancel);
     if (rg->idle_ev)
         event_remove_idle(rg->idle_ev);
@@ -2926,8 +2867,7 @@ route_graph_build_done(struct route_graph *rg, int cancel) {
     rg->busy=0;
 }
 
-static void
-route_graph_build_idle(struct route_graph *rg, struct vehicleprofile *profile) {
+static void route_graph_build_idle(struct route_graph *rg, struct vehicleprofile *profile) {
     int count=1000;
     struct item *item;
 
@@ -2969,9 +2909,9 @@ route_graph_build_idle(struct route_graph *rg, struct vehicleprofile *profile) {
  * @return The new route graph.
  */
 // FIXME documentation does not match argument list
-static struct route_graph *
-route_graph_build(struct mapset *ms, struct coord *c, int count, struct callback *done_cb, int async,
-                  struct vehicleprofile *profile) {
+static struct route_graph *route_graph_build(struct mapset *ms, struct coord *c, int count, struct callback *done_cb,
+        int async,
+        struct vehicleprofile *profile) {
     struct route_graph *ret=g_new0(struct route_graph, 1);
 
     dbg(lvl_debug,"enter");
@@ -2991,8 +2931,7 @@ route_graph_build(struct mapset *ms, struct coord *c, int count, struct callback
     return ret;
 }
 
-static void
-route_graph_update_done(struct route *this, struct callback *cb) {
+static void route_graph_update_done(struct route *this, struct callback *cb) {
     route_graph_flood(this->graph, this->current_dst, this->vehicleprofile, cb);
 }
 
@@ -3006,8 +2945,7 @@ route_graph_update_done(struct route *this, struct callback *cb) {
  * @param cb The callback function to call when the route graph update is complete (used only in asynchronous mode)
  * @param async Set to nonzero in order to update the route graph asynchronously
  */
-static void
-route_graph_update(struct route *this, struct callback *cb, int async) {
+static void route_graph_update(struct route *this, struct callback *cb, int async) {
     struct attr route_status;
     struct coord *c=g_alloca(sizeof(struct coord)*(1+g_list_length(this->destinations)));
     int i=0;
@@ -3107,8 +3045,7 @@ street_data_dup(struct street_data *orig) {
  *
  * @param sd Street data to be freed
  */
-void
-street_data_free(struct street_data *sd) {
+void street_data_free(struct street_data *sd) {
     g_free(sd);
 }
 
@@ -3119,8 +3056,8 @@ street_data_free(struct street_data *sd) {
  * @param pc The coordinate to find a street nearby
  * @return The nearest street
  */
-static struct route_info *
-route_find_nearest_street(struct vehicleprofile *vehicleprofile, struct mapset *ms, struct pcoord *pc) {
+static struct route_info *route_find_nearest_street(struct vehicleprofile *vehicleprofile, struct mapset *ms,
+        struct pcoord *pc) {
     struct route_info *ret=NULL;
     int max_dist=1000;
     struct map_selection *sel;
@@ -3201,8 +3138,7 @@ route_find_nearest_street(struct vehicleprofile *vehicleprofile, struct mapset *
  *
  * @param info The route info to be destroyed
  */
-void
-route_info_free(struct route_info *inf) {
+void route_info_free(struct route_info *inf) {
     if (!inf)
         return;
     if (inf->street)
@@ -3247,20 +3183,17 @@ struct map_rect_priv {
     GList *dest;
 };
 
-static void
-rm_coord_rewind(void *priv_data) {
+static void rm_coord_rewind(void *priv_data) {
     struct map_rect_priv *mr = priv_data;
     mr->last_coord = 0;
 }
 
-static void
-rm_attr_rewind(void *priv_data) {
+static void rm_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr = priv_data;
     mr->attr_next = attr_street_item;
 }
 
-static int
-rm_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int rm_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr = priv_data;
     struct route_path_segment *seg=mr->seg;
     struct route *route=mr->mpriv->route;
@@ -3340,8 +3273,7 @@ rm_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     return 0;
 }
 
-static int
-rm_coord_get(void *priv_data, struct coord *c, int count) {
+static int rm_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr = priv_data;
     struct route_path_segment *seg = mr->seg;
     int i,rc=0;
@@ -3389,14 +3321,12 @@ static struct item_methods methods_route_item = {
     rm_attr_get,
 };
 
-static void
-rp_attr_rewind(void *priv_data) {
+static void rp_attr_rewind(void *priv_data) {
     struct map_rect_priv *mr = priv_data;
     mr->attr_next = attr_label;
 }
 
-static int
-rp_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int rp_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *mr = priv_data;
     struct route_graph_point *p = mr->point;
     struct route_graph_segment *seg = mr->rseg;
@@ -3529,8 +3459,7 @@ rp_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
  * @param count How many coordinates to get at a max?
  * @return The number of coordinates retrieved
  */
-static int
-rp_coord_get(void *priv_data, struct coord *c, int count) {
+static int rp_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *mr = priv_data;
     struct route_graph_point *p = mr->point;
     struct route_graph_segment *seg = mr->rseg;
@@ -3584,18 +3513,15 @@ static struct item_methods methods_point_item = {
     rp_attr_get,
 };
 
-static void
-rp_destroy(struct map_priv *priv) {
+static void rp_destroy(struct map_priv *priv) {
     g_free(priv);
 }
 
-static void
-rm_destroy(struct map_priv *priv) {
+static void rm_destroy(struct map_priv *priv) {
     g_free(priv);
 }
 
-static struct map_rect_priv *
-rm_rect_new(struct map_priv *priv, struct map_selection *sel) {
+static struct map_rect_priv *rm_rect_new(struct map_priv *priv, struct map_selection *sel) {
     struct map_rect_priv * mr;
     dbg(lvl_debug,"enter");
     mr=g_new0(struct map_rect_priv, 1);
@@ -3626,8 +3552,7 @@ rm_rect_new(struct map_priv *priv, struct map_selection *sel) {
  * @param sel Here it's possible to specify a point for which to search. Please read the function's description.
  * @return A new map rect's private data
  */
-static struct map_rect_priv *
-rp_rect_new(struct map_priv *priv, struct map_selection *sel) {
+static struct map_rect_priv *rp_rect_new(struct map_priv *priv, struct map_selection *sel) {
     struct map_rect_priv * mr;
 
     dbg(lvl_debug,"enter");
@@ -3647,8 +3572,7 @@ rp_rect_new(struct map_priv *priv, struct map_selection *sel) {
     return mr;
 }
 
-static void
-rm_rect_destroy(struct map_rect_priv *mr) {
+static void rm_rect_destroy(struct map_rect_priv *mr) {
     if (mr->str)
         g_free(mr->str);
     if (mr->coord_sel) {
@@ -3666,8 +3590,7 @@ rm_rect_destroy(struct map_rect_priv *mr) {
     g_free(mr);
 }
 
-static struct item *
-rp_get_item(struct map_rect_priv *mr) {
+static struct item *rp_get_item(struct map_rect_priv *mr) {
     struct route *r = mr->mpriv->route;
     struct route_graph_point *p = mr->point;
     struct route_graph_segment *seg = mr->rseg;
@@ -3732,8 +3655,7 @@ rp_get_item(struct map_rect_priv *mr) {
 
 }
 
-static struct item *
-rp_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *rp_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     struct item *ret=NULL;
     while (id_lo-- > 0)
         ret=rp_get_item(mr);
@@ -3741,8 +3663,7 @@ rp_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
 }
 
 
-static struct item *
-rm_get_item(struct map_rect_priv *mr) {
+static struct item *rm_get_item(struct map_rect_priv *mr) {
     struct route *route=mr->mpriv->route;
     void *id=0;
 
@@ -3806,8 +3727,7 @@ rm_get_item(struct map_rect_priv *mr) {
     return &mr->item;
 }
 
-static struct item *
-rm_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
+static struct item *rm_get_item_byid(struct map_rect_priv *mr, int id_hi, int id_lo) {
     struct item *ret=NULL;
     do {
         ret=rm_get_item(mr);
@@ -3841,8 +3761,7 @@ static struct map_methods route_graph_meth = {
     NULL,
 };
 
-static struct map_priv *
-route_map_new_helper(struct map_methods *meth, struct attr **attrs, int graph) {
+static struct map_priv *route_map_new_helper(struct map_methods *meth, struct attr **attrs, int graph) {
     struct map_priv *ret;
     struct attr *route_attr;
 
@@ -3859,18 +3778,15 @@ route_map_new_helper(struct map_methods *meth, struct attr **attrs, int graph) {
     return ret;
 }
 
-static struct map_priv *
-route_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *route_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     return route_map_new_helper(meth, attrs, 0);
 }
 
-static struct map_priv *
-route_graph_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *route_graph_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     return route_map_new_helper(meth, attrs, 1);
 }
 
-static struct map *
-route_get_map_helper(struct route *this_, struct map **map, char *type, char *description) {
+static struct map *route_get_map_helper(struct route *this_, struct map **map, char *type, char *description) {
     struct attr *attrs[5];
     struct attr a_type,navigation,data,a_description;
     a_type.type=attr_type;
@@ -3940,17 +3856,14 @@ enum route_path_flags route_get_flags(struct route *this_) {
  *
  * @return True if the route has a graph, false if not.
  */
-int
-route_has_graph(struct route *this_) {
+int route_has_graph(struct route *this_) {
     return (this_->graph != NULL);
 }
 
-void
-route_set_projection(struct route *this_, enum projection pro) {
+void route_set_projection(struct route *this_, enum projection pro) {
 }
 
-int
-route_set_attr(struct route *this_, struct attr *attr) {
+int route_set_attr(struct route *this_, struct attr *attr) {
     int attr_updated=0;
     switch (attr->type) {
     case attr_route_status:
@@ -3990,8 +3903,7 @@ route_set_attr(struct route *this_, struct attr *attr) {
     return 1;
 }
 
-int
-route_add_attr(struct route *this_, struct attr *attr) {
+int route_add_attr(struct route *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_callback:
         callback_list_add(this_->cbl2, attr->u.callback);
@@ -4001,8 +3913,7 @@ route_add_attr(struct route *this_, struct attr *attr) {
     }
 }
 
-int
-route_remove_attr(struct route *this_, struct attr *attr) {
+int route_remove_attr(struct route *this_, struct attr *attr) {
     dbg(lvl_debug,"enter");
     switch (attr->type) {
     case attr_callback:
@@ -4016,8 +3927,7 @@ route_remove_attr(struct route *this_, struct attr *attr) {
     }
 }
 
-int
-route_get_attr(struct route *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int route_get_attr(struct route *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     int ret=1;
     switch (type) {
     case attr_map:
@@ -4096,19 +4006,16 @@ route_attr_iter_new(void) {
     return g_new0(struct attr_iter, 1);
 }
 
-void
-route_attr_iter_destroy(struct attr_iter *iter) {
+void route_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
-void
-route_init(void) {
+void route_init(void) {
     plugin_register_category_map("route", route_map_new);
     plugin_register_category_map("route_graph", route_graph_map_new);
 }
 
-void
-route_destroy(struct route *this_) {
+void route_destroy(struct route *this_) {
     this_->refcount++; /* avoid recursion */
     route_path_destroy(this_->path2,1);
     route_graph_destroy(this_->graph);

--- a/navit/script.c
+++ b/navit/script.c
@@ -33,8 +33,7 @@ struct script {
     struct command_saved *cs;
 };
 
-static void
-script_run(struct script *scr) {
+static void script_run(struct script *scr) {
     struct attr *xml_text=attr_search(scr->attrs, NULL, attr_xml_text);
     int error;
     if (!xml_text || !xml_text->u.str) {
@@ -45,8 +44,7 @@ script_run(struct script *scr) {
     command_evaluate_to_void(&scr->parent, xml_text->u.str, &error);
 }
 
-static int
-script_set_attr_int(struct script *scr, struct attr *attr) {
+static int script_set_attr_int(struct script *scr, struct attr *attr) {
     switch (attr->type) {
     case attr_refresh_cond:
         dbg(lvl_debug,"refresh_cond");
@@ -64,8 +62,7 @@ script_set_attr_int(struct script *scr, struct attr *attr) {
     }
 }
 
-static struct script *
-script_new(struct attr *parent, struct attr **attrs) {
+static struct script *script_new(struct attr *parent, struct attr **attrs) {
     struct script *scr=g_new0(struct script, 1);
     scr->func=&script_func;
     navit_object_ref((struct navit_object *)scr);
@@ -79,8 +76,7 @@ script_new(struct attr *parent, struct attr **attrs) {
     return scr;
 }
 
-static void
-script_destroy(struct script *scr) {
+static void script_destroy(struct script *scr) {
     dbg(lvl_debug,"enter %p",scr);
     if (scr->timeout)
         event_remove_timeout(scr->timeout);

--- a/navit/search.c
+++ b/navit/search.c
@@ -72,15 +72,13 @@ struct search_list {
     GList *address_results,*address_results_pos;
 };
 
-static guint
-search_item_hash_hash(gconstpointer key) {
+static guint search_item_hash_hash(gconstpointer key) {
     const struct item *itm=key;
     gconstpointer hashkey=(gconstpointer)GINT_TO_POINTER(itm->id_hi^itm->id_lo);
     return g_direct_hash(hashkey);
 }
 
-static gboolean
-search_item_hash_equal(gconstpointer a, gconstpointer b) {
+static gboolean search_item_hash_equal(gconstpointer a, gconstpointer b) {
     const struct item *itm_a=a;
     const struct item *itm_b=b;
     if (item_is_equal_id(*itm_a, *itm_b))
@@ -111,8 +109,7 @@ static void search_list_search_free(struct search_list *sl, int level);
  * @param attr_type attribute value
  * @return corresponding search list level (country=0, town=1, ...)
  */
-int
-search_list_level(enum attr_type attr_type) {
+int search_list_level(enum attr_type attr_type) {
     switch(attr_type) {
     case attr_country_all:
     case attr_country_id:
@@ -139,8 +136,7 @@ search_list_level(enum attr_type attr_type) {
     }
 }
 
-static char *
-search_fix_spaces(char *str) {
+static char *search_fix_spaces(char *str) {
     int i;
     int len=strlen(str);
     char c,*s,*d,*ret=g_strdup(str);
@@ -174,8 +170,7 @@ struct phrase {
     int wordcount;
 };
 
-static GList *
-search_split_phrases(char *str) {
+static GList *search_split_phrases(char *str) {
     char *s,*d;
     int wordcount=0;
     GList *ret=NULL;
@@ -204,8 +199,7 @@ search_split_phrases(char *str) {
     return ret;
 }
 
-static char *
-search_phrase_str(struct phrase *p) {
+static char *search_phrase_str(struct phrase *p) {
     int len=p->end-p->start;
     char *ret=g_malloc(len+1);
     strncpy(ret, p->start, len);
@@ -213,8 +207,7 @@ search_phrase_str(struct phrase *p) {
     return ret;
 }
 
-static int
-search_phrase_used(struct phrase *p, GList *used_phrases) {
+static int search_phrase_used(struct phrase *p, GList *used_phrases) {
     while (used_phrases) {
         struct phrase *pu=used_phrases->data;
         dbg(lvl_debug,"'%s'-'%s' vs '%s'-'%s'",p->start,p->end,pu->start,pu->end);
@@ -226,17 +219,16 @@ search_phrase_used(struct phrase *p, GList *used_phrases) {
     return 0;
 }
 
-static gint
-search_by_address_compare(gconstpointer a, gconstpointer b) {
+static gint search_by_address_compare(gconstpointer a, gconstpointer b) {
     const struct search_list_result *slra=a;
     const struct search_list_result *slrb=b;
     return slrb->id-slra->id;
 }
 
 
-static GList *
-search_by_address_attr(GList *results, struct search_list *sl, GList *phrases, GList *exclude, enum attr_type attr_type,
-                       int wordcount) {
+static GList *search_by_address_attr(GList *results, struct search_list *sl, GList *phrases, GList *exclude,
+                                     enum attr_type attr_type,
+                                     int wordcount) {
     GList *tmp=phrases;
     struct attr attr;
     attr.type=attr_type;
@@ -284,8 +276,7 @@ search_by_address_attr(GList *results, struct search_list *sl, GList *phrases, G
     return results;
 }
 
-static void
-search_by_address(struct search_list *this_, char *addr) {
+static void search_by_address(struct search_list *this_, char *addr) {
     char *str=search_fix_spaces(addr);
     GList *tmp,*phrases=search_split_phrases(str);
     struct search_list *sl=search_list_new(this_->ms);
@@ -302,8 +293,7 @@ search_by_address(struct search_list *this_, char *addr) {
     // currently dead code, so no way to test it.
 }
 
-static void
-search_address_results_free(struct search_list *this_) {
+static void search_address_results_free(struct search_list *this_) {
     GList *tmp;
     tmp=this_->address_results;
     while (tmp) {
@@ -332,8 +322,7 @@ search_address_results_free(struct search_list *this_) {
  * @param search_attr attributes to use for the search
  * @param partial do partial search? (1=yes,0=no)
  */
-void
-search_list_search(struct search_list *this_, struct attr *search_attr, int partial) {
+void search_list_search(struct search_list *this_, struct attr *search_attr, int partial) {
     struct search_list_level *le;
     int level;
     dbg(lvl_info,"Starting search for '=%s' of type %s", search_attr->u.str, attr_to_name(search_attr->type));
@@ -398,8 +387,7 @@ search_list_select(struct search_list *this_, enum attr_type attr_type, int id, 
     return NULL;
 }
 
-static void
-search_list_common_addattr(struct attr* attr,struct search_list_common *common) {
+static void search_list_common_addattr(struct attr* attr,struct search_list_common *common) {
 
     common->attrs=attr_generic_prepend_attr(common->attrs,attr);
     switch(attr->type) {
@@ -427,8 +415,7 @@ search_list_common_addattr(struct attr* attr,struct search_list_common *common) 
     }
 }
 
-static void
-search_list_common_new(struct item *item, struct search_list_common *common) {
+static void search_list_common_new(struct item *item, struct search_list_common *common) {
     struct attr attr;
     int i;
     enum attr_type common_attrs[]= {
@@ -461,8 +448,7 @@ search_list_common_new(struct item *item, struct search_list_common *common) {
     }
 }
 
-static void
-search_list_common_dup(struct search_list_common *src, struct search_list_common *dst) {
+static void search_list_common_dup(struct search_list_common *src, struct search_list_common *dst) {
     int i;
 
     if(dst->attrs) {
@@ -477,8 +463,7 @@ search_list_common_dup(struct search_list_common *src, struct search_list_common
         dst->c=NULL;
 }
 
-static void
-search_list_common_destroy(struct search_list_common *common) {
+static void search_list_common_destroy(struct search_list_common *common) {
     g_free(common->c);
     attr_list_free(common->attrs);
 
@@ -491,8 +476,7 @@ search_list_common_destroy(struct search_list_common *common) {
     common->attrs=NULL;
 }
 
-static struct search_list_country *
-search_list_country_new(struct item *item) {
+static struct search_list_country *search_list_country_new(struct item *item) {
     struct search_list_country *ret=g_new0(struct search_list_country, 1);
     struct attr attr;
 
@@ -515,8 +499,7 @@ search_list_country_new(struct item *item) {
     return ret;
 }
 
-static struct search_list_country *
-search_list_country_dup(struct search_list_country *this_) {
+static struct search_list_country *search_list_country_dup(struct search_list_country *this_) {
     struct search_list_country *ret=g_new(struct search_list_country, 1);
     ret->car=g_strdup(this_->car);
     ret->iso2=g_strdup(this_->iso2);
@@ -526,8 +509,7 @@ search_list_country_dup(struct search_list_country *this_) {
     return ret;
 }
 
-static void
-search_list_country_destroy(struct search_list_country *this_) {
+static void search_list_country_destroy(struct search_list_country *this_) {
     g_free(this_->car);
     g_free(this_->iso2);
     g_free(this_->iso3);
@@ -536,8 +518,7 @@ search_list_country_destroy(struct search_list_country *this_) {
     g_free(this_);
 }
 
-static struct search_list_town *
-search_list_town_new(struct item *item) {
+static struct search_list_town *search_list_town_new(struct item *item) {
     struct search_list_town *ret=g_new0(struct search_list_town, 1);
     struct attr attr;
     struct coord c;
@@ -562,24 +543,21 @@ search_list_town_new(struct item *item) {
     return ret;
 }
 
-static struct search_list_town *
-search_list_town_dup(struct search_list_town *this_) {
+static struct search_list_town *search_list_town_dup(struct search_list_town *this_) {
     struct search_list_town *ret=g_new0(struct search_list_town, 1);
     ret->county=map_convert_dup(this_->county);
     search_list_common_dup(&this_->common, &ret->common);
     return ret;
 }
 
-static void
-search_list_town_destroy(struct search_list_town *this_) {
+static void search_list_town_destroy(struct search_list_town *this_) {
     map_convert_free(this_->county);
     search_list_common_destroy(&this_->common);
     g_free(this_);
 }
 
 
-static struct search_list_street *
-search_list_street_new(struct item *item) {
+static struct search_list_street *search_list_street_new(struct item *item) {
     struct search_list_street *ret=g_new0(struct search_list_street, 1);
     struct attr attr;
     struct coord p[1024];
@@ -603,24 +581,22 @@ search_list_street_new(struct item *item) {
     return ret;
 }
 
-static struct search_list_street *
-search_list_street_dup(struct search_list_street *this_) {
+static struct search_list_street *search_list_street_dup(struct search_list_street *this_) {
     struct search_list_street *ret=g_new0(struct search_list_street, 1);
     ret->name=map_convert_dup(this_->name);
     search_list_common_dup(&this_->common, &ret->common);
     return ret;
 }
 
-static void
-search_list_street_destroy(struct search_list_street *this_) {
+static void search_list_street_destroy(struct search_list_street *this_) {
     map_convert_free(this_->name);
     search_list_common_destroy(&this_->common);
     g_free(this_);
 }
 
-static struct search_list_house_number *
-search_list_house_number_new(struct item *item, struct house_number_interpolation *inter, char *inter_match,
-                             int inter_partial) {
+static struct search_list_house_number *search_list_house_number_new(struct item *item,
+        struct house_number_interpolation *inter, char *inter_match,
+        int inter_partial) {
     struct search_list_house_number *ret=g_new0(struct search_list_house_number, 1);
     struct attr attr;
     char *house_number=NULL;
@@ -643,23 +619,20 @@ search_list_house_number_new(struct item *item, struct house_number_interpolatio
     return ret;
 }
 
-static struct search_list_house_number *
-search_list_house_number_dup(struct search_list_house_number *this_) {
+static struct search_list_house_number *search_list_house_number_dup(struct search_list_house_number *this_) {
     struct search_list_house_number *ret=g_new0(struct search_list_house_number, 1);
     ret->house_number=map_convert_dup(this_->house_number);
     search_list_common_dup(&this_->common, &ret->common);
     return ret;
 }
 
-static void
-search_list_house_number_destroy(struct search_list_house_number *this_) {
+static void search_list_house_number_destroy(struct search_list_house_number *this_) {
     map_convert_free(this_->house_number);
     search_list_common_destroy(&this_->common);
     g_free(this_);
 }
 
-static void
-search_list_result_destroy(int level, void *p) {
+static void search_list_result_destroy(int level, void *p) {
     switch (level) {
     case 0:
         search_list_country_destroy(p);
@@ -676,8 +649,7 @@ search_list_result_destroy(int level, void *p) {
     }
 }
 
-static struct search_list_result *
-search_list_result_dup(struct search_list_result *slr) {
+static struct search_list_result *search_list_result_dup(struct search_list_result *slr) {
     struct search_list_result *ret=g_new0(struct search_list_result, 1);
     ret->id=slr->id;
     if (slr->c) {
@@ -695,8 +667,7 @@ search_list_result_dup(struct search_list_result *slr) {
     return ret;
 }
 
-static void
-search_list_search_free(struct search_list *sl, int level) {
+static void search_list_search_free(struct search_list *sl, int level) {
     struct search_list_level *le=&sl->levels[level];
     GList *next,*curr;
     if (le->search) {
@@ -722,8 +693,7 @@ search_list_search_free(struct search_list *sl, int level) {
     le->last=NULL;
 }
 
-char *
-search_postal_merge(char *mask, char *new) {
+char *search_postal_merge(char *mask, char *new) {
     int i;
     char *ret=NULL;
     dbg(lvl_debug,"enter %s %s", mask, new);
@@ -747,8 +717,7 @@ search_postal_merge(char *mask, char *new) {
     return ret;
 }
 
-char *
-search_postal_merge_replace(char *mask, char *new) {
+char *search_postal_merge_replace(char *mask, char *new) {
     char *ret=search_postal_merge(mask, new);
     if (!ret)
         return mask;
@@ -757,8 +726,7 @@ search_postal_merge_replace(char *mask, char *new) {
 }
 
 
-static int
-postal_match(char *postal, char *mask) {
+static int postal_match(char *postal, char *mask) {
     for (;;) {
         if ((*postal != *mask) && (*mask != '.'))
             return 0;
@@ -773,8 +741,7 @@ postal_match(char *postal, char *mask) {
     }
 }
 
-static int
-search_add_result(struct search_list_level *le, struct search_list_common *slc) {
+static int search_add_result(struct search_list_level *le, struct search_list_common *slc) {
     struct search_list_common *slo;
     char *merged;
     int unique=0;
@@ -982,12 +949,10 @@ search_list_get_result(struct search_list *this_) {
     return NULL;
 }
 
-void
-search_list_destroy(struct search_list *this_) {
+void search_list_destroy(struct search_list *this_) {
     g_free(this_->postal);
     g_free(this_);
 }
 
-void
-search_init(void) {
+void search_init(void) {
 }

--- a/navit/search_houseno_interpol.c
+++ b/navit/search_houseno_interpol.c
@@ -59,8 +59,7 @@ struct hn_interpol_attr house_number_interpol_attrs[] = {
     { house_number_interpol_attr_END, -1, -1 },
 };
 
-void
-house_number_interpolation_clear_current(struct house_number_interpolation *inter) {
+void house_number_interpolation_clear_current(struct house_number_interpolation *inter) {
     g_free(inter->first);
     g_free(inter->last);
     g_free(inter->curr);
@@ -68,14 +67,12 @@ house_number_interpolation_clear_current(struct house_number_interpolation *inte
     inter->increment=inter->include_end_nodes=-1;
 }
 
-void
-house_number_interpolation_clear_all(struct house_number_interpolation *inter) {
+void house_number_interpolation_clear_all(struct house_number_interpolation *inter) {
     inter->curr_interpol_attr_idx=0;
     house_number_interpolation_clear_current(inter);
 }
 
-static char *
-search_next_house_number_curr_interpol_with_ends(struct house_number_interpolation *inter) {
+static char *search_next_house_number_curr_interpol_with_ends(struct house_number_interpolation *inter) {
     dbg(lvl_debug,"interpolate %s-%s %s",inter->first,inter->last,inter->curr);
     if (!inter->first || !inter->last)
         return NULL;
@@ -98,14 +95,12 @@ search_next_house_number_curr_interpol_with_ends(struct house_number_interpolati
     return inter->curr;
 }
 
-static int
-house_number_is_end_number(char* house_number, struct house_number_interpolation *inter) {
+static int house_number_is_end_number(char* house_number, struct house_number_interpolation *inter) {
     return ( (!strcmp(house_number, inter->first))
              || (!strcmp(house_number, inter->last)) );
 }
 
-static char *
-search_next_house_number_curr_interpol(struct house_number_interpolation *inter) {
+static char *search_next_house_number_curr_interpol(struct house_number_interpolation *inter) {
     char* hn=NULL;
     switch (inter->include_end_nodes) {
     case end_nodes_yes:
@@ -120,8 +115,7 @@ search_next_house_number_curr_interpol(struct house_number_interpolation *inter)
     return hn;
 }
 
-static void
-search_house_number_interpolation_split(char *str, struct house_number_interpolation *inter) {
+static void search_house_number_interpolation_split(char *str, struct house_number_interpolation *inter) {
     char *pos=strchr(str,'-');
     char *first,*last;
     int len;
@@ -208,17 +202,16 @@ search_house_number_coordinate(struct item *item, struct house_number_interpolat
     return ret;
 }
 
-static int
-search_match(char *str, char *search, int partial) {
+static int search_match(char *str, char *search, int partial) {
     if (!partial)
         return (!g_ascii_strcasecmp(str, search));
     else
         return (!g_ascii_strncasecmp(str, search, strlen(search)));
 }
 
-char *
-search_next_interpolated_house_number(struct item *item, struct house_number_interpolation *inter, char *inter_match,
-                                      int inter_partial) {
+char *search_next_interpolated_house_number(struct item *item, struct house_number_interpolation *inter,
+        char *inter_match,
+        int inter_partial) {
     while (1) {
         char *hn;
         struct attr attr;

--- a/navit/speech.c
+++ b/navit/speech.c
@@ -63,15 +63,13 @@ speech_new(struct attr *parent, struct attr **attrs) {
     return this_;
 }
 
-void
-speech_destroy(struct speech *this_) {
+void speech_destroy(struct speech *this_) {
     if (this_->priv)
         this_->meth.destroy(this_->priv);
     navit_object_destroy((struct navit_object *)this_);
 }
 
-int
-speech_say(struct speech *this_, const char *text) {
+int speech_say(struct speech *this_, const char *text) {
     dbg(lvl_debug, "this_=%p text='%s' calling %p", this_, text, this_->meth.say);
     return (this_->meth.say)(this_->priv, text);
 }
@@ -92,8 +90,7 @@ struct attr *speech_default_attrs[]= {
  * @return True if the attribute type was found, false if not
  */
 
-int
-speech_get_attr(struct speech *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int speech_get_attr(struct speech *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     return attr_generic_get_attr(this_->attrs, speech_default_attrs, type, attr, iter);
 }
 
@@ -108,8 +105,7 @@ speech_get_attr(struct speech *this_, enum attr_type type, struct attr *attr, st
  * @param str The string that should be estimated
  * @return Time in tenth of seconds or -1 on error
  */
-int
-speech_estimate_duration(struct speech *this_, char *str) {
+int speech_estimate_duration(struct speech *this_, char *str) {
     int count;
     struct attr cps_attr;
 
@@ -134,8 +130,7 @@ speech_estimate_duration(struct speech *this_, char *str) {
  * @return True if the attr could be set, false otherwise
  */
 
-int
-speech_set_attr(struct speech *this_, struct attr *attr) {
+int speech_set_attr(struct speech *this_, struct attr *attr) {
     this_->attrs=attr_generic_set_attr(this_->attrs, attr);
     //callback_list_call_attr_2(this_->attr_cbl, attr->type, this_, attr);
     return 1;

--- a/navit/speech/android/speech_android.c
+++ b/navit/speech/android/speech_android.c
@@ -33,8 +33,7 @@ struct speech_priv {
     int flags;
 };
 
-static int
-speech_android_say(struct speech_priv *this, const char *text) {
+static int speech_android_say(struct speech_priv *this, const char *text) {
     char *str=g_strdup(text);
     jstring string;
     int i;
@@ -48,8 +47,7 @@ speech_android_say(struct speech_priv *this, const char *text) {
     return 1;
 }
 
-static void
-speech_android_destroy(struct speech_priv *this) {
+static void speech_android_destroy(struct speech_priv *this) {
     g_free(this);
 }
 
@@ -58,8 +56,7 @@ static struct speech_methods speech_android_meth = {
     speech_android_say,
 };
 
-static int
-speech_android_init(struct speech_priv *ret) {
+static int speech_android_init(struct speech_priv *ret) {
     jmethodID cid;
     char *class="org/navitproject/navit/NavitSpeech2";
 
@@ -85,8 +82,7 @@ speech_android_init(struct speech_priv *ret) {
     return 1;
 }
 
-static struct speech_priv *
-speech_android_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
+static struct speech_priv *speech_android_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
     struct speech_priv *this;
     struct attr *flags;
     *meth=speech_android_meth;
@@ -105,7 +101,6 @@ speech_android_new(struct speech_methods *meth, struct attr **attrs, struct attr
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_speech("android", speech_android_new);
 }

--- a/navit/speech/cmdline/speech_cmdline.c
+++ b/navit/speech/cmdline/speech_cmdline.c
@@ -57,8 +57,7 @@ static char *urldecode(char *str) {
     return ret;
 }
 
-static GList *
-speech_cmdline_search(GList *samples, int suffix_len, const char *text, int decode) {
+static GList *speech_cmdline_search(GList *samples, int suffix_len, const char *text, int decode) {
     GList *loop_samples=samples,*result=NULL,*recursion_result;
     int shortest_result_length=INT_MAX;
     dbg(lvl_debug,"searching samples for text: '%s'",text);
@@ -110,8 +109,7 @@ struct speech_priv {
     struct spawn_process_info *spi;
 };
 
-static int
-speechd_say(struct speech_priv *this, const char *text) {
+static int speechd_say(struct speech_priv *this, const char *text) {
     char **cmdv=g_strsplit(this->cmdline," ", -1);
     int variable_arg_no=-1;
     GList *argl=NULL;
@@ -187,8 +185,7 @@ speechd_say(struct speech_priv *this, const char *text) {
 }
 
 
-static void
-speechd_destroy(struct speech_priv *this) {
+static void speechd_destroy(struct speech_priv *this) {
     GList *l=this->samples;
     g_free(this->cmdline);
     g_free(this->sample_dir);
@@ -207,8 +204,7 @@ static struct speech_methods speechd_meth = {
     speechd_say,
 };
 
-static struct speech_priv *
-speechd_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
+static struct speech_priv *speechd_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
     struct speech_priv *this;
     struct attr *attr;
     attr=attr_search(attrs, NULL, attr_data);
@@ -246,7 +242,6 @@ speechd_new(struct speech_methods *meth, struct attr **attrs, struct attr *paren
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_speech("cmdline", speechd_new);
 }

--- a/navit/speech/dbus/speech_dbus.c
+++ b/navit/speech/dbus/speech_dbus.c
@@ -31,8 +31,7 @@ struct speech_priv {
     struct navit *nav;
 };
 
-static int
-speech_dbus_say(struct speech_priv *this, const char *text) {
+static int speech_dbus_say(struct speech_priv *this, const char *text) {
     struct attr attr1,attr2,cb,*attr_list[3];
     int valid=0;
     attr1.type=attr_type;
@@ -47,8 +46,7 @@ speech_dbus_say(struct speech_priv *this, const char *text) {
     return 0;
 }
 
-static void
-speech_dbus_destroy(struct speech_priv *this) {
+static void speech_dbus_destroy(struct speech_priv *this) {
     g_free(this);
 }
 
@@ -57,8 +55,7 @@ static struct speech_methods speech_dbus_meth = {
     speech_dbus_say,
 };
 
-static struct speech_priv *
-speech_dbus_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
+static struct speech_priv *speech_dbus_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
     struct speech_priv *this;
     if (!parent || parent->type != attr_navit)
         return NULL;
@@ -69,7 +66,6 @@ speech_dbus_new(struct speech_methods *meth, struct attr **attrs, struct attr *p
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_speech("dbus", speech_dbus_new);
 }

--- a/navit/speech/espeak/speak.c
+++ b/navit/speech/espeak/speak.c
@@ -341,8 +341,7 @@ static DWORD startThread( LPVOID sp_priv) {
     return 0;
 }
 
-static int
-espeak_say(struct speech_priv *this, const char *text) {
+static int espeak_say(struct speech_priv *this, const char *text) {
     char *phrase = g_strdup(text);
     dbg(lvl_debug, "Speak: '%s'", text);
 
@@ -364,8 +363,7 @@ static void free_list(gpointer pointer, gpointer this ) {
     g_free(pointer);
 }
 
-static void
-espeak_destroy(struct speech_priv *this) {
+static void espeak_destroy(struct speech_priv *this) {
     g_list_foreach( this->free_buffers, free_list, (gpointer)this );
     g_list_free( this->free_buffers );
 
@@ -381,8 +379,7 @@ static struct speech_methods espeak_meth = {
     espeak_say,
 };
 
-static struct speech_priv *
-espeak_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
+static struct speech_priv *espeak_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent) {
     struct speech_priv *this = NULL;
     struct attr *path;
     struct attr *language;
@@ -462,7 +459,6 @@ espeak_new(struct speech_methods *meth, struct attr **attrs, struct attr *parent
     return this;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_speech("espeak", espeak_new);
 }

--- a/navit/speech/qt5_espeak/qt5_espeak.cpp
+++ b/navit/speech/qt5_espeak/qt5_espeak.cpp
@@ -71,8 +71,7 @@ int qt5_espeak_SynthCallback(short* wav, int numsamples, espeak_EVENT* events) {
 }
 
 /* set up espeak */
-static bool
-qt5_espeak_init_espeak(struct speech_priv* sr, struct attr** attrs) {
+static bool qt5_espeak_init_espeak(struct speech_priv* sr, struct attr** attrs) {
     struct attr* path;
 
     /* prepare espeak library path home */
@@ -109,8 +108,7 @@ qt5_espeak_init_espeak(struct speech_priv* sr, struct attr** attrs) {
 }
 
 /* set language to espeak */
-static bool
-qt5_espeak_init_language(struct speech_priv* pr, struct attr** attrs) {
+static bool qt5_espeak_init_language(struct speech_priv* pr, struct attr** attrs) {
     struct attr* language;
     gchar* lang_str = NULL;
     espeak_ERROR error;
@@ -156,8 +154,7 @@ qt5_espeak_init_language(struct speech_priv* pr, struct attr** attrs) {
 }
 
 /* init audio system */
-static bool
-qt5_espeak_init_audio(struct speech_priv* sr, const char* category) {
+static bool qt5_espeak_init_audio(struct speech_priv* sr, const char* category) {
     try {
         sr->audio = new Qt5EspeakAudioOut(sr->sample_rate, category);
     } catch (void* exception) {
@@ -171,8 +168,7 @@ qt5_espeak_init_audio(struct speech_priv* sr, const char* category) {
  * sr - private handle
  * text - new (utf8) text
  */
-static int
-qt5_espeak_say(struct speech_priv* sr, const char* text) {
+static int qt5_espeak_say(struct speech_priv* sr, const char* text) {
     espeak_ERROR error;
     dbg(lvl_debug, "Say \"%s\"", text);
     error = espeak_Synth(text, strlen(text), 0, POS_CHARACTER, 0,
@@ -184,8 +180,7 @@ qt5_espeak_say(struct speech_priv* sr, const char* text) {
 }
 
 /* destructor */
-static void
-qt5_espeak_destroy(struct speech_priv* sr) {
+static void qt5_espeak_destroy(struct speech_priv* sr) {
     dbg(lvl_debug, "Enter");
 
     if (sr->path_home != NULL)
@@ -204,9 +199,8 @@ static struct speech_methods qt5_espeak_meth = {
  * attr - get decoded attributes from config
  * parent - get parent attributes from config
  */
-static struct speech_priv*
-qt5_espeak_new(struct speech_methods* meth, struct attr** attrs,
-               struct attr* parent) {
+static struct speech_priv* qt5_espeak_new(struct speech_methods* meth, struct attr** attrs,
+        struct attr* parent) {
     struct speech_priv* sr = NULL;
     dbg(lvl_debug, "Enter");
 

--- a/navit/speech/speech_dispatcher/speech_speech_dispatcher.c
+++ b/navit/speech/speech_dispatcher/speech_speech_dispatcher.c
@@ -35,8 +35,7 @@ struct speech_priv {
     SPDConnection *conn;
 };
 
-static int
-speechd_say(struct speech_priv *this, const char *text) {
+static int speechd_say(struct speech_priv *this, const char *text) {
     int err;
 
     err = spd_sayf(this->conn, SPD_MESSAGE, text);
@@ -45,8 +44,7 @@ speechd_say(struct speech_priv *this, const char *text) {
     return 0;
 }
 
-static void
-speechd_destroy(struct speech_priv *this) {
+static void speechd_destroy(struct speech_priv *this) {
     spd_close(this->conn);
     g_free(this);
 }
@@ -56,8 +54,7 @@ static struct speech_methods speechd_meth = {
     speechd_say,
 };
 
-static struct speech_priv *
-speechd_new(struct speech_methods *meth, struct attr **attrs, struct attr *attr) {
+static struct speech_priv *speechd_new(struct speech_methods *meth, struct attr **attrs, struct attr *attr) {
     struct speech_priv *this;
     SPDConnection *conn;
 
@@ -74,7 +71,6 @@ speechd_new(struct speech_methods *meth, struct attr **attrs, struct attr *attr)
 }
 
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_register_category_speech("speech_dispatcher", speechd_new);
 }

--- a/navit/start.c
+++ b/navit/start.c
@@ -19,7 +19,6 @@
 
 #include "start_real.h"
 
-int
-main(int argc, char **argv) {
+int main(int argc, char **argv) {
     return main_real(argc, argv);
 }

--- a/navit/start_real.c
+++ b/navit/start_real.c
@@ -55,8 +55,7 @@ char *version=PACKAGE_VERSION"+git:"GIT_VERSION""NAVIT_VARIANT;
 int main_argc;
 char * const* main_argv;
 
-static void
-print_usage(void) {
+static void print_usage(void) {
     printf("%s",_("navit usage:\n"
                   "navit [options] [configfile]\n"
                   "\t-c <file>: use <file> as config file, instead of using the default file.\n"

--- a/navit/tools/gpx2navit_txt/src/elementControl.c
+++ b/navit/tools/gpx2navit_txt/src/elementControl.c
@@ -27,9 +27,8 @@ void endElementControl(parsedata * pdata, const char *element);
  * This method controls tag start event.
  * It corrects attributes.
  */
-void
-startElementControl(parsedata * pdata, const char *element,
-                    const char **attr) {
+void startElementControl(parsedata * pdata, const char *element,
+                         const char **attr) {
     int i;
     static int isFirstTrk = 1;
     static int isFirstRte = 1;

--- a/navit/track.c
+++ b/navit/track.c
@@ -121,8 +121,7 @@ struct tracking {
 
 
 
-static void
-tracking_init_cdf(struct cdf_data *cdf, int hist_size) {
+static void tracking_init_cdf(struct cdf_data *cdf, int hist_size) {
     cdf->extrapolating = 0;
     cdf->available = 0;
     cdf->poscount = 0;
@@ -145,9 +144,8 @@ tracking_init_cdf(struct cdf_data *cdf, int hist_size) {
 #define CDF_MINDIST 49 // 7 meters, I guess this value has to be changed for pedestrians.
 
 #if 0
-static void
-tracking_process_cdf(struct cdf_data *cdf, struct pcoord *pin, struct pcoord *pout, int dirin, int *dirout,
-                     int cur_speed, time_t fixtime) {
+static void tracking_process_cdf(struct cdf_data *cdf, struct pcoord *pin, struct pcoord *pout, int dirin, int *dirout,
+                                 int cur_speed, time_t fixtime) {
     struct cdf_speed *speed,*sc,*sl;
     double speed_avg;
     int speed_num,i;
@@ -298,8 +296,7 @@ tracking_process_cdf(struct cdf_data *cdf, struct pcoord *pin, struct pcoord *po
 }
 #endif
 
-int
-tracking_get_angle(struct tracking *tr) {
+int tracking_get_angle(struct tracking *tr) {
     return tr->curr_angle;
 }
 
@@ -308,13 +305,11 @@ tracking_get_pos(struct tracking *tr) {
     return &tr->curr_out;
 }
 
-int
-tracking_get_street_direction(struct tracking *tr) {
+int tracking_get_street_direction(struct tracking *tr) {
     return tr->street_direction;
 }
 
-int
-tracking_get_segment_pos(struct tracking *tr) {
+int tracking_get_segment_pos(struct tracking *tr) {
     return tr->pos;
 }
 
@@ -325,8 +320,7 @@ tracking_get_street_data(struct tracking *tr) {
     return NULL;
 }
 
-int
-tracking_get_attr(struct tracking *_this, enum attr_type type, struct attr *attr, struct attr_iter *attr_iter) {
+int tracking_get_attr(struct tracking *_this, enum attr_type type, struct attr *attr, struct attr_iter *attr_iter) {
     struct item *item;
     struct map_rect *mr;
     struct tracking_line *tl;
@@ -400,23 +394,20 @@ tracking_get_current_item(struct tracking *_this) {
     return &_this->curr_line->street->item;
 }
 
-int *
-tracking_get_current_flags(struct tracking *_this) {
+int *tracking_get_current_flags(struct tracking *_this) {
     if (! _this->curr_line || ! _this->curr_line->street)
         return NULL;
     return &_this->curr_line->street->flags;
 }
 
-static void
-tracking_get_angles(struct tracking_line *tl) {
+static void tracking_get_angles(struct tracking_line *tl) {
     int i;
     struct street_data *sd=tl->street;
     for (i = 0 ; i < sd->count-1 ; i++)
         tl->angle[i]=transform_get_angle_delta(&sd->c[i], &sd->c[i+1], 0);
 }
 
-static int
-street_data_within_selection(struct street_data *sd, struct map_selection *sel) {
+static int street_data_within_selection(struct street_data *sd, struct map_selection *sel) {
     struct coord_rect r;
     struct map_selection *curr;
     int i;
@@ -447,8 +438,7 @@ street_data_within_selection(struct street_data *sd, struct map_selection *sel) 
 }
 
 
-static void
-tracking_doupdate_lines(struct tracking *tr, struct coord *pc, enum projection pro) {
+static void tracking_doupdate_lines(struct tracking *tr, struct coord *pc, enum projection pro) {
     int max_dist=1000;
     struct map_selection *sel;
     struct mapset_handle *h;
@@ -494,8 +484,7 @@ tracking_doupdate_lines(struct tracking *tr, struct coord *pc, enum projection p
 }
 
 
-void
-tracking_flush(struct tracking *tr) {
+void tracking_flush(struct tracking *tr) {
     struct tracking_line *tl=tr->lines,*next;
     dbg(lvl_debug,"enter(tr=%p)", tr);
 
@@ -509,8 +498,7 @@ tracking_flush(struct tracking *tr) {
     tr->curr_line = NULL;
 }
 
-static int
-tracking_angle_diff(int a1, int a2, int full) {
+static int tracking_angle_diff(int a1, int a2, int full) {
     int ret=(a1-a2)%full;
     if (ret > full/2)
         ret-=full;
@@ -519,16 +507,14 @@ tracking_angle_diff(int a1, int a2, int full) {
     return ret;
 }
 
-static int
-tracking_angle_abs_diff(int a1, int a2, int full) {
+static int tracking_angle_abs_diff(int a1, int a2, int full) {
     int ret=tracking_angle_diff(a1, a2, full);
     if (ret < 0)
         ret=-ret;
     return ret;
 }
 
-static int
-tracking_angle_delta(struct tracking *tr, int vehicle_angle, int street_angle, int flags) {
+static int tracking_angle_delta(struct tracking *tr, int vehicle_angle, int street_angle, int flags) {
     int full=180,ret=360,fwd=0,rev=0;
     struct vehicleprofile *profile=tr->vehicleprofile;
 
@@ -547,8 +533,7 @@ tracking_angle_delta(struct tracking *tr, int vehicle_angle, int street_angle, i
     return ret*ret;
 }
 
-static int
-tracking_is_connected(struct tracking *tr, struct coord *c1, struct coord *c2) {
+static int tracking_is_connected(struct tracking *tr, struct coord *c1, struct coord *c2) {
     if (c1[0].x == c2[0].x && c1[0].y == c2[0].y)
         return 0;
     if (c1[0].x == c2[1].x && c1[0].y == c2[1].y)
@@ -560,15 +545,13 @@ tracking_is_connected(struct tracking *tr, struct coord *c1, struct coord *c2) {
     return tr->connected_pref;
 }
 
-static int
-tracking_is_no_stop(struct tracking *tr, struct coord *c1, struct coord *c2) {
+static int tracking_is_no_stop(struct tracking *tr, struct coord *c1, struct coord *c2) {
     if (c1->x == c2->x && c1->y == c2->y)
         return tr->nostop_pref;
     return 0;
 }
 
-static int
-tracking_is_on_route(struct tracking *tr, struct route *rt, struct item *item) {
+static int tracking_is_on_route(struct tracking *tr, struct route *rt, struct item *item) {
 #ifdef USE_ROUTING
     if (! rt)
         return 0;
@@ -580,8 +563,8 @@ tracking_is_on_route(struct tracking *tr, struct route *rt, struct item *item) {
 #endif
 }
 
-static int
-tracking_value(struct tracking *tr, struct tracking_line *t, int offset, struct coord *lpnt, int min, int flags) {
+static int tracking_value(struct tracking *tr, struct tracking_line *t, int offset, struct coord *lpnt, int min,
+                          int flags) {
     int value=0;
     struct street_data *sd=t->street;
     dbg(lvl_info, "%d: (0x%x,0x%x)-(0x%x,0x%x)", offset, sd->c[offset].x, sd->c[offset].y, sd->c[offset+1].x,
@@ -629,8 +612,8 @@ tracking_value(struct tracking *tr, struct tracking_line *t, int offset, struct 
  * @param vehicleprofile The vehicle profile to use
  * @param pro The projection to use for transformations
  */
-void
-tracking_update(struct tracking *tr, struct vehicle *v, struct vehicleprofile *vehicleprofile, enum projection pro) {
+void tracking_update(struct tracking *tr, struct vehicle *v, struct vehicleprofile *vehicleprofile,
+                     enum projection pro) {
     struct tracking_line *t;
     int i,value,min,time;
     struct coord lpnt;
@@ -784,8 +767,7 @@ tracking_update(struct tracking *tr, struct vehicle *v, struct vehicleprofile *v
     callback_list_call_attr_0(tr->callback_list, attr_position_coord_geo);
 }
 
-static int
-tracking_set_attr_do(struct tracking *tr, struct attr *attr, int initial) {
+static int tracking_set_attr_do(struct tracking *tr, struct attr *attr, int initial) {
     switch (attr->type) {
     case attr_angle_pref:
         tr->angle_pref=attr->u.num;
@@ -816,13 +798,11 @@ tracking_set_attr_do(struct tracking *tr, struct attr *attr, int initial) {
     }
 }
 
-int
-tracking_set_attr(struct tracking *tr, struct attr *attr) {
+int tracking_set_attr(struct tracking *tr, struct attr *attr) {
     return tracking_set_attr_do(tr, attr, 0);
 }
 
-int
-tracking_add_attr(struct tracking *this_, struct attr *attr) {
+int tracking_add_attr(struct tracking *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_callback:
         callback_list_add(this_->callback_list, attr->u.callback);
@@ -832,8 +812,7 @@ tracking_add_attr(struct tracking *this_, struct attr *attr) {
     }
 }
 
-int
-tracking_remove_attr(struct tracking *this_, struct attr *attr) {
+int tracking_remove_attr(struct tracking *this_, struct attr *attr) {
     switch (attr->type) {
     case attr_callback:
         callback_list_remove(this_->callback_list, attr->u.callback);
@@ -887,18 +866,15 @@ tracking_new(struct attr *parent, struct attr **attrs) {
     return this;
 }
 
-void
-tracking_set_mapset(struct tracking *this, struct mapset *ms) {
+void tracking_set_mapset(struct tracking *this, struct mapset *ms) {
     this->ms=ms;
 }
 
-void
-tracking_set_route(struct tracking *this, struct route *rt) {
+void tracking_set_route(struct tracking *this, struct route *rt) {
     this->rt=rt;
 }
 
-void
-tracking_destroy(struct tracking *tr) {
+void tracking_destroy(struct tracking *tr) {
     if (tr->attr)
         attr_free(tr->attr);
     tracking_flush(tr);
@@ -945,14 +921,12 @@ struct map_rect_priv {
     char *str;
 };
 
-static void
-tracking_map_item_coord_rewind(void *priv_data) {
+static void tracking_map_item_coord_rewind(void *priv_data) {
     struct map_rect_priv *this=priv_data;
     this->ccount=0;
 }
 
-static int
-tracking_map_item_coord_get(void *priv_data, struct coord *c, int count) {
+static int tracking_map_item_coord_get(void *priv_data, struct coord *c, int count) {
     struct map_rect_priv *this=priv_data;
     enum projection pro;
     int ret=0;
@@ -974,15 +948,13 @@ tracking_map_item_coord_get(void *priv_data, struct coord *c, int count) {
     return ret;
 }
 
-static void
-tracking_map_item_attr_rewind(void *priv_data) {
+static void tracking_map_item_attr_rewind(void *priv_data) {
     struct map_rect_priv *this_=priv_data;
     this_->debug_idx=0;
     this_->attr_next=attr_debug;
 }
 
-static int
-tracking_map_item_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
+static int tracking_map_item_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
     struct map_rect_priv *this_=priv_data;
     struct coord lpnt,*c;
     struct tracking *tr=this_->tracking;
@@ -1070,13 +1042,11 @@ static struct item_methods tracking_map_item_methods = {
 };
 
 
-static void
-tracking_map_destroy(struct map_priv *priv) {
+static void tracking_map_destroy(struct map_priv *priv) {
     g_free(priv);
 }
 
-static void
-tracking_map_rect_init(struct map_rect_priv *priv) {
+static void tracking_map_rect_init(struct map_rect_priv *priv) {
     priv->next=priv->tracking->lines;
     priv->curr=NULL;
     priv->coord=0;
@@ -1084,8 +1054,7 @@ tracking_map_rect_init(struct map_rect_priv *priv) {
     priv->item.id_hi=0;
 }
 
-static struct map_rect_priv *
-tracking_map_rect_new(struct map_priv *priv, struct map_selection *sel) {
+static struct map_rect_priv *tracking_map_rect_new(struct map_priv *priv, struct map_selection *sel) {
     struct tracking *tracking=priv->tracking;
     struct map_rect_priv *ret=g_new0(struct map_rect_priv, 1);
     ret->tracking=tracking;
@@ -1096,13 +1065,11 @@ tracking_map_rect_new(struct map_priv *priv, struct map_selection *sel) {
     return ret;
 }
 
-static void
-tracking_map_rect_destroy(struct map_rect_priv *priv) {
+static void tracking_map_rect_destroy(struct map_rect_priv *priv) {
     g_free(priv);
 }
 
-static struct item *
-tracking_map_get_item(struct map_rect_priv *priv) {
+static struct item *tracking_map_get_item(struct map_rect_priv *priv) {
     struct item *ret=&priv->item;
     int value;
     struct coord lpnt;
@@ -1148,8 +1115,7 @@ tracking_map_get_item(struct map_rect_priv *priv) {
     return ret;
 }
 
-static struct item *
-tracking_map_get_item_byid(struct map_rect_priv *priv, int id_hi, int id_lo) {
+static struct item *tracking_map_get_item_byid(struct map_rect_priv *priv, int id_hi, int id_lo) {
     struct item *ret;
     tracking_map_rect_init(priv);
     while ((ret=tracking_map_get_item(priv))) {
@@ -1172,8 +1138,7 @@ static struct map_methods tracking_map_meth = {
     NULL,
 };
 
-static struct map_priv *
-tracking_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
+static struct map_priv *tracking_map_new(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *ret;
     struct attr *tracking_attr;
 
@@ -1188,7 +1153,6 @@ tracking_map_new(struct map_methods *meth, struct attr **attrs, struct callback_
 }
 
 
-void
-tracking_init(void) {
+void tracking_init(void) {
     plugin_register_category_map("tracking", tracking_map_new);
 }

--- a/navit/transform.c
+++ b/navit/transform.c
@@ -97,16 +97,14 @@ struct transformation {
 #define HOG(t) 0
 #endif
 
-static void
-transform_set_screen_dist(struct transformation *t, int dist) {
+static void transform_set_screen_dist(struct transformation *t, int dist) {
     t->screen_dist=dist;
     t->xscale3d=dist;
     t->yscale3d=dist;
     t->wscale3d=dist << POST_SHIFT;
 }
 
-static void
-transform_setup_matrix(struct transformation *t) {
+static void transform_setup_matrix(struct transformation *t) {
     navit_float det;
     navit_float fac;
     navit_float yawc=navit_cos(-M_PI*t->yaw/180);
@@ -203,13 +201,11 @@ transform_new(struct pcoord *center, int scale, int yaw) {
     return this_;
 }
 
-int
-transform_get_hog(struct transformation *this_) {
+int transform_get_hog(struct transformation *this_) {
     return HOG(*this_);
 }
 
-void
-transform_set_hog(struct transformation *this_, int hog) {
+void transform_set_hog(struct transformation *this_, int hog) {
 #ifdef ENABLE_ROLL
     this_->hog=hog;
 #else
@@ -218,8 +214,7 @@ transform_set_hog(struct transformation *this_, int hog) {
 
 }
 
-int
-transform_get_attr(struct transformation *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int transform_get_attr(struct transformation *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     switch (type) {
 #ifdef ENABLE_ROLL
     case attr_hog:
@@ -233,8 +228,7 @@ transform_get_attr(struct transformation *this_, enum attr_type type, struct att
     return 1;
 }
 
-int
-transform_set_attr(struct transformation *this_, struct attr *attr) {
+int transform_set_attr(struct transformation *this_, struct attr *attr) {
     switch (attr->type) {
 #ifdef ENABLE_ROLL
     case attr_hog:
@@ -246,13 +240,11 @@ transform_set_attr(struct transformation *this_, struct attr *attr) {
     }
 }
 
-int
-transformation_get_order_base(struct transformation *this_) {
+int transformation_get_order_base(struct transformation *this_) {
     return this_->order_base;
 }
 
-void
-transform_set_order_base(struct transformation *this_, int order_base) {
+void transform_set_order_base(struct transformation *this_, int order_base) {
     this_->order_base=order_base;
 }
 
@@ -269,8 +261,7 @@ transform_dup(struct transformation *t) {
 static const navit_float gar2geo_units = 360.0/(1<<24);
 static const navit_float geo2gar_units = 1/(360.0/(1<<24));
 
-void
-transform_to_geo(enum projection pro, struct coord *c, struct coord_geo *g) {
+void transform_to_geo(enum projection pro, struct coord *c, struct coord_geo *g) {
     int x,y,northern,zone;
     switch (pro) {
     case projection_mg:
@@ -297,8 +288,7 @@ transform_to_geo(enum projection pro, struct coord *c, struct coord_geo *g) {
     }
 }
 
-void
-transform_from_geo(enum projection pro, struct coord_geo *g, struct coord *c) {
+void transform_from_geo(enum projection pro, struct coord_geo *g, struct coord *c) {
     switch (pro) {
     case projection_mg:
         c->x=g->lng*6371000.0*M_PI/180;
@@ -313,8 +303,8 @@ transform_from_geo(enum projection pro, struct coord_geo *g, struct coord *c) {
     }
 }
 
-void
-transform_from_to_count(struct coord *cfrom, enum projection from, struct coord *cto, enum projection to, int count) {
+void transform_from_to_count(struct coord *cfrom, enum projection from, struct coord *cto, enum projection to,
+                             int count) {
     struct coord_geo g;
     int i;
 
@@ -326,8 +316,7 @@ transform_from_to_count(struct coord *cfrom, enum projection from, struct coord 
     }
 }
 
-void
-transform_from_to(struct coord *cfrom, enum projection from, struct coord *cto, enum projection to) {
+void transform_from_to(struct coord *cfrom, enum projection from, struct coord *cto, enum projection to) {
     struct coord_geo g;
     transform_to_geo(from, cfrom, &g);
     transform_from_geo(to, &g, cto);
@@ -345,8 +334,7 @@ transform_from_to(struct coord *cfrom, enum projection from, struct coord *cto, 
  * @param b Semi-minor axis of the ellipsoid
  * @param cart Points to a structure that will receive the Cartesian coordinates
  */
-void
-transform_geo_to_cart(struct coord_geo *geo, navit_float a, navit_float b, struct coord_geo_cart *cart) {
+void transform_geo_to_cart(struct coord_geo *geo, navit_float a, navit_float b, struct coord_geo_cart *cart) {
     navit_float n,ee=1-b*b/(a*a);
     n = a/sqrtf(1-ee*navit_sin(geo->lat)*navit_sin(geo->lat));
     cart->x=n*navit_cos(geo->lat)*navit_cos(geo->lng);
@@ -366,8 +354,7 @@ transform_geo_to_cart(struct coord_geo *geo, navit_float a, navit_float b, struc
  * @param b Semi-minor axis of the ellipsoid
  * @param geo Points to a structure that will receive the geodetic coordinates
  */
-void
-transform_cart_to_geo(struct coord_geo_cart *cart, navit_float a, navit_float b, struct coord_geo *geo) {
+void transform_cart_to_geo(struct coord_geo_cart *cart, navit_float a, navit_float b, struct coord_geo *geo) {
     navit_float lat,lati,n,ee=1-b*b/(a*a), lng = navit_tan(cart->y/cart->x);
 
     lat = navit_tan(cart->z / navit_sqrt((cart->x * cart->x) + (cart->y * cart->y)));
@@ -390,9 +377,8 @@ transform_cart_to_geo(struct coord_geo_cart *cart, navit_float a, navit_float b,
  *
  * @author Chuck Gantz- chuck.gantz@globalstar.com
  */
-void
-transform_utm_to_geo(const double UTMEasting, const double UTMNorthing, int ZoneNumber, int NorthernHemisphere,
-                     struct coord_geo *geo) {
+void transform_utm_to_geo(const double UTMEasting, const double UTMNorthing, int ZoneNumber, int NorthernHemisphere,
+                          struct coord_geo *geo) {
 //East Longitudes are positive, West longitudes are negative.
 //North latitudes are positive, South latitudes are negative
 //Lat and Long are in decimal degrees.
@@ -444,8 +430,8 @@ transform_utm_to_geo(const double UTMEasting, const double UTMNorthing, int Zone
     geo->lng=Long;
 }
 
-static struct coord
-transform_correct_projection(struct transformation *t, enum projection required_projection, struct coord c) {
+static struct coord transform_correct_projection(struct transformation *t, enum projection required_projection,
+        struct coord c) {
     struct coord result;
     struct coord_geo g;
     if (required_projection == t->pro) {
@@ -457,8 +443,7 @@ transform_correct_projection(struct transformation *t, enum projection required_
     return result;
 }
 
-static struct coord
-transform_shift_by_center_and_scale(struct transformation *t, struct coord c) {
+static struct coord transform_shift_by_center_and_scale(struct transformation *t, struct coord c) {
     struct coord result;
     result.x = c.x - t->map_center.x;
     result.y = c.y - t->map_center.y;
@@ -474,8 +459,7 @@ struct coord_3d {
 };
 
 
-static struct coord_3d
-transform_rotate(struct transformation *t, struct coord c) {
+static struct coord_3d transform_rotate(struct transformation *t, struct coord c) {
     struct coord_3d result;
     result.x=c.x*t->m00+c.y*t->m01+HOG(*t)*t->m02;
     result.y=c.x*t->m10+c.y*t->m11+HOG(*t)*t->m12;
@@ -485,8 +469,7 @@ transform_rotate(struct transformation *t, struct coord c) {
     return result;
 }
 
-static struct coord_3d
-transform_z_clip(struct coord_3d c, struct coord_3d c_old, int zlimit) {
+static struct coord_3d transform_z_clip(struct coord_3d c, struct coord_3d c_old, int zlimit) {
     struct coord_3d result;
     float clip_factor = ((float)zlimit-c.z)/(c_old.z-c.z);
     dbg(lvl_debug,"in (%d,%d,%d) - (%d,%d,%d)", c.x,c.y,c.z, c_old.x,c_old.y,c_old.z);
@@ -497,8 +480,7 @@ transform_z_clip(struct coord_3d c, struct coord_3d c_old, int zlimit) {
     return result;
 }
 
-static struct point
-transform_project_onto_view_plane(struct transformation *t, struct coord_3d c) {
+static struct point transform_project_onto_view_plane(struct transformation *t, struct coord_3d c) {
     struct point result;
 #if 0
     dbg(lvl_debug,"z=%d",c.z);
@@ -508,8 +490,7 @@ transform_project_onto_view_plane(struct transformation *t, struct coord_3d c) {
     return result;
 }
 
-static int
-transform_points_too_close(struct point screen_point, struct point screen_point_old, int mindist) {
+static int transform_points_too_close(struct point screen_point, struct point screen_point_old, int mindist) {
     if (!mindist) {
         return 0;
     }
@@ -525,8 +506,8 @@ struct z_clip_result {
     int skip_coord;
 };
 
-static struct z_clip_result
-transform_z_clip_if_necessary(struct coord_3d coord, int zlimit, struct z_clip_result clip_result_old) {
+static struct z_clip_result transform_z_clip_if_necessary(struct coord_3d coord, int zlimit,
+        struct z_clip_result clip_result_old) {
     int visibility_changed;
     struct z_clip_result clip_result= {{0,0}, 0, 0, 0};
     clip_result.visible=(coord.z < zlimit ? 0:1);
@@ -546,9 +527,8 @@ transform_z_clip_if_necessary(struct coord_3d coord, int zlimit, struct z_clip_r
     return clip_result;
 }
 
-int
-transform(struct transformation *t, enum projection required_projection, struct coord *input,
-          struct point *result, int count, int mindist, int width, int *width_result) {
+int transform(struct transformation *t, enum projection required_projection, struct coord *input,
+              struct point *result, int count, int mindist, int width, int *width_result) {
     struct coord projected_coord, shifted_coord;
     struct coord_3d rotated_coord;
     struct point screen_point;
@@ -608,16 +588,15 @@ transform(struct transformation *t, enum projection required_projection, struct 
     return result_idx;
 }
 
-static void
-transform_apply_inverse_matrix(struct transformation *t, struct coord_geo_cart *in, struct coord_geo_cart *out) {
+static void transform_apply_inverse_matrix(struct transformation *t, struct coord_geo_cart *in,
+        struct coord_geo_cart *out) {
     out->x=in->x*t->im00+in->y*t->im01+in->z*t->im02;
     out->y=in->x*t->im10+in->y*t->im11+in->z*t->im12;
     out->z=in->x*t->im20+in->y*t->im21+in->z*t->im22;
 }
 
-static int
-transform_zplane_intersection(struct coord_geo_cart *p1, struct coord_geo_cart *p2, navit_float z,
-                              struct coord_geo_cart *result) {
+static int transform_zplane_intersection(struct coord_geo_cart *p1, struct coord_geo_cart *p2, navit_float z,
+        struct coord_geo_cart *result) {
     navit_float dividend=z-p1->z;
     navit_float divisor=p2->z-p1->z;
     navit_float q;
@@ -636,8 +615,8 @@ transform_zplane_intersection(struct coord_geo_cart *p1, struct coord_geo_cart *
     return 2; /* intersection without [p1,p2] */
 }
 
-static void
-transform_screen_to_3d(struct transformation *t, struct point *p, navit_float z, struct coord_geo_cart *cg) {
+static void transform_screen_to_3d(struct transformation *t, struct point *p, navit_float z,
+                                   struct coord_geo_cart *cg) {
     double xc,yc;
     double offz=t->offz << POST_SHIFT;
     xc=p->x - t->offx;
@@ -647,8 +626,7 @@ transform_screen_to_3d(struct transformation *t, struct point *p, navit_float z,
     cg->z=z-offz;
 }
 
-static int
-transform_reverse_near_far(struct transformation *t, struct point *p, struct coord *c, int near, int far) {
+static int transform_reverse_near_far(struct transformation *t, struct point *p, struct coord *c, int near, int far) {
     double xc,yc;
     dbg(lvl_debug,"%d,%d",p->x,p->y);
     if (t->ddd) {
@@ -673,13 +651,11 @@ transform_reverse_near_far(struct transformation *t, struct point *p, struct coo
     return 1;
 }
 
-int
-transform_reverse(struct transformation *t, struct point *p, struct coord *c) {
+int transform_reverse(struct transformation *t, struct point *p, struct coord *c) {
     return transform_reverse_near_far(t, p, c, t->znear, t->zfar);
 }
 
-double
-transform_pixels_to_map_distance(struct transformation *transformation, int pixels) {
+double transform_pixels_to_map_distance(struct transformation *transformation, int pixels) {
     struct point line_in_map_center[2];
     struct coord c[2];
     struct point screen_center=transformation->screen_center;
@@ -695,18 +671,15 @@ transform_pixels_to_map_distance(struct transformation *transformation, int pixe
     return transform_distance(transform_get_projection(transformation), &c[0], &c[1]);
 }
 
-enum projection
-transform_get_projection(struct transformation *this_) {
+enum projection transform_get_projection(struct transformation *this_) {
     return this_->pro;
 }
 
-void
-transform_set_projection(struct transformation *this_, enum projection pro) {
+void transform_set_projection(struct transformation *this_, enum projection pro) {
     this_->pro=pro;
 }
 
-static int
-min4(int v1,int v2, int v3, int v4) {
+static int min4(int v1,int v2, int v3, int v4) {
     int res=v1;
     if (v2 < res)
         res=v2;
@@ -717,8 +690,7 @@ min4(int v1,int v2, int v3, int v4) {
     return res;
 }
 
-static int
-max4(int v1,int v2, int v3, int v4) {
+static int max4(int v1,int v2, int v3, int v4) {
     int res=v1;
     if (v2 > res)
         res=v2;
@@ -773,35 +745,29 @@ transform_get_center(struct transformation *this_) {
     return &this_->map_center;
 }
 
-void
-transform_set_center(struct transformation *this_, struct coord *c) {
+void transform_set_center(struct transformation *this_, struct coord *c) {
     this_->map_center=*c;
 }
 
 
-void
-transform_set_yaw(struct transformation *t,int yaw) {
+void transform_set_yaw(struct transformation *t,int yaw) {
     t->yaw=yaw;
     transform_setup_matrix(t);
 }
 
-int
-transform_get_yaw(struct transformation *this_) {
+int transform_get_yaw(struct transformation *this_) {
     return this_->yaw;
 }
 
-void
-transform_set_pitch(struct transformation *this_,int pitch) {
+void transform_set_pitch(struct transformation *this_,int pitch) {
     this_->pitch=pitch;
     transform_setup_matrix(this_);
 }
-int
-transform_get_pitch(struct transformation *this_) {
+int transform_get_pitch(struct transformation *this_) {
     return this_->pitch;
 }
 
-void
-transform_set_roll(struct transformation *this_,int roll) {
+void transform_set_roll(struct transformation *this_,int roll) {
 #ifdef ENABLE_ROLL
     this_->roll=roll;
     transform_setup_matrix(this_);
@@ -810,8 +776,7 @@ transform_set_roll(struct transformation *this_,int roll) {
 #endif
 }
 
-int
-transform_get_roll(struct transformation *this_) {
+int transform_get_roll(struct transformation *this_) {
 #ifdef ENABLE_ROLL
     return this_->roll;
 #else
@@ -819,26 +784,22 @@ transform_get_roll(struct transformation *this_) {
 #endif
 }
 
-void
-transform_set_distance(struct transformation *this_,int distance) {
+void transform_set_distance(struct transformation *this_,int distance) {
     transform_set_screen_dist(this_, distance);
     transform_setup_matrix(this_);
 }
 
-int
-transform_get_distance(struct transformation *this_) {
+int transform_get_distance(struct transformation *this_) {
     return this_->screen_dist;
 }
 
-void
-transform_set_scales(struct transformation *this_, int xscale, int yscale, int wscale) {
+void transform_set_scales(struct transformation *this_, int xscale, int yscale, int wscale) {
     this_->xscale3d=xscale;
     this_->yscale3d=yscale;
     this_->wscale3d=wscale;
 }
 
-void
-transform_set_screen_selection(struct transformation *t, struct map_selection *sel) {
+void transform_set_screen_selection(struct transformation *t, struct map_selection *sel) {
     map_selection_destroy(t->screen_sel);
     t->screen_sel=map_selection_dup(sel);
     if (sel) {
@@ -848,13 +809,11 @@ transform_set_screen_selection(struct transformation *t, struct map_selection *s
     }
 }
 
-void
-transform_set_screen_center(struct transformation *t, struct point *p) {
+void transform_set_screen_center(struct transformation *t, struct point *p) {
     t->screen_center=*p;
 }
 
-void
-transform_get_size(struct transformation *t, int *width, int *height) {
+void transform_get_size(struct transformation *t, int *width, int *height) {
     struct point_rect *r;
     if (t->screen_sel) {
         r=&t->screen_sel->u.p_rect;
@@ -863,8 +822,7 @@ transform_get_size(struct transformation *t, int *width, int *height) {
     }
 }
 
-void
-transform_setup_source_rect(struct transformation *t) {
+void transform_setup_source_rect(struct transformation *t) {
     int i;
     struct coord screen[4];
     struct point screen_pnt[4];
@@ -950,20 +908,17 @@ transform_setup_source_rect(struct transformation *t) {
     }
 }
 
-long
-transform_get_scale(struct transformation *t) {
+long transform_get_scale(struct transformation *t) {
     return (int)(t->scale*16);
 }
 
-void
-transform_set_scale(struct transformation *t, long scale) {
+void transform_set_scale(struct transformation *t, long scale) {
     t->scale=scale/16.0;
     transform_setup_matrix(t);
 }
 
 
-int
-transform_get_order(struct transformation *t) {
+int transform_get_order(struct transformation *t) {
     dbg(lvl_debug,"order %d", t->order);
     return t->order;
 }
@@ -974,8 +929,7 @@ transform_get_order(struct transformation *t) {
 #define GC2RAD(c) ((c) * TWOPI/(1<<24))
 #define minf(a,b) ((a) < (b) ? (a) : (b))
 
-static double
-transform_distance_garmin(struct coord *c1, struct coord *c2) {
+static double transform_distance_garmin(struct coord *c1, struct coord *c2) {
 #ifdef USE_HALVESINE
     static const int earth_radius = 6371*1000; //m change accordingly
 // static const int earth_radius  = 3960; //miles
@@ -1012,8 +966,7 @@ transform_distance_garmin(struct coord *c1, struct coord *c2) {
 #endif
 }
 
-double
-transform_scale(int y) {
+double transform_scale(int y) {
     struct coord c;
     struct coord_geo g;
     c.x=0;
@@ -1040,8 +993,7 @@ int transform_int_scale(int y) {
 }
 #endif
 
-double
-transform_distance(enum projection pro, struct coord *c1, struct coord *c2) {
+double transform_distance(enum projection pro, struct coord *c1, struct coord *c2) {
     if (pro == projection_mg) {
 #ifndef AVOID_FLOAT
         double dx,dy,scale=transform_scale((c1->y+c2->y)/2);
@@ -1085,8 +1037,7 @@ transform_distance(enum projection pro, struct coord *c1, struct coord *c2) {
     }
 }
 
-void
-transform_project(enum projection pro, struct coord *c, int distance, int angle, struct coord *res) {
+void transform_project(enum projection pro, struct coord *c, int distance, int angle, struct coord *res) {
     double scale;
     switch (pro) {
     case projection_mg:
@@ -1102,8 +1053,7 @@ transform_project(enum projection pro, struct coord *c, int distance, int angle,
 }
 
 
-double
-transform_polyline_length(enum projection pro, struct coord *c, int count) {
+double transform_polyline_length(enum projection pro, struct coord *c, int count) {
     double ret=0;
     int i;
 
@@ -1112,8 +1062,7 @@ transform_polyline_length(enum projection pro, struct coord *c, int count) {
     return ret;
 }
 
-static int
-transform_overflow_possible_if_squared(int count, ...) {
+static int transform_overflow_possible_if_squared(int count, ...) {
     va_list ap;
     int i, value, result = 0;
 
@@ -1136,8 +1085,7 @@ transform_overflow_possible_if_squared(int count, ...) {
  *
  * @return The squared distance between `c1` and `c2`, or `INT_MAX` if an overflow occurs.
  */
-int
-transform_distance_sq(struct coord *c1, struct coord *c2) {
+int transform_distance_sq(struct coord *c1, struct coord *c2) {
     int dx=c1->x-c2->x;
     int dy=c1->y-c2->y;
 
@@ -1147,15 +1095,13 @@ transform_distance_sq(struct coord *c1, struct coord *c2) {
         return dx*dx+dy*dy;
 }
 
-navit_float
-transform_distance_sq_float(struct coord *c1, struct coord *c2) {
+navit_float transform_distance_sq_float(struct coord *c1, struct coord *c2) {
     int dx=c1->x-c2->x;
     int dy=c1->y-c2->y;
     return (navit_float)dx*dx+dy*dy;
 }
 
-int
-transform_distance_sq_pc(struct pcoord *c1, struct pcoord *c2) {
+int transform_distance_sq_pc(struct pcoord *c1, struct pcoord *c2) {
     struct coord p1,p2;
     p1.x = c1->x;
     p1.y = c1->y;
@@ -1175,8 +1121,7 @@ transform_distance_sq_pc(struct pcoord *c1, struct pcoord *c2) {
  *
  * @return The square of the Mercator distance between `ref` and `lpnt`, or `INT_MAX` if an overflow occurred
  */
-int
-transform_distance_line_sq(struct coord *l0, struct coord *l1, struct coord *ref, struct coord *lpnt) {
+int transform_distance_line_sq(struct coord *l0, struct coord *l1, struct coord *ref, struct coord *lpnt) {
     int vx,vy,wx,wy;
     int c1,c2;
     int climit=1000000;
@@ -1214,8 +1159,8 @@ transform_distance_line_sq(struct coord *l0, struct coord *l1, struct coord *ref
     return transform_distance_sq(&l, ref);
 }
 
-navit_float
-transform_distance_line_sq_float(struct coord *l0, struct coord *l1, struct coord *ref, struct coord *lpnt) {
+navit_float transform_distance_line_sq_float(struct coord *l0, struct coord *l1, struct coord *ref,
+        struct coord *lpnt) {
     navit_float vx,vy,wx,wy;
     navit_float c1,c2;
     struct coord l;
@@ -1256,8 +1201,7 @@ transform_distance_line_sq_float(struct coord *l0, struct coord *l1, struct coor
  *
  * @return The square of the Mercator distance between `ref` and `lpnt`, or `INT_MAX` if an overflow occurred
  */
-int
-transform_distance_polyline_sq(struct coord *c, int count, struct coord *ref, struct coord *lpnt, int *pos) {
+int transform_distance_polyline_sq(struct coord *c, int count, struct coord *ref, struct coord *lpnt, int *pos) {
     int i,dist,distn;
     struct coord lp;
     if (count < 2)
@@ -1278,8 +1222,7 @@ transform_distance_polyline_sq(struct coord *c, int count, struct coord *ref, st
     return dist;
 }
 
-int
-transform_douglas_peucker(struct coord *in, int count, int dist_sq, struct coord *out) {
+int transform_douglas_peucker(struct coord *in, int count, int dist_sq, struct coord *out) {
     int ret=0;
     int i,d,dmax=0, idx=0;
     for (i = 1; i < count-2 ; i++) {
@@ -1301,8 +1244,7 @@ transform_douglas_peucker(struct coord *in, int count, int dist_sq, struct coord
     return ret;
 }
 
-int
-transform_douglas_peucker_float(struct coord *in, int count, navit_float dist_sq, struct coord *out) {
+int transform_douglas_peucker_float(struct coord *in, int count, navit_float dist_sq, struct coord *out) {
     int ret=0;
     int i,idx=0;
     navit_float d,dmax=0;
@@ -1326,16 +1268,14 @@ transform_douglas_peucker_float(struct coord *in, int count, navit_float dist_sq
 }
 
 
-void
-transform_print_deg(double deg) {
+void transform_print_deg(double deg) {
     printf("%2.0f:%2.0f:%2.4f", floor(deg), fmod(deg*60,60), fmod(deg*3600,60));
 }
 
 #ifdef AVOID_FLOAT
 static int tab_atan[]= {0,262,524,787,1051,1317,1584,1853,2126,2401,2679,2962,3249,3541,3839,4142,4452,4770,5095,5430,5774,6128,6494,6873,7265,7673,8098,8541,9004,9490,10000,10538};
 
-static int
-atan2_int_lookup(int val) {
+static int atan2_int_lookup(int val) {
     int len=sizeof(tab_atan)/sizeof(int);
     int i=len/2;
     int p=i-1;
@@ -1350,8 +1290,7 @@ atan2_int_lookup(int val) {
     }
 }
 
-static int
-atan2_int(int dx, int dy) {
+static int atan2_int(int dx, int dy) {
     int mul=1,add=0,ret;
     if (! dx) {
         return dy < 0 ? 180 : 0;
@@ -1390,8 +1329,7 @@ atan2_int(int dx, int dy) {
  *
  * @return The bearing in degrees, {@code 0 <= result < 360}.
  */
-int
-transform_get_angle_delta(struct coord *c1, struct coord *c2, int dir) {
+int transform_get_angle_delta(struct coord *c1, struct coord *c2, int dir) {
     int dx=c2->x-c1->x;
     int dy=c2->y-c1->y;
 #ifndef AVOID_FLOAT
@@ -1409,8 +1347,7 @@ transform_get_angle_delta(struct coord *c1, struct coord *c2, int dir) {
     return angle;
 }
 
-int
-transform_within_border(struct transformation *this_, struct point *p, int border) {
+int transform_within_border(struct transformation *this_, struct point *p, int border) {
     struct map_selection *ms=this_->screen_sel;
     while (ms) {
         struct point_rect *r=&ms->u.p_rect;
@@ -1422,8 +1359,7 @@ transform_within_border(struct transformation *this_, struct point *p, int borde
     return 0;
 }
 
-int
-transform_within_dist_point(struct coord *ref, struct coord *c, int dist) {
+int transform_within_dist_point(struct coord *ref, struct coord *c, int dist) {
     if (c->x-dist > ref->x)
         return 0;
     if (c->x+dist < ref->x)
@@ -1437,8 +1373,7 @@ transform_within_dist_point(struct coord *ref, struct coord *c, int dist) {
     return 0;
 }
 
-int
-transform_within_dist_line(struct coord *ref, struct coord *c0, struct coord *c1, int dist) {
+int transform_within_dist_line(struct coord *ref, struct coord *c0, struct coord *c1, int dist) {
     int vx,vy,wx,wy;
     int n1,n2;
     struct coord lc;
@@ -1482,8 +1417,7 @@ transform_within_dist_line(struct coord *ref, struct coord *c0, struct coord *c1
     return transform_within_dist_point(ref, &lc, dist);
 }
 
-int
-transform_within_dist_polyline(struct coord *ref, struct coord *c, int count, int close, int dist) {
+int transform_within_dist_polyline(struct coord *ref, struct coord *c, int count, int close, int dist) {
     int i;
     for (i = 0 ; i < count-1 ; i++) {
         if (transform_within_dist_line(ref,c+i,c+i+1,dist)) {
@@ -1495,8 +1429,7 @@ transform_within_dist_polyline(struct coord *ref, struct coord *c, int count, in
     return 0;
 }
 
-int
-transform_within_dist_polygon(struct coord *ref, struct coord *c, int count, int dist) {
+int transform_within_dist_polygon(struct coord *ref, struct coord *c, int count, int dist) {
     int i, j, ci = 0;
     for (i = 0, j = count-1; i < count; j = i++) {
         if ((((c[i].y <= ref->y) && ( ref->y < c[j].y )) ||
@@ -1513,8 +1446,7 @@ transform_within_dist_polygon(struct coord *ref, struct coord *c, int count, int
     return 1;
 }
 
-int
-transform_within_dist_item(struct coord *ref, enum item_type type, struct coord *c, int count, int dist) {
+int transform_within_dist_item(struct coord *ref, enum item_type type, struct coord *c, int count, int dist) {
     if (type < type_line)
         return transform_within_dist_point(ref, c, dist);
     if (type < type_area)
@@ -1522,13 +1454,11 @@ transform_within_dist_item(struct coord *ref, enum item_type type, struct coord 
     return transform_within_dist_polygon(ref, c, count, dist);
 }
 
-void
-transform_copy(struct transformation *src, struct transformation *dst) {
+void transform_copy(struct transformation *src, struct transformation *dst) {
     memcpy(dst, src, sizeof(*src));
 }
 
-void
-transform_destroy(struct transformation *t) {
+void transform_destroy(struct transformation *t) {
     map_selection_destroy(t->map_sel);
     map_selection_destroy(t->screen_sel);
     g_free(t);

--- a/navit/util.c
+++ b/navit/util.c
@@ -38,22 +38,19 @@ typedef int ssize_t ;
 #include "debug.h"
 #include "config.h"
 
-void
-strtoupper(char *dest, const char *src) {
+void strtoupper(char *dest, const char *src) {
     while (*src)
         *dest++=toupper(*src++);
     *dest='\0';
 }
 
-void
-strtolower(char *dest, const char *src) {
+void strtolower(char *dest, const char *src) {
     while (*src)
         *dest++=tolower(*src++);
     *dest='\0';
 }
 
-int
-navit_utf8_strcasecmp(const char *s1, const char *s2) {
+int navit_utf8_strcasecmp(const char *s1, const char *s2) {
     char *s1_folded,*s2_folded;
     int cmpres;
     s1_folded=g_utf8_casefold(s1,-1);
@@ -65,36 +62,31 @@ navit_utf8_strcasecmp(const char *s1, const char *s2) {
     return cmpres;
 }
 
-static void
-hash_callback(gpointer key, gpointer value, gpointer user_data) {
+static void hash_callback(gpointer key, gpointer value, gpointer user_data) {
     GList **l=user_data;
     *l=g_list_prepend(*l, value);
 }
 
-GList *
-g_hash_to_list(GHashTable *h) {
+GList *g_hash_to_list(GHashTable *h) {
     GList *ret=NULL;
     g_hash_table_foreach(h, hash_callback, &ret);
 
     return ret;
 }
 
-static void
-hash_callback_key(gpointer key, gpointer value, gpointer user_data) {
+static void hash_callback_key(gpointer key, gpointer value, gpointer user_data) {
     GList **l=user_data;
     *l=g_list_prepend(*l, key);
 }
 
-GList *
-g_hash_to_list_keys(GHashTable *h) {
+GList *g_hash_to_list_keys(GHashTable *h) {
     GList *ret=NULL;
     g_hash_table_foreach(h, hash_callback_key, &ret);
 
     return ret;
 }
 
-gchar *
-g_strconcat_printf(gchar *buffer, gchar *fmt, ...) {
+gchar *g_strconcat_printf(gchar *buffer, gchar *fmt, ...) {
     gchar *str,*ret;
     va_list ap;
 
@@ -111,8 +103,7 @@ g_strconcat_printf(gchar *buffer, gchar *fmt, ...) {
 
 #ifndef HAVE_GLIB
 int g_utf8_strlen_force_link(gchar *buffer, int max);
-int
-g_utf8_strlen_force_link(gchar *buffer, int max) {
+int g_utf8_strlen_force_link(gchar *buffer, int max) {
     return g_utf8_strlen(buffer, max);
 }
 #endif
@@ -182,8 +173,7 @@ char *stristr(const char *String, const char *Pattern) {
  *
  * @return Number of characters read (not including the null terminator), or -1 on error or EOF.
 */
-ssize_t
-getdelim (char **lineptr, size_t *n, int delimiter, FILE *fp) {
+ssize_t getdelim (char **lineptr, size_t *n, int delimiter, FILE *fp) {
     int result;
     size_t cur_len = 0;
 
@@ -250,8 +240,7 @@ unlock_return:
 #endif
 
 #ifndef HAVE_GETLINE
-ssize_t
-getline (char **lineptr, size_t *n, FILE *stream) {
+ssize_t getline (char **lineptr, size_t *n, FILE *stream) {
     return getdelim (lineptr, n, '\n', stream);
 }
 #endif
@@ -291,8 +280,7 @@ int gettimeofday(struct timeval *time, void *local) {
  *
  * @return The number of seconds elapsed since January 1, 1970, 00:00:00 UTC.
  */
-unsigned int
-iso8601_to_secs(char *iso8601) {
+unsigned int iso8601_to_secs(char *iso8601) {
     int a,b,d,val[6],i=0;
     char *start=iso8601,*pos=iso8601;
     while (*pos && i < 6) {
@@ -323,8 +311,7 @@ iso8601_to_secs(char *iso8601) {
  *
  * @return Time in ISO 8601 format
  */
-char *
-current_to_iso8601(void) {
+char *current_to_iso8601(void) {
     char *timep=NULL;
 #ifdef HAVE_API_WIN32_BASE
     SYSTEMTIME ST;
@@ -361,8 +348,7 @@ struct spawn_process_info {
  * @param in arg string to escape
  * @returns escaped string
  */
-char *
-shell_escape(char *arg) {
+char *shell_escape(char *arg) {
     char *r;
     int arglen=strlen(arg);
     int i,j,rlen;
@@ -434,8 +420,7 @@ shell_escape(char *arg) {
 }
 
 #ifndef _POSIX_C_SOURCE
-static char*
-spawn_process_compose_cmdline(char **argv) {
+static char* spawn_process_compose_cmdline(char **argv) {
     int i,j;
     char *cmdline=shell_escape(argv[0]);
     for(i=1,j=strlen(cmdline); argv[i]; i++) {
@@ -692,8 +677,7 @@ void spawn_process_init() {
  * @param angle The angle to convert
  * @param mode The conversion mode, see description
  */
-void
-get_compass_direction(char *buffer, int angle, int mode) {
+void get_compass_direction(char *buffer, int angle, int mode) {
     angle=angle%360;
     switch (mode) {
     case 0:

--- a/navit/vehicle.c
+++ b/navit/vehicle.c
@@ -160,8 +160,7 @@ vehicle_new(struct attr *parent, struct attr **attrs) {
  *
  * @param this_ The vehicle to destroy
  */
-void
-vehicle_destroy(struct vehicle *this_) {
+void vehicle_destroy(struct vehicle *this_) {
     dbg(lvl_debug,"enter");
     if (this_->animate_callback) {
         callback_destroy(this_->animate_callback);
@@ -191,8 +190,7 @@ vehicle_attr_iter_new(void) {
  *
  * @param iter a vehicle attr_iter
  */
-void
-vehicle_attr_iter_destroy(struct attr_iter *iter) {
+void vehicle_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
@@ -207,8 +205,7 @@ vehicle_attr_iter_destroy(struct attr_iter *iter) {
  * @param iter A vehicle attr_iter. This is only used for generic attributes; for attributes specific to the vehicle object it is ignored.
  * @return True for success, false for failure
  */
-int
-vehicle_get_attr(struct vehicle *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int vehicle_get_attr(struct vehicle *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     int ret;
     if (type == attr_log_gpx_desc) {
         attr->u.str = this_->gpx_desc;
@@ -229,8 +226,7 @@ vehicle_get_attr(struct vehicle *this_, enum attr_type type, struct attr *attr, 
  * @param attr The attribute to set
  * @return False on success, true on failure
  */
-int
-vehicle_set_attr(struct vehicle *this_, struct attr *attr) {
+int vehicle_set_attr(struct vehicle *this_, struct attr *attr) {
     int ret=1;
     if (attr->type == attr_log_gpx_desc) {
         g_free(this_->gpx_desc);
@@ -254,8 +250,7 @@ vehicle_set_attr(struct vehicle *this_, struct attr *attr) {
  *
  * @return true if the attribute was added, false if not.
  */
-int
-vehicle_add_attr(struct vehicle *this_, struct attr *attr) {
+int vehicle_add_attr(struct vehicle *this_, struct attr *attr) {
     int ret=1;
     switch (attr->type) {
     case attr_callback:
@@ -284,8 +279,7 @@ vehicle_add_attr(struct vehicle *this_, struct attr *attr) {
  * @param this_ A vehicle
  * @param attr
  */
-int
-vehicle_remove_attr(struct vehicle *this_, struct attr *attr) {
+int vehicle_remove_attr(struct vehicle *this_, struct attr *attr) {
     struct callback *cb;
     switch (attr->type) {
     case attr_callback:
@@ -314,8 +308,7 @@ vehicle_remove_attr(struct vehicle *this_, struct attr *attr) {
  * @param cursor A cursor
  * @author Ralph Sennhauser (10/2009)
  */
-void
-vehicle_set_cursor(struct vehicle *this_, struct cursor *cursor, int overwrite) {
+void vehicle_set_cursor(struct vehicle *this_, struct cursor *cursor, int overwrite) {
     struct point sc;
     if (this_->cursor_fixed && !overwrite)
         return;
@@ -360,8 +353,7 @@ vehicle_set_cursor(struct vehicle *this_, struct cursor *cursor, int overwrite) 
  * @param angle The angle relative to the map.
  * @param speed The speed of the vehicle.
  */
-void
-vehicle_draw(struct vehicle *this_, struct graphics *gra, struct point *pnt, int angle, int speed) {
+void vehicle_draw(struct vehicle *this_, struct graphics *gra, struct point *pnt, int angle, int speed) {
     if (angle < 0)
         angle+=360;
     dbg(lvl_debug,"enter this=%p gra=%p pnt=%p dir=%d speed=%d", this_, gra, pnt, angle, speed);
@@ -390,8 +382,7 @@ vehicle_draw(struct vehicle *this_, struct graphics *gra, struct point *pnt, int
     vehicle_draw_do(this_);
 }
 
-int
-vehicle_get_cursor_data(struct vehicle *this, struct point *pnt, int *angle, int *speed) {
+int vehicle_get_cursor_data(struct vehicle *this, struct point *pnt, int *angle, int *speed) {
     *pnt=this->cursor_pnt;
     *angle=this->angle;
     *speed=this->speed;
@@ -410,8 +401,7 @@ static void vehicle_set_default_name(struct vehicle *this_) {
 }
 
 
-static void
-vehicle_draw_do(struct vehicle *this_) {
+static void vehicle_draw_do(struct vehicle *this_) {
     struct point p;
     struct cursor *cursor=this_->cursor;
     int speed=this_->speed;
@@ -467,8 +457,7 @@ vehicle_draw_do(struct vehicle *this_) {
  * @param this_ The vehicle supplying data
  * @param log The log to write to
  */
-static void
-vehicle_log_nmea(struct vehicle *this_, struct log *log) {
+static void vehicle_log_nmea(struct vehicle *this_, struct log *log) {
     struct attr pos_attr;
     if (!this_->meth.position_attr_get)
         return;
@@ -486,8 +475,7 @@ vehicle_log_nmea(struct vehicle *this_, struct log *log) {
  * to be inserted. If {@code *logstr} is NULL, a new string will be created for the extensions section.
  * Upon returning, {@code *logstr} will point to the new string with the additional tag inserted.
  */
-void
-vehicle_log_gpx_add_tag(char *tag, char **logstr) {
+void vehicle_log_gpx_add_tag(char *tag, char **logstr) {
     char *ext_start="\t<extensions>\n";
     char *ext_end="\t</extensions>\n";
     char *trkpt_end="</trkpt>";
@@ -524,8 +512,7 @@ vehicle_log_gpx_add_tag(char *tag, char **logstr) {
  * @param this_ The vehicle supplying data
  * @param log The log to write to
  */
-static void
-vehicle_log_gpx(struct vehicle *this_, struct log *log) {
+static void vehicle_log_gpx(struct vehicle *this_, struct log *log) {
     struct attr attr,*attrp, fix_attr;
     enum attr_type *attr_types;
     char *logstr;
@@ -608,8 +595,7 @@ vehicle_log_gpx(struct vehicle *this_, struct log *log) {
  * @param this_ The vehicle supplying data
  * @param log The log to write to
  */
-static void
-vehicle_log_textfile(struct vehicle *this_, struct log *log) {
+static void vehicle_log_textfile(struct vehicle *this_, struct log *log) {
     struct attr pos_attr,fix_attr;
     char *logstr;
     if (!this_->meth.position_attr_get)
@@ -631,8 +617,7 @@ vehicle_log_textfile(struct vehicle *this_, struct log *log) {
  * @param this_ The vehicle supplying data
  * @param log The log to write to
  */
-static void
-vehicle_log_binfile(struct vehicle *this_, struct log *log) {
+static void vehicle_log_binfile(struct vehicle *this_, struct log *log) {
     struct attr pos_attr, fix_attr;
     int *buffer;
     int *buffer_new;
@@ -692,8 +677,7 @@ vehicle_log_binfile(struct vehicle *this_, struct log *log) {
  *
  * @return False if the log is of an unknown type, true otherwise (including when {@code attr_type} is missing).
  */
-static int
-vehicle_add_log(struct vehicle *this_, struct log *log) {
+static int vehicle_add_log(struct vehicle *this_, struct log *log) {
     struct callback *cb;
     struct attr type_attr;
     if (!log_get_attr(log, attr_type, &type_attr, NULL))

--- a/navit/vehicle/android/vehicle_android.c
+++ b/navit/vehicle/android/vehicle_android.c
@@ -70,8 +70,7 @@ struct vehicle_priv {
  * @param priv vehicle_priv structure for the vehicle
  * @returns nothing
  */
-static void
-vehicle_android_destroy(struct vehicle_priv *priv) {
+static void vehicle_android_destroy(struct vehicle_priv *priv) {
     dbg(lvl_debug,"enter");
     g_free(priv);
 }
@@ -84,9 +83,8 @@ vehicle_android_destroy(struct vehicle_priv *priv) {
  * @param attr Points to an attr structure that will receive the attribute data
  * @returns True for success, false for failure
  */
-static int
-vehicle_android_position_attr_get(struct vehicle_priv *priv,
-                                  enum attr_type type, struct attr *attr) {
+static int vehicle_android_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     dbg(lvl_debug,"enter %s",attr_to_name(type));
     switch (type) {
     case attr_position_fix_type:
@@ -142,8 +140,7 @@ struct vehicle_methods vehicle_android_methods = {
  * @param v The {@code struct_vehicle_priv} for the vehicle
  * @param location A {@code Location} object describing the new position
  */
-static void
-vehicle_android_position_callback(struct vehicle_priv *v, jobject location) {
+static void vehicle_android_position_callback(struct vehicle_priv *v, jobject location) {
     time_t tnow;
     struct tm *tm;
     dbg(lvl_debug,"enter");
@@ -179,8 +176,7 @@ vehicle_android_position_callback(struct vehicle_priv *v, jobject location) {
  * @param sats_in_view The number of satellites in view
  * @param sats_used The number of satellites currently used to determine the position
  */
-static void
-vehicle_android_status_callback(struct vehicle_priv *v, int sats_in_view, int sats_used) {
+static void vehicle_android_status_callback(struct vehicle_priv *v, int sats_in_view, int sats_used) {
     if (v->sats != sats_in_view) {
         v->sats = sats_in_view;
         callback_list_call_attr_0(v->cbl, attr_position_qual);
@@ -199,8 +195,7 @@ vehicle_android_status_callback(struct vehicle_priv *v, int sats_in_view, int sa
  * @param v The {@code struct_vehicle_priv} for the vehicle
  * @param fix_type The fix type (1 = valid, 0 = invalid)
  */
-static void
-vehicle_android_fix_callback(struct vehicle_priv *v, int fix_type) {
+static void vehicle_android_fix_callback(struct vehicle_priv *v, int fix_type) {
     if (v->fix_type != fix_type) {
         v->fix_type = fix_type;
         callback_list_call_attr_0(v->cbl, attr_position_fix_type);
@@ -216,8 +211,7 @@ vehicle_android_fix_callback(struct vehicle_priv *v, int fix_type) {
  *
  * @return True on success, false on failure
  */
-static int
-vehicle_android_init(struct vehicle_priv *ret) {
+static int vehicle_android_init(struct vehicle_priv *ret) {
     jmethodID cid;
 
     if (!android_find_class_global("android/location/Location", &ret->LocationClass))
@@ -264,10 +258,9 @@ vehicle_android_init(struct vehicle_priv *ret) {
  * @param attrs
  * @returns vehicle_priv
  */
-static struct vehicle_priv *
-vehicle_android_new_android(struct vehicle_methods *meth,
-                            struct callback_list *cbl,
-                            struct attr **attrs) {
+static struct vehicle_priv *vehicle_android_new_android(struct vehicle_methods *meth,
+        struct callback_list *cbl,
+        struct attr **attrs) {
     struct vehicle_priv *ret;
 
     dbg(lvl_debug, "enter");
@@ -290,8 +283,7 @@ vehicle_android_new_android(struct vehicle_methods *meth,
  *
  * @returns nothing
  */
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("android", vehicle_android_new_android);
 }

--- a/navit/vehicle/demo/vehicle_demo.c
+++ b/navit/vehicle/demo/vehicle_demo.c
@@ -60,8 +60,7 @@ struct vehicle_priv {
 
 };
 
-static void
-vehicle_demo_destroy(struct vehicle_priv *priv) {
+static void vehicle_demo_destroy(struct vehicle_priv *priv) {
     if (priv->timer)
         event_remove_timeout(priv->timer);
     callback_destroy(priv->timer_callback);
@@ -69,8 +68,7 @@ vehicle_demo_destroy(struct vehicle_priv *priv) {
     g_free(priv);
 }
 
-static void
-nmea_chksum(char *nmea) {
+static void nmea_chksum(char *nmea) {
     int i;
     if (nmea && strlen(nmea) > 3) {
         unsigned char csum=0;
@@ -80,9 +78,8 @@ nmea_chksum(char *nmea) {
     }
 }
 
-static int
-vehicle_demo_position_attr_get(struct vehicle_priv *priv,
-                               enum attr_type type, struct attr *attr) {
+static int vehicle_demo_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     char ns='N',ew='E',*timep,*rmc,*gga;
     int hr,min,sec,year,mon,day;
     double lat,lng;
@@ -144,8 +141,7 @@ vehicle_demo_position_attr_get(struct vehicle_priv *priv,
     return 1;
 }
 
-static int
-vehicle_demo_set_attr_do(struct vehicle_priv *priv, struct attr *attr) {
+static int vehicle_demo_set_attr_do(struct vehicle_priv *priv, struct attr *attr) {
     switch(attr->type) {
     case attr_navit:
         priv->navit = attr->u.navit;
@@ -185,8 +181,7 @@ vehicle_demo_set_attr_do(struct vehicle_priv *priv, struct attr *attr) {
     return 1;
 }
 
-static int
-vehicle_demo_set_attr(struct vehicle_priv *priv, struct attr *attr) {
+static int vehicle_demo_set_attr(struct vehicle_priv *priv, struct attr *attr) {
     return vehicle_demo_set_attr_do(priv, attr);
 }
 
@@ -196,8 +191,7 @@ struct vehicle_methods vehicle_demo_methods = {
     vehicle_demo_set_attr,
 };
 
-static void
-vehicle_demo_timer(struct vehicle_priv *priv) {
+static void vehicle_demo_timer(struct vehicle_priv *priv) {
     struct coord c, c2, pos, ci;
     int slen, len, dx, dy;
     struct route *route=NULL;
@@ -278,10 +272,9 @@ vehicle_demo_timer(struct vehicle_priv *priv) {
 
 
 
-static struct vehicle_priv *
-vehicle_demo_new(struct vehicle_methods
-                 *meth, struct callback_list
-                 *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_demo_new(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
 
     dbg(lvl_debug, "enter");
@@ -299,8 +292,7 @@ vehicle_demo_new(struct vehicle_methods
     return ret;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("demo", vehicle_demo_new);
 }

--- a/navit/vehicle/file/vehicle_file.c
+++ b/navit/vehicle/file/vehicle_file.c
@@ -212,8 +212,7 @@ static int vehicle_win32_serial_track(struct vehicle_priv *priv) {
 *
 * @return 1 if ok, 0 if error
 */
-static int
-vehicle_file_open(struct vehicle_priv *priv) {
+static int vehicle_file_open(struct vehicle_priv *priv) {
     char *name;
 #ifndef _WIN32
     struct termios tio;
@@ -319,8 +318,7 @@ vehicle_file_open(struct vehicle_priv *priv) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_file_close(struct vehicle_priv *priv) {
+static void vehicle_file_close(struct vehicle_priv *priv) {
     dbg(lvl_debug, "enter, priv->fd='%d'", priv->fd);
     vehicle_file_disable_watch(priv);
 #ifdef _WIN32
@@ -352,8 +350,7 @@ vehicle_file_close(struct vehicle_priv *priv) {
 *
 * @return Always 0
 */
-static int
-vehicle_file_enable_watch_timer(struct vehicle_priv *priv) {
+static int vehicle_file_enable_watch_timer(struct vehicle_priv *priv) {
     dbg(lvl_debug, "enter");
     vehicle_file_enable_watch(priv);
 
@@ -367,8 +364,7 @@ vehicle_file_enable_watch_timer(struct vehicle_priv *priv) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_file_fix_timeout_cb(struct vehicle_priv *priv) {
+static void vehicle_file_fix_timeout_cb(struct vehicle_priv *priv) {
     priv->valid = attr_position_valid_invalid;
     priv->ev_fix_timeout = NULL;
     callback_list_call_attr_0(priv->cbl, attr_position_coord_geo);
@@ -380,8 +376,7 @@ vehicle_file_fix_timeout_cb(struct vehicle_priv *priv) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_file_restart_fix_timeout(struct vehicle_priv *priv) {
+static void vehicle_file_restart_fix_timeout(struct vehicle_priv *priv) {
     if (priv->ev_fix_timeout != NULL)
         event_remove_timeout(priv->ev_fix_timeout);
     priv->ev_fix_timeout = event_add_timeout(10000, 0, priv->cb_fix_timeout);
@@ -397,8 +392,7 @@ vehicle_file_restart_fix_timeout(struct vehicle_priv *priv) {
 * @return 1 if new coords were received (fixtime changed) or changed to invalid,
 *         0 if not found
 */
-static int
-vehicle_file_parse(struct vehicle_priv *priv, char *buffer) {
+static int vehicle_file_parse(struct vehicle_priv *priv, char *buffer) {
     char *nmea_data_buf, *p, *item[32];
     double lat, lng;
     int i, j, bcsum;
@@ -666,8 +660,7 @@ vehicle_file_parse(struct vehicle_priv *priv, char *buffer) {
 *
 * @param  priv Pointer on the private data of the plugin
 */
-static void
-vehicle_file_io(struct vehicle_priv *priv) {
+static void vehicle_file_io(struct vehicle_priv *priv) {
     int size, rc = 0;
     char *str, *tok;
     dbg(lvl_debug, "vehicle_file_io : enter");
@@ -735,8 +728,7 @@ vehicle_file_io(struct vehicle_priv *priv) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_file_enable_watch(struct vehicle_priv *priv) {
+static void vehicle_file_enable_watch(struct vehicle_priv *priv) {
     dbg(lvl_debug, "enter");
 #ifdef _WIN32
     // add an event : don't use glib timers and g_timeout_add
@@ -758,8 +750,7 @@ vehicle_file_enable_watch(struct vehicle_priv *priv) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_file_disable_watch(struct vehicle_priv *priv) {
+static void vehicle_file_disable_watch(struct vehicle_priv *priv) {
     dbg(lvl_debug, "vehicle_file_disable_watch : enter");
 #ifdef _WIN32
     if(priv->file_type == file_type_serial) {
@@ -783,8 +774,7 @@ vehicle_file_disable_watch(struct vehicle_priv *priv) {
 *
 * @remarks private data is freed by this function (g_free)
 */
-static void
-vehicle_file_destroy(struct vehicle_priv *priv) {
+static void vehicle_file_destroy(struct vehicle_priv *priv) {
     if (priv->statefile && priv->nmea_data) {
         struct attr readwrite= {attr_readwrite};
         struct attr create= {attr_create};
@@ -820,9 +810,8 @@ vehicle_file_destroy(struct vehicle_priv *priv) {
 *
 * @return 1 if ok, 0 for unknown or invalid attribute
 */
-static int
-vehicle_file_position_attr_get(struct vehicle_priv *priv,
-                               enum attr_type type, struct attr *attr) {
+static int vehicle_file_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_position_fix_type:
         attr->u.num = priv->status;
@@ -897,8 +886,7 @@ vehicle_file_position_attr_get(struct vehicle_priv *priv,
 *
 * @return 1 if ok, 0 for unknown attribute
 */
-static int
-vehicle_file_sat_attr_get(void *priv_data, enum attr_type type, struct attr *attr) {
+static int vehicle_file_sat_attr_get(void *priv_data, enum attr_type type, struct attr *attr) {
     struct gps_sat *sat;
     struct vehicle_priv *priv=priv_data;
     if (priv->sat_item.id_lo < 1)
@@ -949,10 +937,9 @@ static struct vehicle_methods vehicle_file_methods = {
 *
 * @remarks Private data is allocated by this function (g_new0)
 */
-static struct vehicle_priv *
-vehicle_file_new_file(struct vehicle_methods
-                      *meth, struct callback_list
-                      *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_file_new_file(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
     struct attr *source;
     struct attr *time;

--- a/navit/vehicle/file/vehicle_pipe.c
+++ b/navit/vehicle/file/vehicle_pipe.c
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "plugin.h"
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_get_category_vehicle("file");
 }

--- a/navit/vehicle/file/vehicle_serial.c
+++ b/navit/vehicle/file/vehicle_serial.c
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "plugin.h"
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_get_category_vehicle("file");
 }

--- a/navit/vehicle/file/vehicle_socket.c
+++ b/navit/vehicle/file/vehicle_socket.c
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "plugin.h"
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     plugin_get_category_vehicle("file");
 }

--- a/navit/vehicle/gpsd/vehicle_gpsd.c
+++ b/navit/vehicle/gpsd/vehicle_gpsd.c
@@ -210,8 +210,7 @@ vehicle_gpsd_callback(struct gps_data_t *data, const char *buf, size_t len,
  * Return FALSE if retry not required
  * Return TRUE to try again
  */
-static int
-vehicle_gpsd_try_open(struct vehicle_priv *priv) {
+static int vehicle_gpsd_try_open(struct vehicle_priv *priv) {
     char *source = g_strdup(priv->source);
     char *colon = index(source + 7, ':');
     char *port=NULL;
@@ -262,8 +261,7 @@ vehicle_gpsd_try_open(struct vehicle_priv *priv) {
 /**
  * Open a connection to gpsd. Will re-try the connection if it fails
  */
-static void
-vehicle_gpsd_open(struct vehicle_priv *priv) {
+static void vehicle_gpsd_open(struct vehicle_priv *priv) {
 #ifdef HAVE_GPSBT
     char errstr[256] = "";
     /* We need to start gpsd (via gpsbt) first. */
@@ -282,8 +280,7 @@ vehicle_gpsd_open(struct vehicle_priv *priv) {
         priv->retry_timer2=event_add_timeout(priv->retry_interval*1000, 1, priv->cbt);
 }
 
-static void
-vehicle_gpsd_close(struct vehicle_priv *priv) {
+static void vehicle_gpsd_close(struct vehicle_priv *priv) {
 #ifdef HAVE_GPSBT
     int err;
 #endif
@@ -320,8 +317,7 @@ vehicle_gpsd_close(struct vehicle_priv *priv) {
 #endif
 }
 
-static void
-vehicle_gpsd_io(struct vehicle_priv *priv) {
+static void vehicle_gpsd_io(struct vehicle_priv *priv) {
     dbg(lvl_debug, "enter");
     if (priv->gps) {
         vehicle_last = priv;
@@ -349,8 +345,7 @@ vehicle_gpsd_io(struct vehicle_priv *priv) {
     }
 }
 
-static void
-vehicle_gpsd_destroy(struct vehicle_priv *priv) {
+static void vehicle_gpsd_destroy(struct vehicle_priv *priv) {
     vehicle_gpsd_close(priv);
     if (priv->source)
         g_free(priv->source);
@@ -362,9 +357,8 @@ vehicle_gpsd_destroy(struct vehicle_priv *priv) {
     g_free(priv);
 }
 
-static int
-vehicle_gpsd_position_attr_get(struct vehicle_priv *priv,
-                               enum attr_type type, struct attr *attr) {
+static int vehicle_gpsd_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     struct attr * active=NULL;
     switch (type) {
     case attr_position_fix_type:
@@ -431,10 +425,9 @@ static struct vehicle_methods vehicle_gpsd_methods = {
     vehicle_gpsd_position_attr_get,
 };
 
-static struct vehicle_priv *
-vehicle_gpsd_new_gpsd(struct vehicle_methods
-                      *meth, struct callback_list
-                      *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_gpsd_new_gpsd(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
     struct attr *source, *query, *retry_int;
 
@@ -470,8 +463,7 @@ vehicle_gpsd_new_gpsd(struct vehicle_methods
     return ret;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("gpsd", vehicle_gpsd_new_gpsd);
 }

--- a/navit/vehicle/gpsd_dbus/vehicle_gpsd_dbus.c
+++ b/navit/vehicle/gpsd_dbus/vehicle_gpsd_dbus.c
@@ -57,15 +57,13 @@ struct vehicle_priv {
     char fixiso8601[128];
 };
 
-static void
-vehicle_gpsd_dbus_close(struct vehicle_priv *priv) {
+static void vehicle_gpsd_dbus_close(struct vehicle_priv *priv) {
     if (priv->connection)
         dbus_connection_unref(priv->connection);
     priv->connection=NULL;
 }
 
-static DBusHandlerResult
-vehicle_gpsd_dbus_filter(DBusConnection *connection, DBusMessage *message, void *user_data) {
+static DBusHandlerResult vehicle_gpsd_dbus_filter(DBusConnection *connection, DBusMessage *message, void *user_data) {
     struct vehicle_priv *priv=user_data;
     double time,ept,latitude,longitude,eph,altitude,epv,track,epd,speed,eps,climb,epc;
     int mode;
@@ -108,8 +106,7 @@ vehicle_gpsd_dbus_filter(DBusConnection *connection, DBusMessage *message, void 
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
 
-static int
-vehicle_gpsd_dbus_open(struct vehicle_priv *priv) {
+static int vehicle_gpsd_dbus_open(struct vehicle_priv *priv) {
     DBusError error;
 
     dbus_error_init(&error);
@@ -140,17 +137,15 @@ vehicle_gpsd_dbus_open(struct vehicle_priv *priv) {
 }
 
 
-static void
-vehicle_gpsd_dbus_destroy(struct vehicle_priv *priv) {
+static void vehicle_gpsd_dbus_destroy(struct vehicle_priv *priv) {
     vehicle_gpsd_dbus_close(priv);
     if (priv->source)
         g_free(priv->source);
     g_free(priv);
 }
 
-static int
-vehicle_gpsd_dbus_position_attr_get(struct vehicle_priv *priv,
-                                    enum attr_type type, struct attr *attr) {
+static int vehicle_gpsd_dbus_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_position_height:
         attr->u.numd = &priv->altitude;
@@ -183,8 +178,7 @@ vehicle_gpsd_dbus_position_attr_get(struct vehicle_priv *priv,
     return 1;
 }
 
-static int
-vehicle_gpsd_dbus_set_attr_do(struct vehicle_priv *priv, struct attr *attr, int init) {
+static int vehicle_gpsd_dbus_set_attr_do(struct vehicle_priv *priv, struct attr *attr, int init) {
     switch (attr->type) {
     case attr_source:
         if (strncmp(vehicle_gpsd_dbus_prefix,attr->u.str,strlen(vehicle_gpsd_dbus_prefix))) {
@@ -209,8 +203,7 @@ vehicle_gpsd_dbus_set_attr_do(struct vehicle_priv *priv, struct attr *attr, int 
     }
 }
 
-static int
-vehicle_gpsd_dbus_set_attr(struct vehicle_priv *priv, struct attr *attr) {
+static int vehicle_gpsd_dbus_set_attr(struct vehicle_priv *priv, struct attr *attr) {
     return vehicle_gpsd_dbus_set_attr_do(priv, attr, 0);
 }
 
@@ -220,10 +213,9 @@ static struct vehicle_methods vehicle_gpsd_methods = {
     vehicle_gpsd_dbus_set_attr,
 };
 
-static struct vehicle_priv *
-vehicle_gpsd_dbus_new(struct vehicle_methods
-                      *meth, struct callback_list
-                      *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_gpsd_dbus_new(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
 
 
@@ -239,8 +231,7 @@ vehicle_gpsd_dbus_new(struct vehicle_methods
     return ret;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("gpsd_dbus", vehicle_gpsd_dbus_new);
 }

--- a/navit/vehicle/gypsy/vehicle_gypsy.c
+++ b/navit/vehicle/gypsy/vehicle_gypsy.c
@@ -97,10 +97,9 @@ static struct vehicle_priv {
  * @param userdata
  * @returns nothing
  */
-static void
-vehicle_gypsy_fixstatus_changed(GypsyDevice *device,
-                                gint fixstatus,
-                                gpointer userdata) {
+static void vehicle_gypsy_fixstatus_changed(GypsyDevice *device,
+        gint fixstatus,
+        gpointer userdata) {
     struct vehicle_priv *priv = vehicle_last;
 
     if (fixstatus==GYPSY_DEVICE_FIX_STATUS_3D)
@@ -134,11 +133,10 @@ vehicle_gypsy_fixstatus_changed(GypsyDevice *device,
  * @param userdata
  * @returns nothing
  */
-static void
-vehicle_gypsy_position_changed(GypsyPosition *position,
-                               GypsyPositionFields fields_set, int timestamp,
-                               double latitude, double longitude, double altitude,
-                               gpointer userdata) {
+static void vehicle_gypsy_position_changed(GypsyPosition *position,
+        GypsyPositionFields fields_set, int timestamp,
+        double latitude, double longitude, double altitude,
+        gpointer userdata) {
     struct vehicle_priv *priv = vehicle_last;
     int cb = FALSE;
 
@@ -177,10 +175,9 @@ vehicle_gypsy_position_changed(GypsyPosition *position,
  * @param userdata
  * @returns nothing
  */
-static void
-vehicle_gypsy_satellite_changed(GypsySatellite *satellite,
-                                GPtrArray *satellites,
-                                gpointer userdata) {
+static void vehicle_gypsy_satellite_changed(GypsySatellite *satellite,
+        GPtrArray *satellites,
+        gpointer userdata) {
     struct vehicle_priv *priv = vehicle_last;
 
     int i, sats, used=0;
@@ -215,14 +212,13 @@ vehicle_gypsy_satellite_changed(GypsySatellite *satellite,
  * @param userdata
  * @returns nothing
  */
-static void
-vehicle_gypsy_course_changed (GypsyCourse *course,
-                              GypsyCourseFields fields,
-                              int timestamp,
-                              double speed,
-                              double direction,
-                              double climb,
-                              gpointer userdata) {
+static void vehicle_gypsy_course_changed (GypsyCourse *course,
+        GypsyCourseFields fields,
+        int timestamp,
+        double speed,
+        double direction,
+        double climb,
+        gpointer userdata) {
     struct vehicle_priv *priv = vehicle_last;
     int cb = FALSE;
 
@@ -247,8 +243,7 @@ vehicle_gypsy_course_changed (GypsyCourse *course,
  * @param data
  * @returns TRUE to try again; FALSE if retry not required
  */
-static gboolean
-vehicle_gypsy_try_open(gpointer *data) {
+static gboolean vehicle_gypsy_try_open(gpointer *data) {
     struct vehicle_priv *priv = (struct vehicle_priv *)data;
     char *source = g_strdup(priv->source);
 
@@ -292,8 +287,7 @@ vehicle_gypsy_try_open(gpointer *data) {
  * @param priv
  * @returns nothing
  */
-static void
-vehicle_gypsy_open(struct vehicle_priv *priv) {
+static void vehicle_gypsy_open(struct vehicle_priv *priv) {
     priv->retry_timer=0;
     if (vehicle_gypsy_try_open((gpointer *)priv)) {
         priv->retry_timer = g_timeout_add(priv->retry_interval*1000, (GSourceFunc)vehicle_gypsy_try_open, (gpointer *)priv);
@@ -306,8 +300,7 @@ vehicle_gypsy_open(struct vehicle_priv *priv) {
  * @param priv
  * @returns nothing
  */
-static void
-vehicle_gypsy_close(struct vehicle_priv *priv) {
+static void vehicle_gypsy_close(struct vehicle_priv *priv) {
     if (priv->retry_timer) {
         g_source_remove(priv->retry_timer);
         priv->retry_timer=0;
@@ -337,8 +330,7 @@ vehicle_gypsy_close(struct vehicle_priv *priv) {
  * @param priv
  * @returns nothing
  */
-static void
-vehicle_gypsy_destroy(struct vehicle_priv *priv) {
+static void vehicle_gypsy_destroy(struct vehicle_priv *priv) {
     vehicle_gypsy_close(priv);
     if (priv->source)
         g_free(priv->source);
@@ -353,9 +345,8 @@ vehicle_gypsy_destroy(struct vehicle_priv *priv) {
  * @param attr
  * @returns true/false
  */
-static int
-vehicle_gypsy_position_attr_get(struct vehicle_priv *priv,
-                                enum attr_type type, struct attr *attr) {
+static int vehicle_gypsy_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     struct attr * active=NULL;
     switch (type) {
     case attr_position_fix_type:
@@ -420,10 +411,9 @@ struct vehicle_methods vehicle_gypsy_methods = {
  * @param attrs
  * @returns vehicle_priv
  */
-static struct vehicle_priv *
-vehicle_gypsy_new_gypsy(struct vehicle_methods *meth,
-                        struct callback_list *cbl,
-                        struct attr **attrs) {
+static struct vehicle_priv *vehicle_gypsy_new_gypsy(struct vehicle_methods *meth,
+        struct callback_list *cbl,
+        struct attr **attrs) {
     struct vehicle_priv *ret;
     struct attr *source, *retry_int;
 
@@ -478,8 +468,7 @@ vehicle_gypsy_new_gypsy(struct vehicle_methods *meth,
  *
  * @returns nothing
  */
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("gypsy", vehicle_gypsy_new_gypsy);
 }

--- a/navit/vehicle/iphone/vehicle_iphone.c
+++ b/navit/vehicle/iphone/vehicle_iphone.c
@@ -57,15 +57,13 @@ struct vehicle_priv {
     char str_time[200];
 };
 
-static void
-vehicle_iphone_destroy(struct vehicle_priv *priv) {
+static void vehicle_iphone_destroy(struct vehicle_priv *priv) {
     corelocation_exit();
     g_free(priv);
 }
 
-static int
-vehicle_iphone_position_attr_get(struct vehicle_priv *priv,
-                                 enum attr_type type, struct attr *attr) {
+static int vehicle_iphone_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_position_speed:
         attr->u.numd = &priv->speed;
@@ -91,8 +89,7 @@ vehicle_iphone_position_attr_get(struct vehicle_priv *priv,
     return 1;
 }
 
-static int
-vehicle_iphone_set_attr(struct vehicle_priv *priv, struct attr *attr) {
+static int vehicle_iphone_set_attr(struct vehicle_priv *priv, struct attr *attr) {
     if (attr->type == attr_navit) {
         priv->navit = attr->u.navit;
         return 1;
@@ -106,15 +103,14 @@ struct vehicle_methods vehicle_iphone_methods = {
     vehicle_iphone_set_attr,
 };
 
-void
-vehicle_iphone_update(void *arg,
-                      double lat,
-                      double lng,
-                      double dir,
-                      double spd,
-                      char * str_time,
-                      double radius
-                     ) {
+void vehicle_iphone_update(void *arg,
+                           double lat,
+                           double lng,
+                           double dir,
+                           double spd,
+                           char * str_time,
+                           double radius
+                          ) {
     struct vehicle_priv * priv = arg;
     priv->geo.lat = lat;
     priv->geo.lng = lng;
@@ -130,10 +126,9 @@ vehicle_iphone_update(void *arg,
 
 
 
-static struct vehicle_priv *
-vehicle_iphone_new(struct vehicle_methods
-                   *meth, struct callback_list
-                   *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_iphone_new(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
     struct attr *interval,*speed,*position_coord_geo;
 
@@ -161,8 +156,7 @@ vehicle_iphone_new(struct vehicle_methods
     return ret;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("iphone", vehicle_iphone_new);
 }

--- a/navit/vehicle/maemo/vehicle_maemo.c
+++ b/navit/vehicle/maemo/vehicle_maemo.c
@@ -143,8 +143,7 @@ static void vehicle_maemo_error(LocationGPSDControl *control, LocationGPSDContro
 /**
  * Instantiate liblocation objects
  */
-static void
-vehicle_maemo_open(struct vehicle_priv *priv) {
+static void vehicle_maemo_open(struct vehicle_priv *priv) {
 
     priv->control = location_gpsd_control_get_default();
     priv->device = g_object_new(LOCATION_TYPE_GPS_DEVICE, NULL);
@@ -210,8 +209,7 @@ vehicle_maemo_open(struct vehicle_priv *priv) {
     return;
 }
 
-static void
-vehicle_maemo_destroy(struct vehicle_priv *priv) {
+static void vehicle_maemo_destroy(struct vehicle_priv *priv) {
     location_gpsd_control_stop(priv->control);
 
     g_object_unref(priv->device);
@@ -220,9 +218,8 @@ vehicle_maemo_destroy(struct vehicle_priv *priv) {
     return;
 }
 
-static int
-vehicle_maemo_position_attr_get(struct vehicle_priv *priv,
-                                enum attr_type type, struct attr *attr) {
+static int vehicle_maemo_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     struct attr * active=NULL;
     switch (type) {
     case attr_position_fix_type:
@@ -291,10 +288,9 @@ struct vehicle_methods vehicle_maemo_methods = {
     vehicle_maemo_position_attr_get,
 };
 
-static struct vehicle_priv *
-vehicle_maemo_new_maemo(struct vehicle_methods
-                        *meth, struct callback_list
-                        *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_maemo_new_maemo(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
     struct attr *source, *retry_int;
 
@@ -321,8 +317,7 @@ vehicle_maemo_new_maemo(struct vehicle_methods
     return ret;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("maemo", vehicle_maemo_new_maemo);
 }

--- a/navit/vehicle/null/vehicle_null.c
+++ b/navit/vehicle/null/vehicle_null.c
@@ -64,8 +64,7 @@ struct vehicle_priv {
  * @param priv
  * @returns nothing
  */
-static void
-vehicle_null_destroy(struct vehicle_priv *priv) {
+static void vehicle_null_destroy(struct vehicle_priv *priv) {
     dbg(lvl_debug,"enter");
     g_free(priv);
 }
@@ -78,9 +77,8 @@ vehicle_null_destroy(struct vehicle_priv *priv) {
  * @param attr
  * @returns true/false
  */
-static int
-vehicle_null_position_attr_get(struct vehicle_priv *priv,
-                               enum attr_type type, struct attr *attr) {
+static int vehicle_null_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     dbg(lvl_debug,"enter %s",attr_to_name(type));
     switch (type) {
     case attr_position_height:
@@ -111,8 +109,7 @@ vehicle_null_position_attr_get(struct vehicle_priv *priv,
     return 1;
 }
 
-static int
-vehicle_null_set_attr(struct vehicle_priv *priv, struct attr *attr) {
+static int vehicle_null_set_attr(struct vehicle_priv *priv, struct attr *attr) {
     switch (attr->type) {
     case attr_position_speed:
         priv->speed=*attr->u.numd;
@@ -146,10 +143,9 @@ struct vehicle_methods vehicle_null_methods = {
  * @param attrs
  * @returns vehicle_priv
  */
-static struct vehicle_priv *
-vehicle_null_new_null(struct vehicle_methods *meth,
-                      struct callback_list *cbl,
-                      struct attr **attrs) {
+static struct vehicle_priv *vehicle_null_new_null(struct vehicle_methods *meth,
+        struct callback_list *cbl,
+        struct attr **attrs) {
     struct vehicle_priv *ret;
 
     dbg(lvl_debug, "enter");
@@ -165,8 +161,7 @@ vehicle_null_new_null(struct vehicle_methods *meth,
  *
  * @returns nothing
  */
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("null", vehicle_null_new_null);
 }

--- a/navit/vehicle/qt5/vehicle_qt5.cpp
+++ b/navit/vehicle/qt5/vehicle_qt5.cpp
@@ -137,8 +137,7 @@ void QNavitGeoReceiver::positionUpdated(const QGeoPositionInfo& info) {
  * @param priv
  * @returns nothing
  */
-static void
-vehicle_qt5_destroy(struct vehicle_priv* priv) {
+static void vehicle_qt5_destroy(struct vehicle_priv* priv) {
     dbg(lvl_debug, "enter");
     if (priv->receiver != NULL)
         delete priv->receiver;
@@ -155,9 +154,8 @@ vehicle_qt5_destroy(struct vehicle_priv* priv) {
  * @param attr
  * @returns true/false
  */
-static int
-vehicle_qt5_position_attr_get(struct vehicle_priv* priv,
-                              enum attr_type type, struct attr* attr) {
+static int vehicle_qt5_position_attr_get(struct vehicle_priv* priv,
+        enum attr_type type, struct attr* attr) {
     struct attr* active = NULL;
     dbg(lvl_debug, "enter %s", attr_to_name(type));
     switch (type) {
@@ -225,8 +223,7 @@ vehicle_qt5_position_attr_get(struct vehicle_priv* priv,
     return 1;
 }
 
-static int
-vehicle_qt5_set_attr(struct vehicle_priv* priv, struct attr* attr) {
+static int vehicle_qt5_set_attr(struct vehicle_priv* priv, struct attr* attr) {
     switch (attr->type) {
     case attr_position_speed:
         priv->speed = *attr->u.numd;
@@ -259,10 +256,9 @@ struct vehicle_methods vehicle_null_methods = {
  * @param attrs
  * @returns vehicle_priv
  */
-static struct vehicle_priv*
-vehicle_qt5_new_qt5(struct vehicle_methods* meth,
-                    struct callback_list* cbl,
-                    struct attr** attrs) {
+static struct vehicle_priv* vehicle_qt5_new_qt5(struct vehicle_methods* meth,
+        struct callback_list* cbl,
+        struct attr** attrs) {
     struct vehicle_priv* ret;
 
     dbg(lvl_debug, "enter");

--- a/navit/vehicle/webos/bluetooth.c
+++ b/navit/vehicle/webos/bluetooth.c
@@ -21,8 +21,8 @@ static void vehicle_webos_spp_init_read(struct vehicle_priv *priv, unsigned int 
 
 /********************************************************************/
 
-static void
-mlPDL_ServiceCall_callback(struct callback_list *cbl, char *service, char *parameters/*, struct callback *fail_cb*/) {
+static void mlPDL_ServiceCall_callback(struct callback_list *cbl, char *service,
+                                       char *parameters/*, struct callback *fail_cb*/) {
     PDL_Err err;
     dbg(lvl_debug,"PDL_ServiceCall(%s) parameters(%s)",service,parameters);
     err = PDL_ServiceCall(service, parameters);
@@ -35,8 +35,7 @@ mlPDL_ServiceCall_callback(struct callback_list *cbl, char *service, char *param
     g_free(parameters);
 }
 
-static void
-mlPDL_ServiceCall(const char *service, const char *parameters/*, struct callback *fail_cb = NULL*/) {
+static void mlPDL_ServiceCall(const char *service, const char *parameters/*, struct callback *fail_cb = NULL*/) {
     struct callback *cb = NULL;
     struct callback_list *cbl = NULL;
 
@@ -54,13 +53,12 @@ mlPDL_ServiceCall(const char *service, const char *parameters/*, struct callback
 
 /********************************************************************/
 
-static void
-mlPDL_ServiceCallWithCallback_callback(struct callback_list *cbl,
-                                       char *service,
-                                       char *parameters,
-                                       PDL_ServiceCallbackFunc callback,
-                                       void *user,
-                                       PDL_bool removeAfterResponse) {
+static void mlPDL_ServiceCallWithCallback_callback(struct callback_list *cbl,
+        char *service,
+        char *parameters,
+        PDL_ServiceCallbackFunc callback,
+        void *user,
+        PDL_bool removeAfterResponse) {
     PDL_Err err;
     dbg(lvl_debug,"PDL_ServiceCallWithCallback(%s) parameters(%s)",service,parameters);
     err = PDL_ServiceCallWithCallback(service, parameters, callback, user, removeAfterResponse);
@@ -74,12 +72,11 @@ mlPDL_ServiceCallWithCallback_callback(struct callback_list *cbl,
     g_free(parameters);
 }
 
-static void
-mlPDL_ServiceCallWithCallback(const char *service,
-                              const char *parameters,
-                              PDL_ServiceCallbackFunc callback,
-                              void *user,
-                              PDL_bool removeAfterResponse) {
+static void mlPDL_ServiceCallWithCallback(const char *service,
+        const char *parameters,
+        PDL_ServiceCallbackFunc callback,
+        void *user,
+        PDL_bool removeAfterResponse) {
     struct callback *cb = NULL;
     struct callback_list *cbl = NULL;
 
@@ -98,8 +95,8 @@ mlPDL_ServiceCallWithCallback(const char *service,
 
 /********************************************************************/
 
-static void
-vehicle_webos_init_pdl_locationtracking_callback(struct vehicle_priv *priv, struct callback_list *cbl, int param) {
+static void vehicle_webos_init_pdl_locationtracking_callback(struct vehicle_priv *priv, struct callback_list *cbl,
+        int param) {
     PDL_Err err;
 
     priv->gps_type = param ? GPS_TYPE_INT: GPS_TYPE_NONE;
@@ -116,8 +113,7 @@ vehicle_webos_init_pdl_locationtracking_callback(struct vehicle_priv *priv, stru
     callback_list_destroy(cbl);
 }
 
-static void
-vehicle_webos_init_pdl_locationtracking(struct vehicle_priv *priv, int param) {
+static void vehicle_webos_init_pdl_locationtracking(struct vehicle_priv *priv, int param) {
     struct callback *cb = NULL;
     struct callback_list *cbl = NULL;
 
@@ -131,8 +127,7 @@ vehicle_webos_init_pdl_locationtracking(struct vehicle_priv *priv, int param) {
 
 /********************************************************************/
 
-static int
-vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer) {
+static int vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer) {
     char *nmea_data_buf, *p, *item[32];
     double lat, lng;
     int i, bcsum;
@@ -327,8 +322,7 @@ vehicle_webos_parse_nmea(struct vehicle_priv *priv, char *buffer) {
     return ret;
 }
 
-static void
-vehicle_webos_spp_handle_read(PDL_ServiceParameters *params, void *user) {
+static void vehicle_webos_spp_handle_read(PDL_ServiceParameters *params, void *user) {
     struct vehicle_priv *priv = user;
     int size, rc = 0;
     char *str, *tok;
@@ -391,8 +385,7 @@ vehicle_webos_spp_handle_read(PDL_ServiceParameters *params, void *user) {
     vehicle_webos_spp_init_read(priv, buffer_size - priv->buffer_pos - 1);
 }
 
-static void
-vehicle_webos_spp_init_read(struct vehicle_priv *priv, unsigned int length) {
+static void vehicle_webos_spp_init_read(struct vehicle_priv *priv, unsigned int length) {
     //PDL_Err err;
     char parameters[128];
 
@@ -405,8 +398,7 @@ vehicle_webos_spp_init_read(struct vehicle_priv *priv, unsigned int length) {
                                  );
 }
 
-static void
-vehicle_webos_spp_handle_open(PDL_ServiceParameters *params, void *user) {
+static void vehicle_webos_spp_handle_open(PDL_ServiceParameters *params, void *user) {
     struct vehicle_priv *priv = (struct vehicle_priv *)user;
 
     if (!priv->buffer)
@@ -419,8 +411,7 @@ vehicle_webos_spp_handle_open(PDL_ServiceParameters *params, void *user) {
     vehicle_webos_spp_init_read(priv, buffer_size-1);
 }
 
-static void
-vehicle_webos_spp_notify(PDL_ServiceParameters *params, void *user) {
+static void vehicle_webos_spp_notify(PDL_ServiceParameters *params, void *user) {
     struct vehicle_priv *priv = user;
 
     char notification[128];
@@ -485,8 +476,7 @@ vehicle_webos_spp_notify(PDL_ServiceParameters *params, void *user) {
 
 }
 
-static void
-vehicle_webos_init_bt_gps(struct vehicle_priv *priv, char *addr) {
+static void vehicle_webos_init_bt_gps(struct vehicle_priv *priv, char *addr) {
     char parameters[128];
 
     dbg(lvl_debug,"subscribeNotifications");
@@ -502,8 +492,7 @@ vehicle_webos_init_bt_gps(struct vehicle_priv *priv, char *addr) {
     priv->spp_address = addr;
 }
 
-static void
-vehicle_webos_bt_gap_callback(PDL_ServiceParameters *params, void *param) {
+static void vehicle_webos_bt_gap_callback(PDL_ServiceParameters *params, void *param) {
     const char *params_json;
     struct vehicle_priv *priv = (struct vehicle_priv *)param;
     char *device_addr = NULL;
@@ -555,8 +544,7 @@ vehicle_webos_bt_gap_callback(PDL_ServiceParameters *params, void *param) {
     g_free(device_addr);
 }
 
-int
-vehicle_webos_bt_open(struct vehicle_priv *priv) {
+int vehicle_webos_bt_open(struct vehicle_priv *priv) {
     // Try to connect to BT GPS, or use PDL method
 
     dbg(lvl_debug,"enter");
@@ -575,8 +563,7 @@ vehicle_webos_bt_open(struct vehicle_priv *priv) {
     return 1;
 }
 
-void
-vehicle_webos_bt_close(struct vehicle_priv *priv) {
+void vehicle_webos_bt_close(struct vehicle_priv *priv) {
     dbg(lvl_debug,"XXX");
     char parameters[128];
     if (priv->spp_instance_id) {

--- a/navit/vehicle/webos/vehicle_webos.c
+++ b/navit/vehicle/webos/vehicle_webos.c
@@ -49,8 +49,7 @@ static char *vehicle_webos_prefix="webos:";
 
 /*******************************************************************/
 
-static void
-vehicle_webos_callback(PDL_ServiceParameters *params, void *priv) {
+static void vehicle_webos_callback(PDL_ServiceParameters *params, void *priv) {
     PDL_Location *location;
     SDL_Event event;
     SDL_UserEvent userevent;
@@ -84,8 +83,7 @@ vehicle_webos_callback(PDL_ServiceParameters *params, void *priv) {
     return /*PDL_NOERROR*/;
 }
 
-static void
-vehicle_webos_gps_update(struct vehicle_priv *priv, PDL_Location *location) {
+static void vehicle_webos_gps_update(struct vehicle_priv *priv, PDL_Location *location) {
     if(location) {	// location may be NULL if called by bluetooth-code. priv is already prefilled there
         struct timeval tv;
         gettimeofday(&tv,NULL);
@@ -122,8 +120,7 @@ vehicle_webos_gps_update(struct vehicle_priv *priv, PDL_Location *location) {
     callback_list_call_attr_0(priv->cbl, attr_position_coord_geo);
 }
 
-static void
-vehicle_webos_timeout_callback(struct vehicle_priv *priv) {
+static void vehicle_webos_timeout_callback(struct vehicle_priv *priv) {
     struct timeval tv;
     gettimeofday(&tv,NULL);
 
@@ -140,8 +137,7 @@ vehicle_webos_timeout_callback(struct vehicle_priv *priv) {
     }
 }
 
-void
-vehicle_webos_close(struct vehicle_priv *priv) {
+void vehicle_webos_close(struct vehicle_priv *priv) {
     event_remove_timeout(priv->ev_timeout);
     priv->ev_timeout = NULL;
 
@@ -155,8 +151,7 @@ vehicle_webos_close(struct vehicle_priv *priv) {
     }
 }
 
-static int
-vehicle_webos_open(struct vehicle_priv *priv) {
+static int vehicle_webos_open(struct vehicle_priv *priv) {
     PDL_Err err;
 
     priv->pdk_version = PDL_GetPDKVersion();
@@ -193,17 +188,15 @@ vehicle_webos_open(struct vehicle_priv *priv) {
     return 1;
 }
 
-static void
-vehicle_webos_destroy(struct vehicle_priv *priv) {
+static void vehicle_webos_destroy(struct vehicle_priv *priv) {
     vehicle_webos_close(priv);
     if (priv->source)
         g_free(priv->source);
     g_free(priv);
 }
 
-static int
-vehicle_webos_position_attr_get(struct vehicle_priv *priv,
-                                enum attr_type type, struct attr *attr) {
+static int vehicle_webos_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_position_height:
         dbg(lvl_info,"Altitude: %f", priv->altitude);
@@ -310,8 +303,7 @@ vehicle_webos_position_attr_get(struct vehicle_priv *priv,
     return 1;
 }
 
-static int
-vehicle_webos_set_attr_do(struct vehicle_priv *priv, struct attr *attr, int init) {
+static int vehicle_webos_set_attr_do(struct vehicle_priv *priv, struct attr *attr, int init) {
     switch (attr->type) {
     case attr_source:
         if (strncmp(vehicle_webos_prefix,attr->u.str,strlen(vehicle_webos_prefix))) {
@@ -338,8 +330,7 @@ vehicle_webos_set_attr_do(struct vehicle_priv *priv, struct attr *attr, int init
     }
 }
 
-static int
-vehicle_webos_set_attr(struct vehicle_priv *priv, struct attr *attr) {
+static int vehicle_webos_set_attr(struct vehicle_priv *priv, struct attr *attr) {
     return vehicle_webos_set_attr_do(priv, attr, 0);
 }
 
@@ -349,10 +340,9 @@ struct vehicle_methods vehicle_webos_methods = {
     vehicle_webos_set_attr,
 };
 
-static struct vehicle_priv *
-vehicle_webos_new(struct vehicle_methods
-                  *meth, struct callback_list
-                  *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_webos_new(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *priv;
 
     priv = g_new0(struct vehicle_priv, 1);
@@ -372,8 +362,7 @@ vehicle_webos_new(struct vehicle_methods
     return priv;
 }
 
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("webos", vehicle_webos_new);
 }

--- a/navit/vehicle/wince/vehicle_wince.c
+++ b/navit/vehicle/wince/vehicle_wince.c
@@ -314,8 +314,7 @@ static DWORD WINAPI wince_reader_thread (LPVOID lParam) {
     return TRUE;
 }
 
-static int
-vehicle_wince_available_ports(void) {
+static int vehicle_wince_available_ports(void) {
     HKEY hkResult;
     HKEY hkSubResult;
     wchar_t keyname[20];
@@ -353,8 +352,7 @@ vehicle_wince_available_ports(void) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_wince_fix_timeout_cb(struct vehicle_priv *priv) {
+static void vehicle_wince_fix_timeout_cb(struct vehicle_priv *priv) {
     priv->valid = attr_position_valid_invalid;
     priv->ev_fix_timeout = NULL;
     callback_list_call_attr_0(priv->cbl, attr_position_coord_geo);
@@ -366,8 +364,7 @@ vehicle_wince_fix_timeout_cb(struct vehicle_priv *priv) {
 *
 * @param priv Pointer on the private data of the plugin
 */
-static void
-vehicle_wince_restart_fix_timeout(struct vehicle_priv *priv) {
+static void vehicle_wince_restart_fix_timeout(struct vehicle_priv *priv) {
     if (priv->ev_fix_timeout != NULL)
         event_remove_timeout(priv->ev_fix_timeout);
     priv->ev_fix_timeout = event_add_timeout(10000, 0, priv->cb_fix_timeout);
@@ -375,8 +372,7 @@ vehicle_wince_restart_fix_timeout(struct vehicle_priv *priv) {
 
 
 
-static int
-vehicle_wince_open(struct vehicle_priv *priv) {
+static int vehicle_wince_open(struct vehicle_priv *priv) {
     char* raw_setting_str;
     char* strport;
     char* strsettings;
@@ -407,13 +403,11 @@ vehicle_wince_open(struct vehicle_priv *priv) {
     return 1;
 }
 
-static void
-vehicle_wince_close(struct vehicle_priv *priv) {
+static void vehicle_wince_close(struct vehicle_priv *priv) {
     dbg(lvl_debug,"enter");
 }
 
-static int
-vehicle_wince_parse(struct vehicle_priv *priv, char *buffer) {
+static int vehicle_wince_parse(struct vehicle_priv *priv, char *buffer) {
     char *nmea_data_buf, *p, *item[32];
     double lat, lng;
     int i, j, bcsum;
@@ -669,8 +663,7 @@ vehicle_wince_parse(struct vehicle_priv *priv, char *buffer) {
     return ret;
 }
 
-static void
-vehicle_wince_io(struct vehicle_priv *priv) {
+static void vehicle_wince_io(struct vehicle_priv *priv) {
     int size, rc = 0;
     char *str, *tok;
 
@@ -722,8 +715,7 @@ vehicle_wince_io(struct vehicle_priv *priv) {
         callback_list_call_attr_0(priv->cbl, attr_position_coord_geo);
 }
 
-static void
-vehicle_wince_enable_watch(struct vehicle_priv *priv) {
+static void vehicle_wince_enable_watch(struct vehicle_priv *priv) {
     dbg(lvl_debug, "enter");
     vehicle_wince_disable_watch(priv);
     priv->is_running = 1;
@@ -740,8 +732,7 @@ vehicle_wince_enable_watch(struct vehicle_priv *priv) {
     }
 }
 
-static void
-vehicle_wince_disable_watch(struct vehicle_priv *priv) {
+static void vehicle_wince_disable_watch(struct vehicle_priv *priv) {
     int wait = 5000;
 
     dbg(lvl_debug, "enter");
@@ -762,8 +753,7 @@ vehicle_wince_disable_watch(struct vehicle_priv *priv) {
  *
  * @param priv vehicle_priv structure for the vehicle
  */
-static void
-vehicle_wince_destroy(struct vehicle_priv *priv) {
+static void vehicle_wince_destroy(struct vehicle_priv *priv) {
     vehicle_wince_disable_watch(priv);
     vehicle_wince_close(priv);
     if (priv->BthSetMode) {
@@ -788,9 +778,8 @@ vehicle_wince_destroy(struct vehicle_priv *priv) {
  *
  * @return True for success, false for failure
  */
-static int
-vehicle_wince_position_attr_get(struct vehicle_priv *priv,
-                                enum attr_type type, struct attr *attr) {
+static int vehicle_wince_position_attr_get(struct vehicle_priv *priv,
+        enum attr_type type, struct attr *attr) {
     switch (type) {
     case attr_position_fix_type:
         attr->u.num = priv->status;
@@ -856,8 +845,7 @@ vehicle_wince_position_attr_get(struct vehicle_priv *priv,
     return 1;
 }
 
-static int
-vehicle_wince_sat_attr_get(void *priv_data, enum attr_type type, struct attr *attr) {
+static int vehicle_wince_sat_attr_get(void *priv_data, enum attr_type type, struct attr *attr) {
     struct vehicle_priv *priv=priv_data;
     struct gps_sat *sat;
 
@@ -912,10 +900,9 @@ struct vehicle_methods vehicle_wince_methods = {
  *
  * @return vehicle_priv
  */
-static struct vehicle_priv *
-vehicle_wince_new(struct vehicle_methods
-                  *meth, struct callback_list
-                  *cbl, struct attr **attrs) {
+static struct vehicle_priv *vehicle_wince_new(struct vehicle_methods
+        *meth, struct callback_list
+        *cbl, struct attr **attrs) {
     struct vehicle_priv *ret;
     struct attr *source;
     struct attr *time;
@@ -990,8 +977,7 @@ vehicle_wince_new(struct vehicle_methods
 /**
  * @brief Registers the vehicle_wince plugin
  */
-void
-plugin_init(void) {
+void plugin_init(void) {
     dbg(lvl_debug, "enter");
     plugin_register_category_vehicle("wince", vehicle_wince_new);
     plugin_register_category_vehicle("file", vehicle_wince_new);

--- a/navit/vehicleprofile.c
+++ b/navit/vehicleprofile.c
@@ -27,8 +27,7 @@
 #include "vehicleprofile.h"
 #include "callback.h"
 
-static void
-vehicleprofile_set_attr_do(struct vehicleprofile *this_, struct attr *attr) {
+static void vehicleprofile_set_attr_do(struct vehicleprofile *this_, struct attr *attr) {
     dbg(lvl_debug,"%s:%ld", attr_to_name(attr->type), attr->u.num);
     switch (attr->type) {
     case attr_flags:
@@ -95,22 +94,19 @@ vehicleprofile_set_attr_do(struct vehicleprofile *this_, struct attr *attr) {
     }
 }
 
-static void
-vehicleprofile_free_hash_item(gpointer key, gpointer value, gpointer user_data) {
+static void vehicleprofile_free_hash_item(gpointer key, gpointer value, gpointer user_data) {
     struct navit_object *obj=value;
     obj->func->unref(obj);
 }
 
-static void
-vehicleprofile_free_hash(struct vehicleprofile *this_) {
+static void vehicleprofile_free_hash(struct vehicleprofile *this_) {
     if (this_->roadprofile_hash) {
         g_hash_table_foreach(this_->roadprofile_hash, vehicleprofile_free_hash_item, NULL);
         g_hash_table_destroy(this_->roadprofile_hash);
     }
 }
 
-static void
-vehicleprofile_clear(struct vehicleprofile *this_) {
+static void vehicleprofile_clear(struct vehicleprofile *this_) {
     this_->mode=0;
     this_->flags_forward_mask=0;
     this_->flags_reverse_mask=0;
@@ -133,8 +129,7 @@ vehicleprofile_clear(struct vehicleprofile *this_) {
     this_->roadprofile_hash=g_hash_table_new(NULL, NULL);
 }
 
-static void
-vehicleprofile_apply_roadprofile(struct vehicleprofile *this_, struct navit_object *rp, int is_option) {
+static void vehicleprofile_apply_roadprofile(struct vehicleprofile *this_, struct navit_object *rp, int is_option) {
     struct attr item_types_attr;
     if (rp->func->get_attr(rp, attr_item_types, &item_types_attr, NULL)) {
         enum item_type *types=item_types_attr.u.item_types;
@@ -168,8 +163,7 @@ vehicleprofile_apply_roadprofile(struct vehicleprofile *this_, struct navit_obje
     }
 }
 
-static void
-vehicleprofile_apply_attrs(struct vehicleprofile *this_, struct navit_object *obj, int is_option) {
+static void vehicleprofile_apply_attrs(struct vehicleprofile *this_, struct navit_object *obj, int is_option) {
     struct attr attr;
     struct attr_iter *iter=obj->func->iter_new(NULL);
     while (obj->func->get_attr(obj, attr_any, &attr, iter)) {
@@ -182,14 +176,12 @@ vehicleprofile_apply_attrs(struct vehicleprofile *this_, struct navit_object *ob
     obj->func->iter_destroy(iter);
 }
 
-static void
-vehicleprofile_debug_roadprofile(gpointer key, gpointer value, gpointer user_data) {
+static void vehicleprofile_debug_roadprofile(gpointer key, gpointer value, gpointer user_data) {
     struct roadprofile *rp=value;
     dbg(lvl_debug,"type %s avg %d weight %d max %d",item_to_name((int)(long)key),rp->speed,rp->route_weight,rp->maxspeed);
 }
 
-static void
-vehicleprofile_update(struct vehicleprofile *this_) {
+static void vehicleprofile_update(struct vehicleprofile *this_) {
     struct attr_iter *iter=vehicleprofile_attr_iter_new();
     struct attr profile_option;
     dbg(lvl_debug,"enter");
@@ -239,26 +231,23 @@ vehicleprofile_attr_iter_new(void) {
     return (struct attr_iter *)g_new0(void *,1);
 }
 
-void
-vehicleprofile_attr_iter_destroy(struct attr_iter *iter) {
+void vehicleprofile_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
 
-int
-vehicleprofile_get_attr(struct vehicleprofile *this_, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int vehicleprofile_get_attr(struct vehicleprofile *this_, enum attr_type type, struct attr *attr,
+                            struct attr_iter *iter) {
     return attr_generic_get_attr(this_->attrs, NULL, type, attr, iter);
 }
 
-int
-vehicleprofile_set_attr(struct vehicleprofile *this_, struct attr *attr) {
+int vehicleprofile_set_attr(struct vehicleprofile *this_, struct attr *attr) {
     vehicleprofile_set_attr_do(this_, attr);
     this_->attrs=attr_generic_set_attr(this_->attrs, attr);
     return 1;
 }
 
-int
-vehicleprofile_add_attr(struct vehicleprofile *this_, struct attr *attr) {
+int vehicleprofile_add_attr(struct vehicleprofile *this_, struct attr *attr) {
     this_->attrs=attr_generic_add_attr(this_->attrs, attr);
     switch (attr->type) {
     case attr_roadprofile:
@@ -273,8 +262,7 @@ vehicleprofile_add_attr(struct vehicleprofile *this_, struct attr *attr) {
     return 1;
 }
 
-int
-vehicleprofile_remove_attr(struct vehicleprofile *this_, struct attr *attr) {
+int vehicleprofile_remove_attr(struct vehicleprofile *this_, struct attr *attr) {
     this_->attrs=attr_generic_remove_attr(this_->attrs, attr);
     return 1;
 }
@@ -284,13 +272,11 @@ vehicleprofile_get_roadprofile(struct vehicleprofile *this_, enum item_type type
     return g_hash_table_lookup(this_->roadprofile_hash, (void *)(long)type);
 }
 
-char *
-vehicleprofile_get_name(struct vehicleprofile *this_) {
+char *vehicleprofile_get_name(struct vehicleprofile *this_) {
     return this_->name;
 }
 
-static void
-vehicleprofile_init(struct vehicleprofile *this_) {
+static void vehicleprofile_init(struct vehicleprofile *this_) {
     vehicleprofile_update(this_);
 }
 

--- a/navit/xmlconfig.c
+++ b/navit/xmlconfig.c
@@ -152,8 +152,7 @@ static const char * find_attribute(struct xmlstate *state, const char *attribute
     return NULL;
 }
 
-static int
-find_boolean(struct xmlstate *state, const char *attribute, int deflt, int required) {
+static int find_boolean(struct xmlstate *state, const char *attribute, int deflt, int required) {
     const char *value;
 
     value=find_attribute(state, attribute, required);
@@ -170,16 +169,14 @@ find_boolean(struct xmlstate *state, const char *attribute, int deflt, int requi
  * * @param val the string value to convert
  * * @returns int value of converted string
  * */
-static int
-convert_number(const char *val) {
+static int convert_number(const char *val) {
     if (val)
         return g_ascii_strtoull(val,NULL,0);
     else
         return 0;
 }
 
-static int
-xmlconfig_announce(struct xmlstate *state) {
+static int xmlconfig_announce(struct xmlstate *state) {
     const char *type,*value;
     char key[32];
     int level[3];
@@ -564,13 +561,12 @@ static void initStatic(void) {
  * * @returns nothing
  * */
 
-static void
-start_element(xml_context *context,
-              const gchar         *element_name,
-              const gchar        **attribute_names,
-              const gchar        **attribute_values,
-              gpointer             user_data,
-              xmlerror             **error) {
+static void start_element(xml_context *context,
+                          const gchar         *element_name,
+                          const gchar        **attribute_names,
+                          const gchar        **attribute_values,
+                          gpointer             user_data,
+                          xmlerror             **error) {
     struct xmlstate *new=NULL, **parent = user_data;
     struct element_func *e=elements,*func=NULL;
     struct attr_fixme *attr_fixme=attr_fixmes;
@@ -682,11 +678,10 @@ start_element(xml_context *context,
 
 
 /* Called for close tags </foo> */
-static void
-end_element (xml_context *context,
-             const gchar         *element_name,
-             gpointer             user_data,
-             xmlerror             **error) {
+static void end_element (xml_context *context,
+                         const gchar         *element_name,
+                         gpointer             user_data,
+                         xmlerror             **error) {
     struct xmlstate *curr, **state = user_data;
 
     if (!strcmp(element_name,"xml"))
@@ -703,9 +698,8 @@ end_element (xml_context *context,
 
 static gboolean parse_file(struct xmldocument *document, xmlerror **error);
 
-static void
-xinclude(xml_context *context, const gchar **attribute_names, const gchar **attribute_values,
-         struct xmldocument *doc_old, xmlerror **error) {
+static void xinclude(xml_context *context, const gchar **attribute_names, const gchar **attribute_values,
+                     struct xmldocument *doc_old, xmlerror **error) {
     struct xmldocument doc_new;
     struct file_wordexp *we;
     int i,count;
@@ -773,8 +767,7 @@ xinclude(xml_context *context, const gchar **attribute_names, const gchar **attr
     }
 
 }
-static int
-strncmp_len(const char *s1, int s1len, const char *s2) {
+static int strncmp_len(const char *s1, int s1len, const char *s2) {
     int ret;
     ret=strncmp(s1, s2, s1len);
     if (ret)
@@ -782,8 +775,7 @@ strncmp_len(const char *s1, int s1len, const char *s2) {
     return strlen(s2)-s1len;
 }
 
-static int
-xpointer_value(const char *test, int len, struct xistate *elem, const char **out, int out_len) {
+static int xpointer_value(const char *test, int len, struct xistate *elem, const char **out, int out_len) {
     int i,ret=0;
     if (len <= 0 || out_len <= 0) {
         return 0;
@@ -806,8 +798,7 @@ xpointer_value(const char *test, int len, struct xistate *elem, const char **out
     return 0;
 }
 
-static int
-xpointer_test(const char *test, int len, struct xistate *elem) {
+static int xpointer_test(const char *test, int len, struct xistate *elem) {
     int eq,i,count,vlen,cond_req=1,cond=0;
     char c;
     const char *tmp[16];
@@ -834,8 +825,7 @@ xpointer_test(const char *test, int len, struct xistate *elem) {
     return 0;
 }
 
-static int
-xpointer_element_match(const char *xpointer, int len, struct xistate *elem) {
+static int xpointer_element_match(const char *xpointer, int len, struct xistate *elem) {
     int start,tlen;
     start=strcspn(xpointer, "[");
     if (start > len)
@@ -857,8 +847,7 @@ xpointer_element_match(const char *xpointer, int len, struct xistate *elem) {
     }
 }
 
-static int
-xpointer_xpointer_match(const char *xpointer, int len, struct xistate *first) {
+static int xpointer_xpointer_match(const char *xpointer, int len, struct xistate *first) {
     const char *c;
     int s;
     dbg(lvl_info,"%s", xpointer);
@@ -881,8 +870,7 @@ xpointer_xpointer_match(const char *xpointer, int len, struct xistate *first) {
     return 1;
 }
 
-static int
-xpointer_match(const char *xpointer, struct xistate *first) {
+static int xpointer_match(const char *xpointer, struct xistate *first) {
     char *prefix="xpointer(";
     int len;
     if (! xpointer)
@@ -896,13 +884,12 @@ xpointer_match(const char *xpointer, struct xistate *first) {
 
 }
 
-static void
-xi_start_element(xml_context *context,
-                 const gchar         *element_name,
-                 const gchar        **attribute_names,
-                 const gchar        **attribute_values,
-                 gpointer             user_data,
-                 xmlerror             **error) {
+static void xi_start_element(xml_context *context,
+                             const gchar         *element_name,
+                             const gchar        **attribute_names,
+                             const gchar        **attribute_values,
+                             gpointer             user_data,
+                             xmlerror             **error) {
     struct xmldocument *doc=user_data;
     struct xistate *xistate;
     int i,count=0;
@@ -944,11 +931,10 @@ xi_start_element(xml_context *context,
  * * @returns nothing
  * */
 
-static void
-xi_end_element (xml_context *context,
-                const gchar         *element_name,
-                gpointer             user_data,
-                xmlerror             **error) {
+static void xi_end_element (xml_context *context,
+                            const gchar         *element_name,
+                            gpointer             user_data,
+                            xmlerror             **error) {
     struct xmldocument *doc=user_data;
     struct xistate *xistate=doc->last;
     int i=0;
@@ -976,12 +962,11 @@ xi_end_element (xml_context *context,
 
 /* Called for character data */
 /* text is not nul-terminated */
-static void
-xi_text (xml_context *context,
-         const gchar            *text,
-         gsize                   text_len,
-         gpointer                user_data,
-         xmlerror               **error) {
+static void xi_text (xml_context *context,
+                     const gchar            *text,
+                     gsize                   text_len,
+                     gpointer                user_data,
+                     xmlerror               **error) {
     struct xmldocument *doc=user_data;
     int i;
     if (doc->active) {
@@ -1005,11 +990,11 @@ xi_text (xml_context *context,
 }
 
 #if USE_EZXML
-static void
-parse_node_text(ezxml_t node, void *data, void (*start)(void *, const char *, const char **, const char **, void *,
-                void *),
-                void (*end)(void *, const char *, void *, void *),
-                void (*text)(void *, const char *, int, void *, void *)) {
+static void parse_node_text(ezxml_t node, void *data, void (*start)(void *, const char *, const char **, const char **,
+                            void *,
+                            void *),
+                            void (*end)(void *, const char *, void *, void *),
+                            void (*text)(void *, const char *, int, void *, void *)) {
     while (node) {
         if (start)
             start(NULL, node->name, (const char **)node->attr, (const char **)(node->attr+1), data, NULL);
@@ -1024,11 +1009,10 @@ parse_node_text(ezxml_t node, void *data, void (*start)(void *, const char *, co
 }
 #endif
 
-void
-xml_parse_text(const char *document, void *data,
-               void (*start)(xml_context *, const char *, const char **, const char **, void *, GError **),
-               void (*end)(xml_context *, const char *, void *, GError **),
-               void (*text)(xml_context *, const char *, gsize, void *, GError **)) {
+void xml_parse_text(const char *document, void *data,
+                    void (*start)(xml_context *, const char *, const char **, const char **, void *, GError **),
+                    void (*end)(xml_context *, const char *, void *, GError **),
+                    void (*text)(xml_context *, const char *, gsize, void *, GError **)) {
 #if !USE_EZXML
     GMarkupParser parser = { start, end, text, NULL, NULL};
     xml_context *context;
@@ -1074,8 +1058,7 @@ static const GMarkupParser parser = {
  * * @returns boolean TRUE or FALSE
  * */
 
-static gboolean
-parse_file(struct xmldocument *document, xmlerror **error) {
+static gboolean parse_file(struct xmldocument *document, xmlerror **error) {
     xml_context *context;
     gchar *contents, *message;
     gsize len;
@@ -1132,8 +1115,7 @@ parse_file(struct xmldocument *document, xmlerror **error) {
     return result;
 }
 #else
-static void
-parse_node(struct xmldocument *document, ezxml_t node) {
+static void parse_node(struct xmldocument *document, ezxml_t node) {
     while (node) {
         xi_start_element(NULL,node->name, node->attr, node->attr+1, document, NULL);
         if (node->txt)
@@ -1145,8 +1127,7 @@ parse_node(struct xmldocument *document, ezxml_t node) {
     }
 }
 
-static gboolean
-parse_file(struct xmldocument *document, xmlerror **error) {
+static gboolean parse_file(struct xmldocument *document, xmlerror **error) {
     FILE *f;
     ezxml_t root;
 
@@ -1199,8 +1180,7 @@ gboolean config_load(const char *filename, xmlerror **error) {
     return result;
 }
 
-int
-navit_object_set_methods(void *in, int in_size, void *out, int out_size) {
+int navit_object_set_methods(void *in, int in_size, void *out, int out_size) {
     int ret,size=out_size;
     if (out_size > in_size) {
         ret=-1;
@@ -1230,8 +1210,7 @@ navit_object_ref(struct navit_object *obj) {
     return obj;
 }
 
-void
-navit_object_unref(struct navit_object *obj) {
+void navit_object_unref(struct navit_object *obj) {
     if (obj) {
         obj->refcount--;
         dbg(lvl_debug,"refcount %s %p %d",attr_to_name(obj->func->type),obj,obj->refcount);
@@ -1249,8 +1228,7 @@ navit_object_attr_iter_new(void) {
     return g_new0(struct attr_iter, 1);
 }
 
-void
-navit_object_attr_iter_destroy(struct attr_iter *iter) {
+void navit_object_attr_iter_destroy(struct attr_iter *iter) {
     g_free(iter);
 }
 
@@ -1279,27 +1257,23 @@ navit_object_attr_iter_destroy(struct attr_iter *iter) {
  *
  * @return True if a matching attribute was found, false if not.
  */
-int
-navit_object_get_attr(struct navit_object *obj, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
+int navit_object_get_attr(struct navit_object *obj, enum attr_type type, struct attr *attr, struct attr_iter *iter) {
     return attr_generic_get_attr(obj->attrs, NULL, type, attr, iter);
 }
 
-void
-navit_object_callbacks(struct navit_object *obj, struct attr *attr) {
+void navit_object_callbacks(struct navit_object *obj, struct attr *attr) {
     if (obj->attrs && obj->attrs[0] && obj->attrs[0]->type == attr_callback_list)
         callback_list_call_attr_2(obj->attrs[0]->u.callback_list, attr->type, attr->u.data, 0);
 }
 
-int
-navit_object_set_attr(struct navit_object *obj, struct attr *attr) {
+int navit_object_set_attr(struct navit_object *obj, struct attr *attr) {
     dbg(lvl_debug, "enter, obj=%p, attr=%p (%s)", obj, attr, attr_to_name(attr->type));
     obj->attrs=attr_generic_set_attr(obj->attrs, attr);
     navit_object_callbacks(obj, attr);
     return 1;
 }
 
-int
-navit_object_add_attr(struct navit_object *obj, struct attr *attr) {
+int navit_object_add_attr(struct navit_object *obj, struct attr *attr) {
     dbg(lvl_debug, "enter, obj=%p, attr=%p (%s)", obj, attr, attr_to_name(attr->type));
     if (attr->type == attr_callback) {
         struct callback_list *cbl;
@@ -1321,8 +1295,7 @@ navit_object_add_attr(struct navit_object *obj, struct attr *attr) {
     return 1;
 }
 
-int
-navit_object_remove_attr(struct navit_object *obj, struct attr *attr) {
+int navit_object_remove_attr(struct navit_object *obj, struct attr *attr) {
     if (attr->type == attr_callback) {
         if (obj->attrs && obj->attrs[0] && obj->attrs[0]->type == attr_callback_list) {
             callback_list_remove(obj->attrs[0]->u.callback_list, attr->u.callback);
@@ -1336,8 +1309,7 @@ navit_object_remove_attr(struct navit_object *obj, struct attr *attr) {
     return 1;
 }
 
-void
-navit_object_destroy(struct navit_object *obj) {
+void navit_object_destroy(struct navit_object *obj) {
     attr_list_free(obj->attrs);
     g_free(obj);
 }


### PR DESCRIPTION
It seems that there was a miss in #569: the `-xf` and `-xh` options of astyle have been forgotten, so the attachement of the return types was not done.
This PR corrects this for C and Cpp files.
Command-line used:
```
find . -type f   \
  \( -not -path './navit/support/*' -a -not -path './navit/fib-1.1/*' \)  \
  -a \( -iname '*.c' -o -iname '*.cpp' \) \
  -exec  astyle --indent=spaces=4 --style=attach -n --max-code-length=120 -xf -xh {} \;
```