### PR TITLE
Add netbeans project folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.project
 /CMakeLists.txt.user*
 /navit/android/cmake_plugin_settings.txt
+/nbproject/


### PR DESCRIPTION
Hi,

just a very small change - I'd like to have the nbprojects folder netbeans uses for its project included in .gitignore.

Thanks ;)
