### PR TITLE
Fix:scripts:WinCE build script (remove sample map, add espeak-data)

### DIFF
--- a/navit/xslt/wince.xslt
+++ b/navit/xslt/wince.xslt
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<xsl:transform version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<xsl:output method="xml" doctype-system="navit.dtd" cdata-section-elements="gui"/>
+	<xsl:template match="/config/navit/vehicle[@enabled='yes']">
+		<xsl:copy>
+			<xsl:copy-of select="@*[name() != 'gpsd_query']"/>
+				<xsl:attribute name="source">wince:COM2:</xsl:attribute>
+				<xsl:attribute name="baudrate">4800</xsl:attribute>
+			<xsl:apply-templates/>
+		</xsl:copy>
+	</xsl:template>
+	<xsl:template match="@*|node()"><xsl:copy><xsl:apply-templates select="@*|node()"/></xsl:copy></xsl:template>
+</xsl:transform>

--- a/scripts/build_wince.sh
+++ b/scripts/build_wince.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 set -e
 
-mkdir wince && cd wince
-cmake ../ -DCMAKE_TOOLCHAIN_FILE=Toolchain/arm-mingw32ce.cmake -DXSLTS=windows -DCACHE_SIZE=10485760 -Dsvg2png_scaling:STRING=16,32 -Dsvg2png_scaling_nav:STRING=32 -Dsvg2png_scaling_flag=16 -DSAMPLE_MAP=y
+mkdir -p wince && cd wince
+cmake ../ -DCMAKE_TOOLCHAIN_FILE=Toolchain/arm-mingw32ce.cmake -DXSLTS=windows -DCACHE_SIZE=10485760 -Dsvg2png_scaling:STRING=16,32 -Dsvg2png_scaling_nav:STRING=32 -Dsvg2png_scaling_flag=16 -DSAMPLE_MAP=n
 make
 
+test -d output && rm -rf output
 mkdir output
 cp navit/navit.exe output/
 cp navit/navit.xml output/
 cp -r locale/ output/
-cp -r navit/icons/ output
+cp -r navit/icons/ output/
+cp -r ../navit/support/espeak/espeak-data/ output/
 mkdir output/maps
-cp navit/maps/*.bin output/maps
-cp navit/maps/*.xml output/maps
 rm -rf output/icons/CMakeFiles/ icons/cmake_install.cmake
 
 cd output/

--- a/scripts/build_wince.sh
+++ b/scripts/build_wince.sh
@@ -2,7 +2,7 @@
 set -e
 
 mkdir -p wince && cd wince
-cmake ../ -DCMAKE_TOOLCHAIN_FILE=Toolchain/arm-mingw32ce.cmake -DXSLTS=windows -DCACHE_SIZE=10485760 -Dsvg2png_scaling:STRING=16,32 -Dsvg2png_scaling_nav:STRING=32 -Dsvg2png_scaling_flag=16 -DSAMPLE_MAP=n
+cmake ../ -DCMAKE_TOOLCHAIN_FILE=Toolchain/arm-mingw32ce.cmake -DXSLTS=windows,wince -DCACHE_SIZE=10485760 -Dsvg2png_scaling:STRING=16,32 -Dsvg2png_scaling_nav:STRING=32 -Dsvg2png_scaling_flag=16 -DSAMPLE_MAP=n
 make
 
 test -d output && rm -rf output

--- a/scripts/setup_wince.sh
+++ b/scripts/setup_wince.sh
@@ -4,3 +4,4 @@ set -e
 mkdir -p /var/lib/apt/lists/partial
 apt-get update
 apt-get install -y git-core
+apt-get install -y xsltproc


### PR DESCRIPTION
Remove inclusion of sample map in zip package (which, in addition, fails currently because map server is down)
Allow running build_wince.sh script twice by performing cleanup on directories if already created
Adding missing espeak-data to zip package (the content of this directory is currently missing in WinCE output package and makes navit speech synthesis fail unless manually copied on the WinCE device)