### PR TITLE
build:maptool:Fix cmake CMP0026 warning

### DIFF
--- a/navit/maps/CMakeLists.txt
+++ b/navit/maps/CMakeLists.txt
@@ -2,7 +2,6 @@ if(SAMPLE_MAP)
 	set(SAMPLE_MAP_NAME osm_bbox_11.3,47.9,11.7,48.2)
 	set(maptool_args "--attr-debug-level=5")
 
-	GET_TARGET_PROPERTY(MAPTOOL_PATH maptool LOCATION)
 	add_custom_target(sample_map ALL DEPENDS ${SAMPLE_MAP_NAME}.xml)
 	add_custom_command (
 		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${SAMPLE_MAP_NAME}.xml
@@ -25,7 +24,7 @@ if(SAMPLE_MAP)
 		add_custom_command (
 			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${SAMPLE_MAP_NAME}.bin
 			COMMAND bzcat ${CMAKE_CURRENT_BINARY_DIR}/${SAMPLE_MAP_NAME}.osm.bz2
-			| ${MAPTOOL_PATH} ${maptool_args} ${CMAKE_CURRENT_BINARY_DIR}/${SAMPLE_MAP_NAME}.bin
+			| $<TARGET_FILE:maptool> ${maptool_args} ${CMAKE_CURRENT_BINARY_DIR}/${SAMPLE_MAP_NAME}.bin
 			VERBATIM
 			DEPENDS maptool ${CMAKE_CURRENT_BINARY_DIR}/${SAMPLE_MAP_NAME}.osm.bz2
 			)


### PR DESCRIPTION
This fixes the CMP0026 warning from cmake:
```To configure your build use 'cmake -L' to find changeable variables and run cmake again with 'cmake -D <var-name>=<your value> ...'.
CMake Warning (dev) at navit/maps/CMakeLists.txt:5 (GET_TARGET_PROPERTY):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target "maptool".  Use the
  target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.

This warning is for project developers.  Use -Wno-dev to suppress it.
```

Local Build Log: https://gist.github.com/jkoan/ef8723cb99e438b74f2affa3b9fc8db2