### PR TITLE
Fix:circleci:Temporarily disable Coverity as it is currently down

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -9,38 +9,38 @@ cmake_opts="-Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOO
 [ -d $BUILD_PATH ] || mkdir -p $BUILD_PATH
 pushd $BUILD_PATH
 
+# Build everything
+cmake ${cmake_opts} ../
+make -j $(nproc --all)
+make package
+
 if [[ "${CIRCLE_PROJECT_USERNAME}" == "navit-gps" && "${CIRCLE_BRANCH}" == "trunk" ]]; then
 	# If we are building the official trunk code, push an update to coverity
-	curl \
-	    -X POST --data "token=${COVERITY_TOKEN}&project=${CIRCLE_PROJECT_USERNAME}" \
-	    -o /tmp/cov-analysis-linux64-${COVERITY_VERSION}.tar.gz -s \
-	    https://scan.coverity.com/download/linux64
+    # Temporarily disabled because Coverity is down.
+    # TODO on the long run, CI should not fail just because the Coverity test did not run,
+    # especially if the test results are not taken into account.
+	#curl \
+	#    -X POST --data "token=${COVERITY_TOKEN}&project=${CIRCLE_PROJECT_USERNAME}" \
+	#    -o /tmp/cov-analysis-linux64-${COVERITY_VERSION}.tar.gz -s \
+	#    https://scan.coverity.com/download/linux64
 
-	tar xfz /tmp/cov-analysis-linux64-${COVERITY_VERSION}.tar.gz --no-same-owner -C /usr/local/share/
-	export PATH=/usr/local/share/cov-analysis-linux64-${COVERITY_VERSION}/bin:$PATH
+	#tar xfz /tmp/cov-analysis-linux64-${COVERITY_VERSION}.tar.gz --no-same-owner -C /usr/local/share/
+	#export PATH=/usr/local/share/cov-analysis-linux64-${COVERITY_VERSION}/bin:$PATH
 
-	cmake ${cmake_opts} ../
-	cov-build --dir cov-int make -j $(nproc --all)
-	tar czvf navit.tgz cov-int
+	#cov-build --dir cov-int make -j $(nproc --all)
+	#tar czvf navit.tgz cov-int
 
-	curl --form token=$COVERITY_TOKEN \
-  --form email=$COVERITY_EMAIL \
-  --form file=@navit.tgz \
-  --form version="${CIRCLE_BRANCH}-$CIRCLE_SHA1" \
-  --form description="${CIRCLE_BRANCH}-$CIRCLE_SHA1" \
-  https://scan.coverity.com/builds?project=$CIRCLE_PROJECT_USERNAME
-
-        make package
+#	curl --form token=$COVERITY_TOKEN \
+#  --form email=$COVERITY_EMAIL \
+#  --form file=@navit.tgz \
+#  --form version="${CIRCLE_BRANCH}-$CIRCLE_SHA1" \
+#  --form description="${CIRCLE_BRANCH}-$CIRCLE_SHA1" \
+#  https://scan.coverity.com/builds?project=$CIRCLE_PROJECT_USERNAME
 
 	# Then update the translation template on launchpad
 	sed -i '/INTEGER/d' po/navit.pot
 	cp po/navit.pot $CIRCLE_ARTIFACTS/
 	curl "https://translations.launchpad.net/navit/${CIRCLE_BRANCH}/+translations-upload" -H "$lp_cookie" -H "Referer: https://translations.launchpad.net/navit/${CIRCLE_BRANCH}/+translations-upload" -F file=@po/navit.pot | grep title
-
-else
-	cmake ${cmake_opts} ../
-	make -j $(nproc --all)
-	make package
 fi
 
 if [[ "$CIRCLE_ARTIFACTS" != "" ]]; then


### PR DESCRIPTION
As Coverity is currently unavailable (see https://community.synopsys.com/s/article/Coverity-Scan-Update), this PR disables the Coverity scan to allow CI to complete successfully.

Right now, automatic merges of trunk into master are impossible if the Coverity scan (i.e. generating the scan and uploading the results) fails, as this will result in CI failing. Conversely, as I understand it, scan results do not affect the outcome of CI. That is:

* If the scan cannot be executed or uploaded, CI fails and no merges into master take place. (Which is the case if Coverity is down.)
* If the scan runs successfully and the upload goes through, but several bugs are found in the code, that doesn’t prevent CI from reporting success and merging the results.

On the long run, we should IMHO choose one of the two:
* Ensure CI fails if the scan finds anything suspicious, or
* Try scanning and uploading the results, possibly generating a warning if that fails, but still report success for CI.

If we go for the first, we might want some kind of override, i.e. being able to manually tell CI to ignore what we deem a false positive.

For the time being, this PR disables Coverity altogether, to allow CI to complete until Coverity is back online.