### PR TITLE
Readd Navit Download Center for Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,10 @@ jobs:
           destination: reports
       - store_test_results:
           path: test-results
+      - run:
+          name: Update Navit-Download-Center
+          command: |
+            bash scripts/update_download_center.sh
   build_win32:
     docker:
       - image: ubuntu:14.04


### PR DESCRIPTION
After we merged the gradle build with #553 we havent updated the download center with new data from android builds. This should fix it once merged.
