### PR TITLE
Add underscore to internal gui keyboard.

### DIFF
--- a/navit/gui/internal/gui_internal_keyboard.c
+++ b/navit/gui/internal/gui_internal_keyboard.c
@@ -246,7 +246,7 @@ gui_internal_keyboard_do(struct gui_priv *this, struct widget *wkbdb, int mode) 
         KEY("=");
         KEY("?");
         KEY(":");
-        SPACER();
+        KEY("_");
 
 
 


### PR DESCRIPTION
This patch adds a underscore key ('_') to the internal GUI keyboard. The underscore is necessary to search for POI types, for example poi_shop_bicycle.
Thank you for merging.