### PR TITLE
circleci:Android: adding high resolution icons and improving rename steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install -y cmake gettext libsaxonb-java librsvg2-bin pkg-config libprotobuf-c-dev protobuf-c-compiler
-            cmake ./ -Dsvg2png_scaling:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96 -DUSE_PLUGINS=n -DBUILD_MAPTOOL=n -DXSL_PROCESSING=y -DXSLTS=android -DANDROID=y -DSAMPLE_MAP=n
+            cmake ./ -Dsvg2png_scaling:STRING=-1,24,32,48,64,96,128,192,256 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128,192,256 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96 -DUSE_PLUGINS=n -DBUILD_MAPTOOL=n -DXSL_PROCESSING=y -DXSLTS=android -DANDROID=y -DSAMPLE_MAP=n
       - run:
           name: Process icons
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
             cd navit/icons
             make
             mkdir ../android/res/drawable-nodpi
-            rename 'y/A-Z/a-z/' *
+            rename 'y/A-Z/a-z/' *.png
             cp *.png ../android/res/drawable-nodpi
             cd ../../
       - run:
@@ -98,7 +98,7 @@ jobs:
             cd po
             make
             mkdir ../navit/android/res/raw
-            rename 'y/A-Z/a-z/' *
+            rename 'y/A-Z/a-z/' *.mo
             cp *.mo ../navit/android/res/raw
             cd ../
       - run:


### PR DESCRIPTION
In Android build by circleci, icons for 192 and 256px are not built, which, altogether with https://github.com/navit-gps/navit/issues/584 makes icons be displayed with the worst available resolution.
This PR adds high resolution icons during build.
It also fixes successive builds on circleci for android where a rename command applies to all files, including Makefiles, and makes subsequent builds fail.