### PR TITLE
fix:build:Pad metadata files so jekyll sort works corect

### DIFF
--- a/scripts/update_download_center.sh
+++ b/scripts/update_download_center.sh
@@ -69,7 +69,7 @@ cd $UUID/_data/$JOB_NAME
 #############################################
 
 echo "Download metadata of this build"
-wget --no-check-certificate $URL_BUILD_ARTIFACTS -O ${BUILD_NUM}.json
+wget --no-check-certificate $URL_BUILD_ARTIFACTS -O $(printf "%10d" ${BUILD_NUM}).json
 RC=$?
 if [ $RC -ne 0 ]; then
     echo "wget artifacts download failed"
@@ -82,7 +82,7 @@ echo "Push update to ${NAVIT_DOWNLOAD_CENTER_REPO}"
 git config --global push.default simple
 git config user.name "Circle CI"
 git config user.email "circleci@navit-project.org"
-git add ${BUILD_NUM}.json
+git add $(printf "%10d" ${BUILD_NUM}).json
 git commit -m "add:artifacts:Add artifacts for build #${BUILD_NUM} with SHA1:${CIRCLE_SHA1}"
 git push
 RC=$?


### PR DESCRIPTION
Currently our download center does not have the last build because it's sorting is alphabetical instead of numerical. And this can't be fixed easily with jekyll itself, but a easy solution is to do a padding on the filenames before we upload them to git. This PR should fix this. 