### PR TITLE
add:ci:Add sanity check script on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,16 @@ defaults: &defaults
   docker:
     - image: ubuntu:14.04
 jobs:
+  sanity_check:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Setup requirements
+          command: apt-get update && apt-get -y install git astyle sed
+      - run:
+          name: run sanity check script
+          command: bash scripts/ci_sanity_checks.sh
   build_linux:
     <<: *defaults
     steps:
@@ -226,12 +236,25 @@ workflows:
   version: 2
   build_all:
     jobs:
-      - build_linux
-      - build_android
-      - build_win32
-      - build_wince
-      - build_tomtom_minimal
-      - build_tomtom_plugin
+      - sanity_check
+      - build_linux:
+          requires:
+            - sanity_check
+      - build_android:
+          requires:
+            - sanity_check
+      - build_win32:
+          requires:
+            - sanity_check
+      - build_wince:
+          requires:
+            - sanity_check
+      - build_tomtom_minimal:
+          requires:
+            - sanity_check
+      - build_tomtom_plugin:
+          requires:
+            - sanity_check
       - run_doxygen:
           requires:
             - build_linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Setup requirements
-          command: apt-get update && apt-get -y install git astyle sed
+          command: bash scripts/setup_common_requirements.sh
       - run:
           name: run sanity check script
           command: bash scripts/ci_sanity_checks.sh

--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -x
+set -eu
+
+# #############################################################################
+# This script runs on circle CI to verify that the code of the PR has been
+# sanitized before push.
+# #############################################################################
+
+# List the files that are different from the trunk
+from=$(git rev-parse refs/remotes/origin/trunk)
+to=$(git rev-parse HEAD)
+interval=${from}..${to}
+[[ "${from}" == "${to}" ]] && interval=${to}
+
+for f in $(git show -m --pretty="format:" --name-only ${interval}); do
+  if [[ -e "${f}" ]]; then
+    echo $f
+    if [[ "$f" != "*.bat" ]]; then
+      # Removes trailing spaces
+      [[ "$(file -bi """${f}""")" =~ ^text ]] && sed 's/\s*$//' -i "${f}"
+    fi
+    # Formats any *.c and *.cpp files
+    if [[ "$f" == "*.c" ]] || [[ "$f" == "*.cpp" ]]; then
+      astyle --indent=spaces=4 --style=attach -n --max-code-length=120 -xf -xh "${f}"
+    fi
+  fi
+done
+
+# Check if any file has been modified. If yes, that means the best practices
+# have not been followed, so we fail the job.
+git diff --exit-code
+code=$?
+if [[ $code -ne 0 ]]; then
+  echo "You may need to do some cleanup in the files you commited, see the git diff output above."
+fi
+git checkout -- .
+exit $code

--- a/scripts/setup_common_requirements.sh
+++ b/scripts/setup_common_requirements.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-apt-get update && apt-get install -y wget unzip cmake build-essential gettext librsvg2-bin util-linux git ssh
+apt-get update && apt-get install -y wget unzip cmake build-essential gettext librsvg2-bin util-linux git ssh sed astyle


### PR DESCRIPTION
The idea of this is to add a sanity check before even the builds start.
This just remove the trailing spaces and runs astyle with what we did in #569 and #605.
It could be, for example, extended with the nice work @jandegr is doing on checkstyle with Java.