### PR TITLE
Traffic: Improve handling of situations where no segments are found

### DIFF
--- a/navit/route.c
+++ b/navit/route.c
@@ -1,6 +1,6 @@
 /**
  * Navit, a modular navigation system.
- * Copyright (C) 2005-2008 Navit Team
+ * Copyright (C) 2005-2018 Navit Team
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/navit/traffic.c
+++ b/navit/traffic.c
@@ -2158,7 +2158,7 @@ static struct route_graph_segment * traffic_route_append(struct route_graph *rg,
 static struct route_graph_point * traffic_route_prepend(struct route_graph * rg,
         struct route_graph_point * start) {
     struct route_graph_point * ret = start;
-    struct route_graph_segment * s = start->seg, * s_cmp, * s_prev = NULL;
+    struct route_graph_segment * s, * s_cmp, * s_prev = NULL;
     int num_seg;
     int id_match;
     int is_ambiguous;
@@ -2166,6 +2166,8 @@ static struct route_graph_point * traffic_route_prepend(struct route_graph * rg,
     dbg(lvl_debug, "At %p (%d), start", start, start ? start->value : -1);
     if (!start)
         return NULL;
+
+    s = start->seg;
 
     while (s) {
         num_seg = 0;

--- a/navit/traffic.c
+++ b/navit/traffic.c
@@ -2645,10 +2645,21 @@ static int traffic_message_add_segments(struct traffic_message * this_, struct m
                 if (start_new)
                     p_start = start_new;
             }
-            if (dir > 0)
-                traffic_route_flood_graph(rg, pcoords[1], pcoords[2], p_start);
-            else
-                traffic_route_flood_graph(rg, pcoords[1], pcoords[0], p_start);
+            if (dir > 0) {
+                if (!p_start) {
+                    /* fallback if calculating the first piece of the route failed */
+                    p_start = traffic_route_flood_graph(rg, pcoords[1], pcoords[2], NULL);
+                    start_new = traffic_route_prepend(rg, p_start);
+                } else
+                    traffic_route_flood_graph(rg, pcoords[1], pcoords[2], p_start);
+            } else {
+                if (!p_start) {
+                    /* fallback if calculating the first piece of the route failed */
+                    p_start = traffic_route_flood_graph(rg, pcoords[1], pcoords[0], NULL);
+                    start_new = traffic_route_prepend(rg, p_start);
+                } else
+                    traffic_route_flood_graph(rg, pcoords[1], pcoords[0], p_start);
+            }
             dbg(lvl_debug, "*****checkpoint ADD-4.1.2");
         }
 

--- a/navit/traffic.h
+++ b/navit/traffic.h
@@ -142,8 +142,8 @@ enum event_type {
 	event_restriction_exit_blocked,                    /*!< `q_int` th exit slip road blocked */
 	event_restriction_exit_reopened,                   /*!< Exit reopened */
 	event_restriction_intermittent_closures,           /*!< Intermittent short term closures */
-	event_restriction_lane_blocked,                    /*!< `q:int` lanes blocked */
-	event_restriction_lane_closed,                     /*!< `q:int` lanes closed */
+	event_restriction_lane_blocked,                    /*!< `q_int` lanes blocked */
+	event_restriction_lane_closed,                     /*!< `q_int` lanes closed */
 	event_restriction_open,                            /*!< Open */
 	event_restriction_ramp_blocked,                    /*!< Ramps blocked */
 	event_restriction_ramp_closed,                     /*!< Ramps closed */


### PR DESCRIPTION
Fixes a crash in the traffic module if no matching segments are found for a traffic condition.

For three-point locations (from–via–to), if no segments are found for from–via, then via–to is used.