### PR TITLE
fix:scripts:fix malformed shebang

### DIFF
--- a/scripts/setup_wince.sh
+++ b/scripts/setup_wince.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 set -e
 
 mkdir -p /var/lib/apt/lists/partial


### PR DESCRIPTION
This adds a forgotten `!` in the shebang. Fixes: https://www.codefactor.io/repository/github/navit-gps/navit/issues?category=Maintainability&groupId=1694