### PR TITLE
Refactor:gui/internal: Add pointer and label when using function "view on map"

### DIFF
--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -1977,24 +1977,24 @@ static int limit_count(struct coord *c, int count) {
 }
 
 /**
- * @brief Draw a multi-line text close to a specified point
+ * @brief Draw a multi-line text next to a specified point @p pref
  *
  * @param gra The graphics instance on which to draw
- * @param gc The graphics color to use to draw the text
- * @param gc The graphics background color to use to draw the text
+ * @param fg The graphics color to use to draw the text
+ * @param bg The graphics background color to use to draw the text
  * @param font The font to use to draw the text
  * @param pref The position to draw the text (draw at the right and vertically aligned relatively to this point)
- * @param input_labl The text to draw (may contain '\n' for multiline text, if so lines will be stacked vertically)
+ * @param label The text to draw (may contain '\n' for multiline text, if so lines will be stacked vertically)
  * @param line_spacing The delta between each line (set its value at to least the font text size, to be readable)
  */
-static void multiline_label_draw(struct graphics *gra, struct graphics_gc *gc, struct graphics_gc *gc_background,
-                                 struct graphics_font *font, struct point pref, const char *input_label, int line_spacing) {
+static void multiline_label_draw(struct graphics *gra, struct graphics_gc *fg, struct graphics_gc *bg,
+                                 struct graphics_font *font, struct point pref, const char *label, int line_spacing) {
 
-    char *label=g_strdup(input_label);
+    char *input_label=g_strdup(label);
     char *label_lines[10];	/* Max 10 lines of text */
     int label_nblines=0;
     int label_linepos=0;
-    char *startline=label;
+    char *startline=input_label;
     char *endline=startline;
     while (endline && *endline!='\0') {
         while (*endline!='\0' && *endline!='\n') { /* Search for new line */
@@ -2012,7 +2012,7 @@ static void multiline_label_draw(struct graphics *gra, struct graphics_gc *gc, s
     }
     if (label_nblines>(sizeof(label_lines)/sizeof(char
                        *))) {	/* Does label_nblines overflows the number of entries in array label_lines? */
-        dbg(lvl_warning,"Too many lines (%d) in label \"%s\", truncating to %lu", label_nblines, input_label,
+        dbg(lvl_warning,"Too many lines (%d) in label \"%s\", truncating to %lu", label_nblines, label,
             sizeof(label_lines)/sizeof(char *));
         label_nblines=sizeof(label_lines)/sizeof(char *);
     }
@@ -2023,11 +2023,11 @@ static void multiline_label_draw(struct graphics *gra, struct graphics_gc *gc, s
 
     /* Parse all stored lines, and display them */
     for (label_linepos=0; label_linepos<label_nblines; label_linepos++) {
-        gra->meth.draw_text(gra->priv, gc->priv, gc_background?gc_background->priv:NULL, font->priv, label_lines[label_linepos],
+        gra->meth.draw_text(gra->priv, fg->priv, bg?bg->priv:NULL, font->priv, label_lines[label_linepos],
                             &pref, 0x10000, 0);
         pref.y+=line_spacing;
     }
-    g_free(label);
+    g_free(input_label);
 }
 
 

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -2023,7 +2023,7 @@ static void multiline_label_draw(struct graphics *gra, struct graphics_gc *fg, s
 
 
 /**
- * @brief Draw a dispayitem element
+ * @brief Draw a displayitem element
  *
  * This function will invoke the appropriate draw primitive depending on the type of the element to draw
  *

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -1976,7 +1976,70 @@ static int limit_count(struct coord *c, int count) {
     return count;
 }
 
+/**
+ * @brief Draw a multi-line text close to a specified point
+ *
+ * @param gra The graphics instance on which to draw
+ * @param gc The graphics color to use to draw the text
+ * @param gc The graphics background color to use to draw the text
+ * @param font The font to use to draw the text
+ * @param pref The position to draw the text (draw at the right and vertically aligned relatively to this point)
+ * @param input_labl The text to draw (may contain '\n' for multiline text, if so lines will be stacked vertically)
+ * @param line_spacing The delta between each line (set its value at to least the font text size, to be readable)
+ */
+static void multiline_label_draw(struct graphics *gra, struct graphics_gc *gc, struct graphics_gc *gc_background,
+                                 struct graphics_font *font, struct point pref, const char *input_label, int line_spacing) {
 
+    char *label=g_strdup(input_label);
+    char *label_lines[10];	/* Max 10 lines of text */
+    int label_nblines=0;
+    int label_linepos=0;
+    char *startline=label;
+    char *endline=startline;
+    while (endline && *endline!='\0') {
+        while (*endline!='\0' && *endline!='\n') { /* Search for new line */
+            endline=g_utf8_next_char(endline);
+        }
+        if (*endline=='\0')
+            endline=NULL;	/* This means we reached the end of string */
+        if (endline) /* Test if we got a new line character ('\n') */
+            *endline='\0';	/* Terminate string at line ('\n') and print this line */
+        label_lines[label_nblines++]=startline;
+        if (endline==NULL)	/* endline is NULL, this was the last line of the multi-line string */
+            break;
+        endline++;	/* No need for g_utf8_next_char() here, as we know '\n' is a single byte UTF-8 char */
+        startline=endline;	/* Start processing next line, by setting startline to its first character */
+    }
+    if (label_nblines>(sizeof(label_lines)/sizeof(char
+                       *))) {	/* Does label_nblines overflows the number of entries in array label_lines? */
+        dbg(lvl_warning,"Too many lines (%d) in label \"%s\", truncating to %lu", label_nblines, input_label,
+            sizeof(label_lines)/sizeof(char *));
+        label_nblines=sizeof(label_lines)/sizeof(char *);
+    }
+    /* Horizontally, we position the label next to the specified point (on the right handside) */
+    pref.x+=1;
+    /* Vertically, we center the text with respect to specified point */
+    pref.y-=(label_nblines*line_spacing)/2;
+
+    /* Parse all stored lines, and display them */
+    for (label_linepos=0; label_linepos<label_nblines; label_linepos++) {
+        gra->meth.draw_text(gra->priv, gc->priv, gc_background?gc_background->priv:NULL, font->priv, label_lines[label_linepos],
+                            &pref, 0x10000, 0);
+        pref.y+=line_spacing;
+    }
+    g_free(label);
+}
+
+
+/**
+ * @brief Draw a dispayitem element
+ *
+ * This function will invoke the appropriate draw primitive depending on the type of the element to draw
+ *
+ * @brief di The displayitem to draw
+ * @brief dummy Unused
+ * @brief dc The display_context to use to draw items
+ */
 static void displayitem_draw(struct displayitem *di, void *dummy, struct display_context *dc) {
     int *width=g_alloca(sizeof(int)*dc->maxlen);
     struct point *pa=g_alloca(sizeof(struct point)*dc->maxlen);
@@ -2034,43 +2097,10 @@ static void displayitem_draw(struct displayitem *di, void *dummy, struct display
                         dc->gc_background=gc_background;
                     }
                     if (font) {
-                        char *label=g_strdup(di->label);
-                        char *label_lines[10];	/* Max 10 lines of text */
-                        int label_nblines=0;
-                        int label_linepos=0;
-                        char *startline=label;
-                        char *endline=startline;
-                        while (endline && *endline!='\0') {
-                            while (*endline!='\0' && *endline!='\n') { /* Search for new line */
-                                endline=g_utf8_next_char(endline);
-                            }
-                            if (*endline=='\0')
-                                endline=NULL;	/* This means we reached the end of string */
-                            if (endline) /* Test if we got a new line character ('\n') */
-                                *endline='\0';	/* Terminate string at line ('\n') and print this line */
-                            label_lines[label_nblines++]=startline;
-                            if (endline==NULL)	/* endline is NULL, this was the last line of the multi-line string */
-                                break;
-                            endline++;	/* No need for g_utf8_next_char() here, as we know '\n' is a single byte UTF-8 char */
-                            startline=endline;	/* Start processing next line, by setting startline to its first character */
-                        }
-                        if (label_nblines>(sizeof(label_lines)/sizeof(char *))) {	/* Does label_nblines overflows the number of entries in array label_lines? */
-                            dbg(lvl_warning,"Too many lines (%d) in label \"%s\", truncating to %lu", label_nblines, di->label,
-                                sizeof(label_lines)/sizeof(char *));
-                            label_nblines=sizeof(label_lines)/sizeof(char *);
-                        }
-                        /* Horizontally, we position the label next to the circle (on the right handside) */
-                        p.x=pa[0].x+(e->u.circle.radius/2)+1;
-                        /* Vertically, we center the text with respect to circle */
-                        p.y=pa[0].y+(e->u.circle.radius/2)-(label_nblines*(e->text_size+1))/2;
-
-                        /* Parse all stored lines, and display them */
-                        for (label_linepos=0; label_linepos<label_nblines; label_linepos++) {
-                            gra->meth.draw_text(gra->priv, gc->priv, gc_background?gc_background->priv:NULL, font->priv, label_lines[label_linepos],
-                                                &p, 0x10000, 0);
-                            p.y+=e->text_size+1;
-                        }
-                        g_free(label);
+                        /* Set p to the center of the circle */
+                        p.x=pa[0].x+(e->u.circle.radius/2);
+                        p.y=pa[0].y+(e->u.circle.radius/2);
+                        multiline_label_draw(gra, gc, gc_background, font, p, di->label, e->text_size+1);
                     } else
                         dbg(lvl_error,"Failed to get font with size %d",e->text_size);
                 }

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -1444,30 +1444,6 @@ static int fowler(int dy, int dx) {
     }
     return 0;
 }
-static int int_sqrt(unsigned int n) {
-    unsigned int h, p= 0, q= 1, r= n;
-
-    /* avoid q rollover */
-    if(n >= (1<<(sizeof(n)*8-2))) {
-        q = 1<<(sizeof(n)*8-2);
-    } else {
-        while ( q <= n ) {
-            q <<= 2;
-        }
-        q >>= 2;
-    }
-
-    while ( q != 0 ) {
-        h = p + q;
-        p >>= 1;
-        if ( r >= h ) {
-            p += q;
-            r -= h;
-        }
-        q >>= 2;
-    }
-    return p;
-}
 
 struct draw_polyline_shape {
     int wi;
@@ -1515,9 +1491,9 @@ static void draw_shape(struct draw_polyline_context *ctx, struct point *pnt, int
     dys=shape->dy*shape->dy;
     lscales=lscale*lscale;
     if (dxs + dys > lscales)
-        l = int_sqrt(dxs+dys)*lscale;
+        l = uint_sqrt(dxs+dys)*lscale;
     else
-        l = int_sqrt((dxs+dys)*lscales);
+        l = uint_sqrt((dxs+dys)*lscales);
 
     shape->fow=fowler(-shape->dy, shape->dx);
     dbg(lvl_debug,"fow=%d",shape->fow);

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -2054,14 +2054,17 @@ static void displayitem_draw(struct displayitem *di, void *dummy, struct display
                             endline++;	/* No need for g_utf8_next_char() here, as we know '\n' is a single byte UTF-8 char */
                             startline=endline;	/* Start processing next line, by setting startline to its first character */
                         }
-                        if (label_nblines>sizeof(label_lines)/sizeof(char *)) {
+                        if (label_nblines>(sizeof(label_lines)/sizeof(char *))) {	/* Does label_nblines overflows the number of entries in array label_lines? */
                             dbg(lvl_warning,"Too many lines (%d) in label \"%s\", truncating to %lu", label_nblines, di->label,
                                 sizeof(label_lines)/sizeof(char *));
-                            label_nblines=10;
+                            label_nblines=sizeof(label_lines)/sizeof(char *);
                         }
+                        /* Horizontally, we position the label next to the circle (on the right handside) */
                         p.x=pa[0].x+(e->u.circle.radius/2)+1;
-                        p.y=pa[0].y+(e->u.circle.radius/2)-(label_nblines*(e->text_size
-                                                            +1))/2;	/* Vertically center text with respect to circle */
+                        /* Vertically, we center the text with respect to circle */
+                        p.y=pa[0].y+(e->u.circle.radius/2)-(label_nblines*(e->text_size+1))/2;
+
+                        /* Parse all stored lines, and display them */
                         for (label_linepos=0; label_linepos<label_nblines; label_linepos++) {
                             gra->meth.draw_text(gra->priv, gc->priv, gc_background?gc_background->priv:NULL, font->priv, label_lines[label_linepos],
                                                 &p, 0x10000, 0);

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -745,15 +745,15 @@ static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *w
             type=type_selected_area;
         graphics_clear_selection(this->gra, NULL);
         graphics_add_selection(this->gra, &wm->item, type, NULL);
-    }
-    else {
+    } else {
         if (wm->item.priv_data)
             label = wm->item.priv_data;	/* Use the label of the point to view on map */
         else
             label = g_strdup("");
         w = gui_internal_widget_table_new(this, 0, 0);	/* Create a basic table */
         gui_internal_widget_append(w,wr=gui_internal_widget_table_row_new(this,0));	/* In this table, add one row */
-        gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,label));	/* That row contains a widget of type widget_box */
+        gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,
+                                         label));	/* That row contains a widget of type widget_box */
         wi->name = label;	/* Use the label of the point to view on map */
         wi->c.x=wm->c.x;	/* Use the coordinates of the point to place it on the map */
         wi->c.y=wm->c.y;
@@ -951,58 +951,60 @@ static struct map *get_search_results_map(struct gui_priv *this) {
  * @param[in,out] s The string to proces (will be modified by this function, but length will be unchanged)
  */
 static void square_shape_str(char *s) {
-	char *c;
-	char *last_break;
-	unsigned int max_cols = 0;
-	unsigned int cur_cols = 0;
-	unsigned int max_rows = 0;
-	unsigned int surface;
-	unsigned int target_cols;
-	
-	if (!s)
-		return;
-	for (c=s; *c!='\0'; c++) {
-		if (*c==' ') {
-			if (max_cols < cur_cols)
-				max_cols = cur_cols;
-			cur_cols = 0;
-			max_rows++;
-		}
-		else
-			cur_cols++;
-	}
-	if (max_cols < cur_cols)
-		max_cols = cur_cols;
-	if (cur_cols)	/* If last line does not end with CR, add it to line numbers anyway */
-		max_rows++;
-	surface = max_rows * 2 * max_cols;
-	target_cols = sqrt(surface);
-	
-	if (target_cols < max_cols)
-		target_cols = max_cols;
+    char *c;
+    char *last_break;
+    unsigned int max_cols = 0;
+    unsigned int cur_cols = 0;
+    unsigned int max_rows = 0;
+    unsigned int surface;
+    unsigned int target_cols;
 
-	target_cols = target_cols + target_cols/10;	/* Allow 10% extra on columns */
-	dbg(lvl_debug, "square_shape_str(): analyzing input text=\"%s\". max_rows=%u, max_cols=%u, surface=%u, target_cols=%u", s, max_rows, max_cols, max_rows * 2 * max_cols, target_cols);
+    if (!s)
+        return;
+    for (c=s; *c!='\0'; c++) {
+        if (*c==' ') {
+            if (max_cols < cur_cols)
+                max_cols = cur_cols;
+            cur_cols = 0;
+            max_rows++;
+        } else
+            cur_cols++;
+    }
+    if (max_cols < cur_cols)
+        max_cols = cur_cols;
+    if (cur_cols)	/* If last line does not end with CR, add it to line numbers anyway */
+        max_rows++;
+    surface = max_rows * 2 * max_cols;
+    target_cols = sqrt(surface);
 
-	cur_cols = 0;
-	last_break = NULL;
-	for (c=s; *c!='\0'; c++) {
-		if (*c==' ') {
-			if (cur_cols>=target_cols) {	/* This line is too long, break at the previous non alnum character */
-				if (last_break) {
-					*last_break = '\n';	/* Replace the previous non alnum character with a line break, this creates a new line and prevents the previous line from being too long */
-					cur_cols = c-last_break;
-				}
-			}
-			last_break = c;	/* Record this position as a candidate to insert a line break */
-		}
-		cur_cols++;
-	}
-	if (cur_cols>=target_cols && last_break) {
-		*last_break = '\n';	/* Replace the previous non alnum character with a line break, this creates a new line and prevents the previous line from being too long */
-	}
+    if (target_cols < max_cols)
+        target_cols = max_cols;
 
-	dbg(lvl_debug, "square_shape_str(): output text=\"%s\"", s);
+    target_cols = target_cols + target_cols/10;	/* Allow 10% extra on columns */
+    dbg(lvl_debug, "square_shape_str(): analyzing input text=\"%s\". max_rows=%u, max_cols=%u, surface=%u, target_cols=%u",
+        s, max_rows, max_cols, max_rows * 2 * max_cols, target_cols);
+
+    cur_cols = 0;
+    last_break = NULL;
+    for (c=s; *c!='\0'; c++) {
+        if (*c==' ') {
+            if (cur_cols>=target_cols) {	/* This line is too long, break at the previous non alnum character */
+                if (last_break) {
+                    *last_break =
+                        '\n';	/* Replace the previous non alnum character with a line break, this creates a new line and prevents the previous line from being too long */
+                    cur_cols = c-last_break;
+                }
+            }
+            last_break = c;	/* Record this position as a candidate to insert a line break */
+        }
+        cur_cols++;
+    }
+    if (cur_cols>=target_cols && last_break) {
+        *last_break =
+            '\n';	/* Replace the previous non alnum character with a line break, this creates a new line and prevents the previous line from being too long */
+    }
+
+    dbg(lvl_debug, "square_shape_str(): output text=\"%s\"", s);
 }
 
 /**
@@ -1337,8 +1339,7 @@ void gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, s
         wbc->c=pc;
         if ((flags & 4) && wm) {
             wbc->item=wm->item;
-        }
-        else {
+        } else {
             wbc->item.type=type_none;
             wbc->item.priv_data = g_strdup(name); /* Will be freed up by gui_internal_cmd_view_on_map() */
         }

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -977,7 +977,7 @@ static void square_shape_str(char *s) {
     /* Give twice more room for rows (hence the factor 2 below)
      * This will render as a rectangular shape, taking more horizontal space than vertical */
     surface = max_rows * 2 * max_cols;
-    target_cols = sqrt(surface);
+    target_cols = uint_sqrt(surface);
 
     if (target_cols < max_cols)
         target_cols = max_cols;

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -888,29 +888,15 @@ static void gui_internal_cmd_view_in_browser(struct gui_priv *this, struct widge
 }
 
 
-/**
- * @brief Create a map rect highlighting one of multiple points provided in argument @data and displayed using
- *        the style type_found_item (name for each point will also be displayed aside)
- *
- * @param this The GUI context
- * @param table A table widget or any of its descendants. The table contain results to place on the map.
- *              Providing NULL here will remove all previous results from the map.
- * @param[out] r The minimum rect focused to contain all results placed  on the map (or unchanged if r==NULL)
- */
-static void gui_internal_prepare_search_results_map(struct gui_priv *this, struct widget *table, struct coord_rect *r) {
-    struct widget *w;
+static struct map *get_search_results_map(struct gui_priv *this) {
+
     struct mapset *ms;
     struct map *map;
-    struct map_rect *mr;
-    struct item *item;
-    GList *l;
-    struct attr a;
-    int count;
 
     ms=navit_get_mapset(this->nav);
 
     if(!ms)
-        return;
+        return NULL;
 
     map=mapset_get_map_by_name(ms, "search_results");
     if(!map) {
@@ -946,9 +932,30 @@ static void gui_internal_prepare_search_results_map(struct gui_priv *this, struc
 
         for(i=0; attrs[i]; i++)
             g_free(attrs[i]);
-
     }
+    return map;
+}
 
+/**
+ * @brief Create a map rect highlighting one of multiple points provided in argument @data and displayed using
+ *        the style type_found_item (name for each point will also be displayed aside)
+ *
+ * @param this The GUI context
+ * @param table A table widget or any of its descendants. The table contain results to place on the map.
+ *              Providing NULL here will remove all previous results from the map.
+ * @param[out] r The minimum rect focused to contain all results placed  on the map (or unchanged if r==NULL)
+ */
+static void gui_internal_prepare_search_results_map(struct gui_priv *this, struct widget *table, struct coord_rect *r) {
+    struct widget *w;
+    struct mapset *ms;
+    struct map *map;
+    struct map_rect *mr;
+    struct item *item;
+    GList *l;
+    struct attr a;
+    int count;
+
+    map = get_search_results_map(this);
     if(!map)
         return;
 
@@ -1034,9 +1041,8 @@ static void gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget
  * @brief Removes all existing search results from a map.
  *
  * @param this The GUI context
- * @param wm The widget that points to this function as a callback
- * @param data Private data provided during callback (should be a pointer to the table widget containing results,
- *             or NULL to remove all previous results from the map).
+ * @param wm The widget that called us
+ * @param data Private data (unused).
  */
 static void gui_internal_cmd_results_map_clean(struct gui_priv *this, struct widget *wm, void *data) {
     gui_internal_cmd_results_to_map(this,wm,NULL);

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -733,6 +733,7 @@ static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *w
     struct widget *w;
     struct widget *wr;
     struct widget *wi;
+    char *label;
 
     if (wm->item.type != type_none) {
         enum item_type type;
@@ -746,19 +747,20 @@ static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *w
         graphics_add_selection(this->gra, &wm->item, type, NULL);
     }
     else {
+        if (wm->item.priv_data)
+            label = wm->item.priv_data;	/* Use the label of the point to view on map */
+        else
+            label = g_strdup("");
         w = gui_internal_widget_table_new(this, 0, 0);	/* Create a basic table */
         gui_internal_widget_append(w,wr=gui_internal_widget_table_row_new(this,0));	/* In this table, add one row */
-        gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,""));	/* That row contains a widget of type widget_box */
-        if (wm->item.priv_data)
-            wi->name = wm->item.priv_data;	/* Use the label of the point to view on map */
-        else
-            wi->name = g_strdup("");
+        gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,label));	/* That row contains a widget of type widget_box */
+        wi->name = label;	/* Use the label of the point to view on map */
         wi->c.x=wm->c.x;	/* Use the coordinates of the point to place it on the map */
         wi->c.y=wm->c.y;
         gui_internal_prepare_search_results_map(this, w, NULL);
-        g_free(wi->name);
+        g_free(label);
         wi->name = NULL;
-        //gui_internal_widget_destroy(this, w); // FIXME: This will cause a segfault at next draw
+        gui_internal_widget_destroy(this, w);
     }
     navit_set_center(this->nav, &wm->c, 1);
     gui_internal_prune_menu(this, NULL);

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -724,7 +724,7 @@ char *removecase(char *s) {
  * @brief Apply the command "View on Map", centers the map on the selected point and highlight this point using
  * type_found_item style
  *
- * @param this The GUI object that called us
+ * @param this The GUI context
  * @param wm The widget that points to this function as a callback
  * @param data Private data provided during callback (unused)
  */
@@ -757,7 +757,8 @@ static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *w
         wi->c.y=wm->c.y;
         gui_internal_prepare_search_results_map(this, w, NULL);
         g_free(wi->name);
-        /* FIXME: deallocate all widgets here? They won't be displayed, they were just used to create the input for gui_internal_cmd_results_to_map() */
+        wi->name = NULL;
+        //gui_internal_widget_destroy(this, w); // FIXME: This will cause a segfault at next draw
     }
     navit_set_center(this->nav, &wm->c, 1);
     gui_internal_prune_menu(this, NULL);
@@ -887,7 +888,13 @@ static void gui_internal_cmd_view_in_browser(struct gui_priv *this, struct widge
     }
 }
 
-
+/**
+ * @brief Get the search result map (and create it if it does not exist)
+ *
+ * @param this The GUI context
+ *
+ * @return A pointer to the map named "search_results" or NULL if there wasa failure
+ */
 static struct map *get_search_results_map(struct gui_priv *this) {
 
     struct mapset *ms;

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -974,6 +974,8 @@ static void square_shape_str(char *s) {
         max_cols = cur_cols;
     if (cur_cols)	/* If last line does not end with CR, add it to line numbers anyway */
         max_rows++;
+    /* Give twice more room for rows (hence the factor 2 below)
+     * This will render as a rectangular shape, taking more horizontal space than vertical */
     surface = max_rows * 2 * max_cols;
     target_cols = sqrt(surface);
 

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -947,7 +947,6 @@ static struct map *get_search_results_map(struct gui_priv *this) {
  */
 static void gui_internal_prepare_search_results_map(struct gui_priv *this, struct widget *table, struct coord_rect *r) {
     struct widget *w;
-    struct mapset *ms;
     struct map *map;
     struct map_rect *mr;
     struct item *item;

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -707,12 +707,12 @@ static void gui_internal_cmd_delete_bookmark(struct gui_priv *this, struct widge
 
 
 /**
- *  @brief Remove the case in a string
+ * @brief Remove the case in a string
  *
- *  @warning Result should be g_free()d after use.
+ * @warning Result should be g_free()d after use.
  *
- *  @param s The input utf-8 string
- *  @return An equivalent string prepared for case insensitive search
+ * @param s The input utf-8 string
+ * @return An equivalent string prepared for case insensitive search
  */
 char *removecase(char *s) {
     char *r;
@@ -750,10 +750,10 @@ static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *w
         gui_internal_widget_append(w,wr=gui_internal_widget_table_row_new(this,0));    /* In this table, add one row */
         gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,""));  /* That row contains a widget of type widget_box */
         if (wm->item.priv_data)
-            wi->name = wm->item.priv_data;
+            wi->name = wm->item.priv_data;	/* Use the label of the point to view on map */
         else
             wi->name = g_strdup("");
-        wi->c.x=wm->c.x;
+        wi->c.x=wm->c.x;	/* Use the coordinates of the point to place it on the map */
         wi->c.y=wm->c.y;
         gui_internal_cmd_results_to_map(this,wm,w);
         g_free(wi->name);
@@ -1245,7 +1245,7 @@ void gui_internal_cmd_position_do(struct gui_priv *this, struct pcoord *pc_in, s
         }
         else {
             wbc->item.type=type_none;
-            wbc->item.priv_data = g_strdup(name);
+            wbc->item.priv_data = g_strdup(name); /* Will be freed up by gui_internal_cmd_view_on_map() */
         }
     }
     if(flags & 256 && this->results_map_population) {

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -746,9 +746,9 @@ static void gui_internal_cmd_view_on_map(struct gui_priv *this, struct widget *w
         graphics_add_selection(this->gra, &wm->item, type, NULL);
     }
     else {
-        w = gui_internal_widget_table_new(this, 0, 0); /* Create a basic table */
-        gui_internal_widget_append(w,wr=gui_internal_widget_table_row_new(this,0));    /* In this table, add one row */
-        gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,""));  /* That row contains a widget of type widget_box */
+        w = gui_internal_widget_table_new(this, 0, 0);	/* Create a basic table */
+        gui_internal_widget_append(w,wr=gui_internal_widget_table_row_new(this,0));	/* In this table, add one row */
+        gui_internal_widget_append(wr,wi=gui_internal_box_new_with_label(this,0,""));	/* That row contains a widget of type widget_box */
         if (wm->item.priv_data)
             wi->name = wm->item.priv_data;	/* Use the label of the point to view on map */
         else
@@ -894,10 +894,10 @@ static void gui_internal_cmd_view_in_browser(struct gui_priv *this, struct widge
  *
  * @param this The GUI context
  * @param wm The widget that points to this function as a callback
- * @param data Private data provided during callback (should be a pointer to the table widget containing results,
- *             or NULL to remove all previous results from the map).
+ * @param table Private data provided during callback (should be a pointer to the table widget containing results,
+ *              or NULL to remove all previous results from the map).
  */
-static void gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget *wm, void *data) {
+static void gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget *wm, void *table) {
     struct widget *w;
     struct mapset *ms;
     struct map *map;
@@ -966,8 +966,8 @@ static void gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget
 
     this->results_map_population=0;
 
-    /* Find the table to pupulate the map */
-    for(w=data; w && w->type!=widget_table; w=w->parent);
+    /* Find the table to populate the map */
+    for(w=table; w && w->type!=widget_table; w=w->parent);
 
     if(!w) {
         map_rect_destroy(mr);
@@ -1006,9 +1006,9 @@ static void gui_internal_cmd_results_to_map(struct gui_priv *this, struct widget
         return;
     a.type=attr_orientation;
     a.u.num=0;
-    navit_set_attr(this->nav,&a);
-    //navit_zoom_to_rect(this->nav,&r);
-    //gui_internal_prune_menu(this, NULL);
+    navit_set_attr(this->nav,&a);	/* Set orientation to North */
+    navit_zoom_to_rect(this->nav,&r);
+    gui_internal_prune_menu(this, NULL);
     this->results_map_population=count;
 }
 

--- a/navit/route.c
+++ b/navit/route.c
@@ -3267,7 +3267,8 @@ static int rm_attr_get(void *priv_data, enum attr_type attr_type, struct attr *a
         if(mr->item.type==type_waypoint || mr->item.type == type_route_end) {
             if(mr->str)
                 g_free(mr->str);
-            /* Set the text close to the destination cursor to contain the sequence number of the waypoint (1, 2...) */
+            /* Build the text displayed close to the destination cursor.
+             * It will contain the sequence number of the waypoint (1, 2...) */
             mr->str=g_strdup_printf("%d",route->reached_destinations_count+g_list_position(route->destinations,mr->dest)+1);
             attr->u.str=mr->str;
             return 1;

--- a/navit/route.c
+++ b/navit/route.c
@@ -3260,6 +3260,7 @@ static int rm_attr_get(void *priv_data, enum attr_type attr_type, struct attr *a
         if(mr->item.type==type_waypoint || mr->item.type == type_route_end) {
             if(mr->str)
                 g_free(mr->str);
+            /* Set the text close to the destination cursor to contain the sequence number of the waypoint (1, 2...) */
             mr->str=g_strdup_printf("%d",route->reached_destinations_count+g_list_position(route->destinations,mr->dest)+1);
             attr->u.str=mr->str;
             return 1;

--- a/navit/util.c
+++ b/navit/util.c
@@ -50,6 +50,37 @@ void strtolower(char *dest, const char *src) {
     *dest='\0';
 }
 
+/**
+ * @brief Fast compute of square root for unsigned ints
+ *
+ * @param n The input number
+ * @return sqrt(n)
+ */
+unsigned int uint_sqrt(unsigned int n) {
+    unsigned int h, p= 0, q= 1, r= n;
+
+    /* avoid q rollover */
+    if(n >= (1<<(sizeof(n)*8-2))) {
+        q = 1<<(sizeof(n)*8-2);
+    } else {
+        while ( q <= n ) {
+            q <<= 2;
+        }
+        q >>= 2;
+    }
+
+    while ( q != 0 ) {
+        h = p + q;
+        p >>= 1;
+        if ( r >= h ) {
+            p += q;
+            r -= h;
+        }
+        q >>= 2;
+    }
+    return p;
+}
+
 int navit_utf8_strcasecmp(const char *s1, const char *s2) {
     char *s1_folded,*s2_folded;
     int cmpres;

--- a/navit/util.h
+++ b/navit/util.h
@@ -25,6 +25,7 @@
 
 void strtoupper(char *dest, const char *src);
 void strtolower(char *dest, const char *src);
+unsigned int uint_sqrt(unsigned int n);
 int navit_utf8_strcasecmp(const char *s1, const char *s2);
 GList * g_hash_to_list(GHashTable *h);
 GList * g_hash_to_list_keys(GHashTable *h);

--- a/navit/xslt/android.xslt
+++ b/navit/xslt/android.xslt
@@ -68,7 +68,7 @@
          <xsl:apply-templates/>
       </xsl:copy>
    </xsl:template>
-   <xsl:template match="/config/navit/layout/layer/itemgra/child::*">
+   <xsl:template match="/config/navit/layout/layer/itemgra/child::*|/config/navit/layer/itemgra/child::*">
       <xsl:copy>
          <xsl:copy-of select="@*[not(name()='text_size') and not(name()='width') and not(name()='radius') and not(name()='w') and not(name()='h') and not(name()='x') and not(name()='y') and not(name()='dash')]"/>
          <xsl:if test="@text_size">


### PR DESCRIPTION
When selecting GPS coords or a town/street, and choosing "View on map", the display is centered on the selected location, but there is no visible pointer on this location.
In order to implement this, I have am re-using the code that is already existing to handle action "Show results on the map", and that is already able to display multiple result pointers on the map.

Here is an example of the result when selecting "View on map" for "An der Hauptfeuerwache" in Mûnchen.
![example_view_on_map](https://user-images.githubusercontent.com/383502/42726908-c66ea850-879c-11e8-84e6-277c2fb93804.png)

I added some code to split long strings to multilines, in order to avoid having the text spread too much accross the map. This is also useful when using GPS coords:
![example_view_on_map_coords](https://user-images.githubusercontent.com/383502/42726981-13c584c4-879e-11e8-9c2d-22d295b18c03.png)
