### PR TITLE
fix:scripts:replace \s with the supported use of the space class

### DIFF
--- a/scripts/generate_contributors.sh
+++ b/scripts/generate_contributors.sh
@@ -23,7 +23,7 @@ git log --encoding=utf-8 --full-history --date=short --use-mailmap "--format=for
     commitDate=`date +%s --date="${arrLine[0]}"`
 
     # Exclude circleci
-    if [[ $author =~ [Cc]ircle\s*[Cc][Ii] ]]; then
+    if [[ $author =~ [Cc]ircle[[:space:]]*[Cc][Ii] ]]; then
       continue
     fi
 


### PR DESCRIPTION
Seems the space with `\s` is not correctly supported in bash regex and we should use the space class instead. This PR fixes that.
Codefactore issue: https://www.codefactor.io/repository/github/navit-gps/navit/issues?category=Maintainability&groupId=1667