### PR TITLE
update:scripts:change the scripts that use non-POSIX functionalities to bash (v2)

### DIFF
--- a/scripts/build_win32.sh
+++ b/scripts/build_win32.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 apt-get update && apt-get install -y mingw32 mingw32-binutils mingw32-runtime default-jdk nsis libsaxonb-java
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ -z $CI ];then
     echo "This Script needs to be run by CI"


### PR DESCRIPTION
Seems I forgot to take care of the 2nd page of warnings that were on codefactor about the use of functionalities that was not POSIX sh compliant.
https://www.codefactor.io/repository/github/navit-gps/navit/issues?category=Compatibility&groupId=1669