### PR TITLE
cleanup:python:cleanup python scripts

### DIFF
--- a/navit/binding/dbus/eval.py
+++ b/navit/binding/dbus/eval.py
@@ -4,9 +4,9 @@ import sys
 bus = dbus.SessionBus()
 conn = bus.get_object('org.navit_project.navit',
                        '/org/navit_project/navit')
-iface = dbus.Interface(conn, dbus_interface='org.navit_project.navit');
-iter=iface.attr_iter();
-navit=bus.get_object('org.navit_project.navit', conn.get_attr_wi('navit',iter)[1]);
-iface.attr_iter_destroy(iter);
-navit_iface = dbus.Interface(navit, dbus_interface='org.navit_project.navit.navit');
-print navit_iface.evaluate(sys.argv[1]);
+iface = dbus.Interface(conn, dbus_interface='org.navit_project.navit')
+_iter=iface.attr_iter()
+navit=bus.get_object('org.navit_project.navit', conn.get_attr_wi('navit',_iter)[1])
+iface.attr_iter_destroy(_iter)
+navit_iface = dbus.Interface(navit, dbus_interface='org.navit_project.navit.navit')
+print navit_iface.evaluate(sys.argv[1])

--- a/navit/binding/dbus/test.py
+++ b/navit/binding/dbus/test.py
@@ -3,9 +3,9 @@ import dbus
 bus = dbus.SessionBus()
 conn = bus.get_object('org.navit_project.navit',
                        '/org/navit_project/navit')
-iface = dbus.Interface(conn, dbus_interface='org.navit_project.navit');
-iter=iface.attr_iter();
-navit=bus.get_object('org.navit_project.navit', conn.get_attr_wi("navit",iter)[1]);
-iface.attr_iter_destroy(iter);
-navit_iface = dbus.Interface(navit, dbus_interface='org.navit_project.navit.navit');
-navit_iface.set_center((1,0x138a4a,0x5d773f));
+iface = dbus.Interface(conn, dbus_interface='org.navit_project.navit')
+_iter=iface.attr_iter()
+navit=bus.get_object('org.navit_project.navit', conn.get_attr_wi("navit",_iter)[1])
+iface.attr_iter_destroy(_iter)
+navit_iface = dbus.Interface(navit, dbus_interface='org.navit_project.navit.navit')
+navit_iface.set_center((1,0x138a4a,0x5d773f))

--- a/navit/binding/python/startup.py
+++ b/navit/binding/python/startup.py
@@ -1,8 +1,8 @@
 import navit
 navit.config_load("navit.xml.local")
-pos=navit.pcoord("5023.7493 N 00730.2898 E",1);
-dest=navit.pcoord("5023.6604 N 00729.8500 E",1);
-inst=navit.config().navit();
-inst.set_position(pos);
-inst.set_destination(dest,"Test");
-inst.set_center(pos);
+pos=navit.pcoord("5023.7493 N 00730.2898 E",1)
+dest=navit.pcoord("5023.6604 N 00729.8500 E",1)
+inst=navit.config().navit()
+inst.set_position(pos)
+inst.set_destination(dest,"Test")
+inst.set_center(pos)


### PR DESCRIPTION
Remove unnecessary semicolon at the end of line.
Fixes: https://www.codefactor.io/repository/github/navit-gps/navit/issues?category=Maintainability&groupId=459

`iter` is the name of a builtin function in python, so avoid overwriting that keyword.
Fixes: https://www.codefactor.io/repository/github/navit-gps/navit/issues/trunk?category=Maintainability&groupId=415
