### PR TITLE
update:style:optimize the usage of cat in shell scripts

### DIFF
--- a/contrib/sailfish/build_on_sailfish_sdk.sh
+++ b/contrib/sailfish/build_on_sailfish_sdk.sh
@@ -4,9 +4,9 @@
 if [ -z ${VERSION_ID+x} ]; then echo "VERSION_ID not set. Forgot to export VERSION_ID?"; exit 1; fi
 
 #arm devices
-sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-install -R zypper in `cat navit-sailfish.spec | grep "^BuildRequires: " | sed -e "s/BuildRequires: //"`
+sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-install -R zypper in `grep navit-sailfish.spec "^BuildRequires: " | sed -e "s/BuildRequires: //"`
 sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 #intel devices
-sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-install -R zypper in `cat navit-sailfish.spec | grep "^BuildRequires: " | sed -e "s/BuildRequires: //"`
+sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-install -R zypper in `grep navit-sailfish.spec "^BuildRequires: " | sed -e "s/BuildRequires: //"`
 sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-build rpmbuild --define "_topdir /home/src1/rpmbuild" --define "navit_source `pwd`/../.." -bb navit-sailfish.spec
 

--- a/navit/android/change_xslt.sh
+++ b/navit/android/change_xslt.sh
@@ -24,35 +24,30 @@ REG4='{round(@1@-number($LAYOUT_001_ORDER_DELTA_1))}'
 
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;do
 	a=`echo "$REG0"|sed -e "s#@1@#$i#"`
-	cat "$temp"|sed -e "s#order=\"0-${i}\"#order=\"${a}\"#g" > "$out"
-	cp -p "$out" "$temp"
+	sed -e "s#order=\"0-${i}\"#order=\"${a}\"#g" -i "$temp"
 done
 
 # dont change order="0-" values !!
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;do
 	a=`echo "$REG1"|sed -e "s#@1@#$i#"`
-	cat "$temp"|sed -e "s#order=\"${i}-\"#order=\"${a}\"#g" > "$out"
-	cp -p "$out" "$temp"
+	sed -e "s#order=\"${i}-\"#order=\"${a}\"#g" -i "$temp"
 done
 
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;do
 	a=`echo "$REG2"|sed -e "s#@1@#$i#"`
-	cat "$temp"|sed -e "s#order=\"-${i}\"#order=\"${a}\"#g" > "$out"
-	cp -p "$out" "$temp"
+	sed -e "s#order=\"-${i}\"#order=\"${a}\"#g" -i "$temp"
 done
 
 
 for j in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;do
 	for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;do
 		a=`echo "$REG3"|sed -e "s#@1@#$i#"|sed -e "s#@2@#$j#"`
-		cat "$temp"|sed -e "s#order=\"${i}-${j}\"#order=\"${a}\"#g" > "$out"
-		cp -p "$out" "$temp"
+		sed -e "s#order=\"${i}-${j}\"#order=\"${a}\"#g" -i "$temp"
 	done
 done
 
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;do
 	a=`echo "$REG4"|sed -e "s#@1@#$i#"`
-	cat "$temp"|sed -e "s#order=\"${i}\"#order=\"${a}\"#g" > "$out"
-	cp -p "$out" "$temp"
+	sed -e "s#order=\"${i}\"#order=\"${a}\"#g" -i "$temp"
 done
-
+cp -p "$temp" "$out"


### PR DESCRIPTION
This PR removes the warnings in codefactor about "Useless cat usage": https://www.codefactor.io/repository/github/navit-gps/navit/issues?category=Performance&groupId=1692
Note that it also remove unnecessary copy and redirect of temporary file by using the "in-place" capabilities of sed.