### PR TITLE
update:ci:Refactor the sanity check for better output and add xmllint check

### DIFF
--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -1,11 +1,27 @@
 #!/usr/bin/env bash
-set -x
-set -eu
+set -u
 
-# #############################################################################
+# #####################################################################################################################
 # This script runs on circle CI to verify that the code of the PR has been
 # sanitized before push.
-# #############################################################################
+#
+# WARNING: make sure you commit ALL your changes before running it locally if you ever do it because it will run a git
+# checkout -- which will reset your changes on all files...
+# #####################################################################################################################
+
+return_code=0
+
+# Check if any file has been modified. If yes, that means the best practices
+# have not been followed, so we will fail the job later but print a message here.
+check_diff(){
+  git diff --exit-code
+  code=$?
+  if [[ $code -ne 0 ]]; then
+    echo "[ERROR] You may need to do some cleanup in the files you commited, see the git diff output above."
+  fi
+  git checkout -- .
+  return_code=$(($return_code + $code))
+}
 
 # List the files that are different from the trunk
 from=$(git rev-parse refs/remotes/origin/trunk)
@@ -13,26 +29,34 @@ to=$(git rev-parse HEAD)
 interval=${from}..${to}
 [[ "${from}" == "${to}" ]] && interval=${to}
 
-for f in $(git show -m --pretty="format:" --name-only ${interval}); do
+for f in $(git show -m --pretty="format:" --name-only ${interval} | sort | uniq); do
   if [[ -e "${f}" ]]; then
-    echo $f
+
+    # Checks for trailing spaces
     if [[ "$f" != "*.bat" ]]; then
-      # Removes trailing spaces
-      [[ "$(file -bi """${f}""")" =~ ^text ]] && sed 's/\s*$//' -i "${f}"
+      echo "[INFO] Checking for trailing spaces on ${f}..."
+      if [[ "$(file -bi """${f}""")" =~ ^text ]]; then
+        sed 's/\s*$//' -i "${f}"
+        check_diff
+      fi
     fi
+
     # Formats any *.c and *.cpp files
     if [[ "$f" == "*.c" ]] || [[ "$f" == "*.cpp" ]]; then
+      echo "[INFO] Checking for indentation and style compliance on ${f}..."
       astyle --indent=spaces=4 --style=attach -n --max-code-length=120 -xf -xh "${f}"
+      check_diff
+    fi
+
+    if [[ "${f}" == "navit/navit_shipped.xml" ]]; then
+      echo "[INFO] Checking for compliance with the DTD using xmllint on ${f}..."
+      xmllint --noout --dtdvalid navit/navit.dtd "$f"
+      rc=$?
+      if [[ $rc -ne 0 ]]; then
+        echo "[ERROR] Your ${f} file doesn't validate against the navit/navit.dtd using xmllint"
+      fi
     fi
   fi
 done
 
-# Check if any file has been modified. If yes, that means the best practices
-# have not been followed, so we fail the job.
-git diff --exit-code
-code=$?
-if [[ $code -ne 0 ]]; then
-  echo "You may need to do some cleanup in the files you commited, see the git diff output above."
-fi
-git checkout -- .
-exit $code
+exit $return_code

--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -33,7 +33,7 @@ for f in $(git diff --name-only ${interval} | sort -u); do
   if [[ -e "${f}" ]]; then
 
     # Checks for trailing spaces
-    if [[ "$f" != "*.bat" ]]; then
+    if [[ "${f: -4}" != ".bat" ]]; then
       echo "[INFO] Checking for trailing spaces on ${f}..."
       if [[ "$(file -bi """${f}""")" =~ ^text ]]; then
         sed 's/\s*$//' -i "${f}"
@@ -42,7 +42,7 @@ for f in $(git diff --name-only ${interval} | sort -u); do
     fi
 
     # Formats any *.c and *.cpp files
-    if [[ "$f" == "*.c" ]] || [[ "$f" == "*.cpp" ]]; then
+    if [[ "${f: -2}" == ".c" ]] || [[ "${f: -4}" == ".cpp" ]]; then
       echo "[INFO] Checking for indentation and style compliance on ${f}..."
       astyle --indent=spaces=4 --style=attach -n --max-code-length=120 -xf -xh "${f}"
       check_diff

--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -29,7 +29,7 @@ to=$(git rev-parse HEAD)
 interval=${from}..${to}
 [[ "${from}" == "${to}" ]] && interval=${to}
 
-for f in $(git show -m --pretty="format:" --name-only ${interval} | sort | uniq); do
+for f in $(git show -m --pretty="format:" --name-only ${interval} | sort -u); do
   if [[ -e "${f}" ]]; then
 
     # Checks for trailing spaces

--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -29,7 +29,7 @@ to=$(git rev-parse HEAD)
 interval=${from}..${to}
 [[ "${from}" == "${to}" ]] && interval=${to}
 
-for f in $(git show -m --pretty="format:" --name-only ${interval} | sort -u); do
+for f in $(git diff --name-only ${interval} | sort -u); do
   if [[ -e "${f}" ]]; then
 
     # Checks for trailing spaces


### PR DESCRIPTION
This PR:
* Adds a check for the xmllint if modified in the PR as a follow-up from #583
* removes the `set -x` so that it has a more understandable output
* makes sure that the diff is done for each check and each file, not just one big diff that would make it less understandable
* only run the check on each file once (using `| sort | uniq`)
* show all the errors before exiting (so I had to remove `set -e`)
* add a warning in case people try to run it locally