### PR TITLE
Fix:gui/internal:Handling "spacing" attribute properly for tag <gui type="internal">

### DIFF
--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -525,7 +525,8 @@ void gui_internal_apply_config(struct gui_priv *this) {
     if(this->config.spacing == -1 ) {
         this->spacing = current_config->spacing;
     } else {
-        this->spacing = current_config->spacing;
+        this->spacing = this->config.spacing;
+        dbg(lvl_info, "Overriding default spacing %d with value %d provided in config file", current_config->spacing, this->config.spacing);
     }
     if (!this->fonts[0]) {
         int i,sizes[]= {100,66,50};


### PR DESCRIPTION
Feature was introduced in SVN r1456 (commit 5dea1c6d5ea177a39ba0a9ce29cd247a30005960) but was not applying tag properly from config file