### PR TITLE
update:scripts:change the sanity script to exclude fib and support

### DIFF
--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -14,13 +14,13 @@ return_code=0
 # Check if any file has been modified. If yes, that means the best practices
 # have not been followed, so we will fail the job later but print a message here.
 check_diff(){
-  git diff --exit-code
-  code=$?
-  if [[ $code -ne 0 ]]; then
-    echo "[ERROR] You may need to do some cleanup in the files you commited, see the git diff output above."
-  fi
-  git checkout -- .
-  return_code=$(($return_code + $code))
+    git diff --exit-code
+    code=$?
+    if [[ $code -ne 0 ]]; then
+        echo "[ERROR] You may need to do some cleanup in the files you commited, see the git diff output above."
+    fi
+    git checkout -- .
+    return_code=$(($return_code + $code))
 }
 
 # List the files that are different from the trunk
@@ -30,33 +30,37 @@ interval=${from}..${to}
 [[ "${from}" == "${to}" ]] && interval=${to}
 
 for f in $(git diff --name-only ${interval} | sort -u); do
-  if [[ -e "${f}" ]]; then
-
-    # Checks for trailing spaces
-    if [[ "${f: -4}" != ".bat" ]]; then
-      echo "[INFO] Checking for trailing spaces on ${f}..."
-      if [[ "$(file -bi """${f}""")" =~ ^text ]]; then
-        sed 's/\s*$//' -i "${f}"
-        check_diff
-      fi
+    if [[ "${f}" =~ navit/support/ ]] || [[ "${f}" =~ navit/fib-1\.1/ ]]; then
+        echo "[DEBUG] Skipping file ${f} ..."
+        continue
     fi
+    if [[ -e "${f}" ]]; then
 
-    # Formats any *.c and *.cpp files
-    if [[ "${f: -2}" == ".c" ]] || [[ "${f: -4}" == ".cpp" ]]; then
-      echo "[INFO] Checking for indentation and style compliance on ${f}..."
-      astyle --indent=spaces=4 --style=attach -n --max-code-length=120 -xf -xh "${f}"
-      check_diff
-    fi
+        # Checks for trailing spaces
+        if [[ "${f: -4}" != ".bat" ]]; then
+            echo "[INFO] Checking for trailing spaces on ${f}..."
+            if [[ "$(file -bi """${f}""")" =~ ^text ]]; then
+                sed 's/\s*$//' -i "${f}"
+                check_diff
+            fi
+        fi
 
-    if [[ "${f}" == "navit/navit_shipped.xml" ]]; then
-      echo "[INFO] Checking for compliance with the DTD using xmllint on ${f}..."
-      xmllint --noout --dtdvalid navit/navit.dtd "$f"
-      rc=$?
-      if [[ $rc -ne 0 ]]; then
-        echo "[ERROR] Your ${f} file doesn't validate against the navit/navit.dtd using xmllint"
-      fi
+        # Formats any *.c and *.cpp files
+        if [[ "${f: -2}" == ".c" ]] || [[ "${f: -4}" == ".cpp" ]]; then
+            echo "[INFO] Checking for indentation and style compliance on ${f}..."
+            astyle --indent=spaces=4 --style=attach -n --max-code-length=120 -xf -xh "${f}"
+            check_diff
+        fi
+
+        if [[ "${f}" == "navit/navit_shipped.xml" ]]; then
+            echo "[INFO] Checking for compliance with the DTD using xmllint on ${f}..."
+            xmllint --noout --dtdvalid navit/navit.dtd "$f"
+            rc=$?
+            if [[ $rc -ne 0 ]]; then
+                echo "[ERROR] Your ${f} file doesn't validate against the navit/navit.dtd using xmllint"
+            fi
+        fi
     fi
-  fi
 done
 
 exit $return_code


### PR DESCRIPTION
As requested in #624, removes checking for trailing spaces and other style-related elments on `navit/support`. Also added `navit/fib-1.1` to it as it is a 3rd party lib.
Note: the indentation change is just to make sure we're also using 4 spaces indentation in the script (I was using 2 spaces before).

You can use the diff settings button when reviewing to get rid of the white spaces diffs which makes the review way easier.