### PR TITLE
update:scripts:avoid iterating over ls output by using glob

### DIFF
--- a/navit/script/cabify.sh
+++ b/navit/script/cabify.sh
@@ -42,7 +42,7 @@ echo "PocketPc dir: $BASEDIR"
 
 echo -n > $CABLIST.$$
 
-for i in `ls $SRCDIR/locale/*/*/*.mo`
+for i in $SRCDIR/locale/*/*/*.mo
 do
 	bn="`basename "$i"`"
 	d=${i##$SRCDIR/}


### PR DESCRIPTION
Removes a warning in codefactor: https://www.codefactor.io/repository/github/navit-gps/navit/issues?category=Maintainability&groupId=1697