### PR TITLE
circleci:add ppa for cmake 3.x on win32 target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,6 @@ jobs:
             apt-get update && xargs -a scripts/setup_14.04_requirements.list apt-get install -y
             apt-get install -y software-properties-common
             add-apt-repository -y ppa:george-edison55/cmake-3.x
-            #apt-get upgrade
             apt-get remove -y cmake
             apt-get install -y cmake3
             bash scripts/build_win32.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,11 @@ jobs:
           name: Build for Windows
           command: |
             apt-get update && xargs -a scripts/setup_14.04_requirements.list apt-get install -y
+            apt-get install -y software-properties-common
+            add-apt-repository -y ppa:george-edison55/cmake-3.x
+            #apt-get upgrade
+            apt-get remove -y cmake
+            apt-get install -y cmake3
             bash scripts/build_win32.sh
       - store_artifacts:
           path: win32/navit.exe

--- a/scripts/build_win32.sh
+++ b/scripts/build_win32.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 export nixpaste="curl -F 'text=<-' http://nixpaste.lbr.uno"
+
 apt-get update && apt-get install -y mingw-w64 mingw-w64-tools  \
   default-jdk nsis libsaxonb-java curl
 


### PR DESCRIPTION
Since no people are interested to update image, this quickfix the cmake version on old 14.04 for win32 target.