### PR TITLE
Fix:graphics_qt5:fix overlay handling

### DIFF
--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -90,7 +90,10 @@ void QNavitQuick::paint(QPainter* painter) {
     painter->drawPixmap(graphics_priv->scroll_x, graphics_priv->scroll_y, *graphics_priv->pixmap,
                         boundingRect().x(), boundingRect().y(),
                         boundingRect().width(), boundingRect().height());
-    paintOverlays(painter, graphics_priv, &event);
+    /* disable on root pane disables ALL overlays (for drag of background) */
+    if(!(graphics_priv->disable)) {
+        paintOverlays(painter, graphics_priv, &event);
+    }
 }
 
 void QNavitQuick::keyPressEvent(QKeyEvent* event) {

--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -171,11 +171,14 @@ void QNavitQuick::geometryChanged(const QRectF& newGeometry, const QRectF& oldGe
         return;
     }
     if (graphics_priv->pixmap != NULL) {
-        delete graphics_priv->pixmap;
-        graphics_priv->pixmap = NULL;
+        if((width() != graphics_priv->pixmap->width()) || (height() != graphics_priv->pixmap->height())) {
+            delete graphics_priv->pixmap;
+            graphics_priv->pixmap = NULL;
+        }
     }
-
-    graphics_priv->pixmap = new QPixmap(width(), height());
+    if (graphics_priv->pixmap == NULL) {
+        graphics_priv->pixmap = new QPixmap(width(), height());
+    }
     painter = new QPainter(graphics_priv->pixmap);
     if (painter != NULL) {
         QBrush brush;

--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-//Style with: clang-format -style=WebKit -i
 
 #include <glib.h>
 #ifdef HAVE_UNISTD_H

--- a/navit/graphics/qt5/QNavitQuick.h
+++ b/navit/graphics/qt5/QNavitQuick.h
@@ -27,9 +27,10 @@ class QNavitQuick;
 
 class QNavitQuick : public QQuickPaintedItem {
     Q_OBJECT
-public: QNavitQuick(QQuickItem* parent = 0);
-
+public:
     void paint(QPainter* painter);
+    QNavitQuick(QQuickItem* parent = 0);
+
 
     Q_INVOKABLE void setGraphicContext(GraphicsPriv* gp);
 

--- a/navit/graphics/qt5/QNavitQuick.h
+++ b/navit/graphics/qt5/QNavitQuick.h
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #ifndef QNAVITQUICK_H
 #define QNAVITQUICK_H
@@ -28,8 +27,7 @@ class QNavitQuick;
 
 class QNavitQuick : public QQuickPaintedItem {
     Q_OBJECT
-public:
-    QNavitQuick(QQuickItem* parent = 0);
+public: QNavitQuick(QQuickItem* parent = 0);
 
     void paint(QPainter* painter);
 

--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -95,11 +95,13 @@ void QNavitWidget::paintEvent(QPaintEvent* event) {
 void QNavitWidget::resizeEvent(QResizeEvent* event) {
     QPainter* painter = NULL;
     if (graphics_priv->pixmap != NULL) {
-        delete graphics_priv->pixmap;
-        graphics_priv->pixmap = NULL;
+        if((width() != graphics_priv->pixmap->width()) || (height() != graphics_priv->pixmap->height())) {
+            delete graphics_priv->pixmap;
+            graphics_priv->pixmap = NULL;
     }
-
-    graphics_priv->pixmap = new QPixmap(size());
+    if (graphics_priv->pixmap == NULL) {
+       graphics_priv->pixmap = new QPixmap(size());
+    }
     painter = new QPainter(graphics_priv->pixmap);
     if (painter != NULL) {
         QBrush brush;

--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #include <glib.h>
 #ifdef HAVE_UNISTD_H
@@ -98,149 +97,149 @@ void QNavitWidget::resizeEvent(QResizeEvent* event) {
         if((width() != graphics_priv->pixmap->width()) || (height() != graphics_priv->pixmap->height())) {
             delete graphics_priv->pixmap;
             graphics_priv->pixmap = NULL;
+        }
+        if (graphics_priv->pixmap == NULL) {
+            graphics_priv->pixmap = new QPixmap(size());
+        }
+        painter = new QPainter(graphics_priv->pixmap);
+        if (painter != NULL) {
+            QBrush brush;
+            painter->fillRect(0, 0, width(), height(), brush);
+            delete painter;
+        }
+        dbg(lvl_debug, "size %dx%d", width(), height());
+        dbg(lvl_debug, "pixmap %p %dx%d", graphics_priv->pixmap, graphics_priv->pixmap->width(),
+            graphics_priv->pixmap->height());
+        /* if the root window got resized, tell navit about it */
+        if (graphics_priv->root)
+            resize_callback(graphics_priv, width(), height());
     }
-    if (graphics_priv->pixmap == NULL) {
-       graphics_priv->pixmap = new QPixmap(size());
-    }
-    painter = new QPainter(graphics_priv->pixmap);
-    if (painter != NULL) {
-        QBrush brush;
-        painter->fillRect(0, 0, width(), height(), brush);
-        delete painter;
-    }
-    dbg(lvl_debug, "size %dx%d", width(), height());
-    dbg(lvl_debug, "pixmap %p %dx%d", graphics_priv->pixmap, graphics_priv->pixmap->width(),
-        graphics_priv->pixmap->height());
-    /* if the root window got resized, tell navit about it */
-    if (graphics_priv->root)
-        resize_callback(graphics_priv, width(), height());
-}
 
-void QNavitWidget::mouseEvent(int pressed, QMouseEvent* event) {
-    struct point p;
-    //        dbg(lvl_debug,"enter");
-    p.x = event->x();
-    p.y = event->y();
-    switch (event->button()) {
-    case Qt::LeftButton:
-        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1),
-                                  GINT_TO_POINTER(&p));
-        break;
-    case Qt::MidButton:
-        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2),
-                                  GINT_TO_POINTER(&p));
-        break;
-    case Qt::RightButton:
-        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3),
-                                  GINT_TO_POINTER(&p));
-        break;
-    default:
-        break;
-    }
-}
-
-void QNavitWidget::keyPressEvent(QKeyEvent* event) {
-    dbg(lvl_debug, "enter");
-    char key[2];
-    int keycode;
-    char* text = NULL;
-
-    keycode = event->key();
-    key[0] = '\0';
-    key[1] = '\0';
-    switch (keycode) {
-    case Qt::Key_Up:
-        key[0] = NAVIT_KEY_UP;
-        break;
-    case Qt::Key_Down:
-        key[0] = NAVIT_KEY_DOWN;
-        break;
-    case Qt::Key_Left:
-        key[0] = NAVIT_KEY_LEFT;
-        break;
-    case Qt::Key_Right:
-        key[0] = NAVIT_KEY_RIGHT;
-        break;
-    case Qt::Key_Backspace:
-        key[0] = NAVIT_KEY_BACKSPACE;
-        break;
-    case Qt::Key_Tab:
-        key[0] = NAVIT_KEY_TAB;
-        break;
-    case Qt::Key_Delete:
-        key[0] = NAVIT_KEY_DELETE;
-        break;
-    case Qt::Key_Escape:
-        key[0] = NAVIT_KEY_BACK;
-        break;
-    case Qt::Key_Return:
-    case Qt::Key_Enter:
-        key[0] = NAVIT_KEY_RETURN;
-        break;
-    case Qt::Key_ZoomIn:
-        key[0] = NAVIT_KEY_ZOOM_IN;
-        break;
-    case Qt::Key_ZoomOut:
-        key[0] = NAVIT_KEY_ZOOM_OUT;
-        break;
-    case Qt::Key_PageUp:
-        key[0] = NAVIT_KEY_PAGE_UP;
-        break;
-    case Qt::Key_PageDown:
-        key[0] = NAVIT_KEY_PAGE_DOWN;
-        break;
-    default:
-        QString str = event->text();
-        if ((str != NULL) && (str.size() != 0)) {
-            text = str.toUtf8().data();
+    void QNavitWidget::mouseEvent(int pressed, QMouseEvent* event) {
+        struct point p;
+        //        dbg(lvl_debug,"enter");
+        p.x = event->x();
+        p.y = event->y();
+        switch (event->button()) {
+        case Qt::LeftButton:
+            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1),
+                                      GINT_TO_POINTER(&p));
+            break;
+        case Qt::MidButton:
+            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2),
+                                      GINT_TO_POINTER(&p));
+            break;
+        case Qt::RightButton:
+            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3),
+                                      GINT_TO_POINTER(&p));
+            break;
+        default:
+            break;
         }
     }
-    if (text != NULL)
-        callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)text);
-    else if (key[0])
-        callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)key);
-    else
-        dbg(lvl_debug, "keyval 0x%x", keycode);
-}
 
-void QNavitWidget::mousePressEvent(QMouseEvent* event) {
-    //        dbg(lvl_debug,"enter");
-    mouseEvent(1, event);
-}
+    void QNavitWidget::keyPressEvent(QKeyEvent* event) {
+        dbg(lvl_debug, "enter");
+        char key[2];
+        int keycode;
+        char* text = NULL;
 
-void QNavitWidget::mouseReleaseEvent(QMouseEvent* event) {
-    //        dbg(lvl_debug,"enter");
-    mouseEvent(0, event);
-}
-
-void QNavitWidget::mouseMoveEvent(QMouseEvent* event) {
-    struct point p;
-    //        dbg(lvl_debug,"enter");
-    p.x = event->x();
-    p.y = event->y();
-    callback_list_call_attr_1(graphics_priv->callbacks, attr_motion, (void*)&p);
-}
-
-void QNavitWidget::wheelEvent(QWheelEvent* event) {
-    struct point p;
-    int button;
-    dbg(lvl_debug, "enter");
-    p.x = event->x(); // xy-coordinates of the mouse pointer
-    p.y = event->y();
-
-    if (event->delta() > 0) // wheel movement away from the person
-        button = 4;
-    else if (event->delta() < 0) // wheel movement towards the person
-        button = 5;
-    else
-        button = -1;
-
-    if (button != -1) {
-        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button),
-                                  GINT_TO_POINTER(&p));
-        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button),
-                                  GINT_TO_POINTER(&p));
+        keycode = event->key();
+        key[0] = '\0';
+        key[1] = '\0';
+        switch (keycode) {
+        case Qt::Key_Up:
+            key[0] = NAVIT_KEY_UP;
+            break;
+        case Qt::Key_Down:
+            key[0] = NAVIT_KEY_DOWN;
+            break;
+        case Qt::Key_Left:
+            key[0] = NAVIT_KEY_LEFT;
+            break;
+        case Qt::Key_Right:
+            key[0] = NAVIT_KEY_RIGHT;
+            break;
+        case Qt::Key_Backspace:
+            key[0] = NAVIT_KEY_BACKSPACE;
+            break;
+        case Qt::Key_Tab:
+            key[0] = NAVIT_KEY_TAB;
+            break;
+        case Qt::Key_Delete:
+            key[0] = NAVIT_KEY_DELETE;
+            break;
+        case Qt::Key_Escape:
+            key[0] = NAVIT_KEY_BACK;
+            break;
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+            key[0] = NAVIT_KEY_RETURN;
+            break;
+        case Qt::Key_ZoomIn:
+            key[0] = NAVIT_KEY_ZOOM_IN;
+            break;
+        case Qt::Key_ZoomOut:
+            key[0] = NAVIT_KEY_ZOOM_OUT;
+            break;
+        case Qt::Key_PageUp:
+            key[0] = NAVIT_KEY_PAGE_UP;
+            break;
+        case Qt::Key_PageDown:
+            key[0] = NAVIT_KEY_PAGE_DOWN;
+            break;
+        default:
+            QString str = event->text();
+            if ((str != NULL) && (str.size() != 0)) {
+                text = str.toUtf8().data();
+            }
+        }
+        if (text != NULL)
+            callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)text);
+        else if (key[0])
+            callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)key);
+        else
+            dbg(lvl_debug, "keyval 0x%x", keycode);
     }
 
-    event->accept();
-}
+    void QNavitWidget::mousePressEvent(QMouseEvent* event) {
+        //        dbg(lvl_debug,"enter");
+        mouseEvent(1, event);
+    }
+
+    void QNavitWidget::mouseReleaseEvent(QMouseEvent* event) {
+        //        dbg(lvl_debug,"enter");
+        mouseEvent(0, event);
+    }
+
+    void QNavitWidget::mouseMoveEvent(QMouseEvent* event) {
+        struct point p;
+        //        dbg(lvl_debug,"enter");
+        p.x = event->x();
+        p.y = event->y();
+        callback_list_call_attr_1(graphics_priv->callbacks, attr_motion, (void*)&p);
+    }
+
+    void QNavitWidget::wheelEvent(QWheelEvent* event) {
+        struct point p;
+        int button;
+        dbg(lvl_debug, "enter");
+        p.x = event->x(); // xy-coordinates of the mouse pointer
+        p.y = event->y();
+
+        if (event->delta() > 0) // wheel movement away from the person
+            button = 4;
+        else if (event->delta() < 0) // wheel movement towards the person
+            button = 5;
+        else
+            button = -1;
+
+        if (button != -1) {
+            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button),
+                                      GINT_TO_POINTER(&p));
+            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button),
+                                      GINT_TO_POINTER(&p));
+        }
+
+        event->accept();
+    }

--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -88,7 +88,10 @@ void QNavitWidget::paintEvent(QPaintEvent* event) {
     painter.drawPixmap(event->rect().x(), event->rect().y(), *graphics_priv->pixmap,
                        event->rect().x() - graphics_priv->scroll_x, event->rect().y() - graphics_priv->scroll_y,
                        event->rect().width(), event->rect().height());
-    paintOverlays(&painter, graphics_priv, event);
+    /* disable on root pane disables ALL overlays (for drag of background) */
+    if(!(graphics_priv->disable)) {
+        paintOverlays(&painter, graphics_priv, event);
+    };
 }
 
 void QNavitWidget::resizeEvent(QResizeEvent* event) {
@@ -98,148 +101,149 @@ void QNavitWidget::resizeEvent(QResizeEvent* event) {
             delete graphics_priv->pixmap;
             graphics_priv->pixmap = NULL;
         }
-        if (graphics_priv->pixmap == NULL) {
-            graphics_priv->pixmap = new QPixmap(size());
+    }
+    if (graphics_priv->pixmap == NULL) {
+        graphics_priv->pixmap = new QPixmap(size());
+    }
+    painter = new QPainter(graphics_priv->pixmap);
+    if (painter != NULL) {
+        QBrush brush;
+        painter->fillRect(0, 0, width(), height(), brush);
+        delete painter;
+    }
+    dbg(lvl_debug, "size %dx%d", width(), height());
+    dbg(lvl_debug, "pixmap %p %dx%d", graphics_priv->pixmap, graphics_priv->pixmap->width(),
+        graphics_priv->pixmap->height());
+    /* if the root window got resized, tell navit about it */
+    if (graphics_priv->root)
+        resize_callback(graphics_priv, width(), height());
+}
+
+void QNavitWidget::mouseEvent(int pressed, QMouseEvent* event) {
+    struct point p;
+    //        dbg(lvl_debug,"enter");
+    p.x = event->x();
+    p.y = event->y();
+    switch (event->button()) {
+    case Qt::LeftButton:
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1),
+                                  GINT_TO_POINTER(&p));
+        break;
+    case Qt::MidButton:
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2),
+                                  GINT_TO_POINTER(&p));
+        break;
+    case Qt::RightButton:
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3),
+                                  GINT_TO_POINTER(&p));
+        break;
+    default:
+        break;
+    }
+}
+
+void QNavitWidget::keyPressEvent(QKeyEvent* event) {
+    dbg(lvl_debug, "enter");
+    char key[2];
+    int keycode;
+    char* text = NULL;
+
+    keycode = event->key();
+    key[0] = '\0';
+    key[1] = '\0';
+    switch (keycode) {
+    case Qt::Key_Up:
+        key[0] = NAVIT_KEY_UP;
+        break;
+    case Qt::Key_Down:
+        key[0] = NAVIT_KEY_DOWN;
+        break;
+    case Qt::Key_Left:
+        key[0] = NAVIT_KEY_LEFT;
+        break;
+    case Qt::Key_Right:
+        key[0] = NAVIT_KEY_RIGHT;
+        break;
+    case Qt::Key_Backspace:
+        key[0] = NAVIT_KEY_BACKSPACE;
+        break;
+    case Qt::Key_Tab:
+        key[0] = NAVIT_KEY_TAB;
+        break;
+    case Qt::Key_Delete:
+        key[0] = NAVIT_KEY_DELETE;
+        break;
+    case Qt::Key_Escape:
+        key[0] = NAVIT_KEY_BACK;
+        break;
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+        key[0] = NAVIT_KEY_RETURN;
+        break;
+    case Qt::Key_ZoomIn:
+        key[0] = NAVIT_KEY_ZOOM_IN;
+        break;
+    case Qt::Key_ZoomOut:
+        key[0] = NAVIT_KEY_ZOOM_OUT;
+        break;
+    case Qt::Key_PageUp:
+        key[0] = NAVIT_KEY_PAGE_UP;
+        break;
+    case Qt::Key_PageDown:
+        key[0] = NAVIT_KEY_PAGE_DOWN;
+        break;
+    default:
+        QString str = event->text();
+        if ((str != NULL) && (str.size() != 0)) {
+            text = str.toUtf8().data();
         }
-        painter = new QPainter(graphics_priv->pixmap);
-        if (painter != NULL) {
-            QBrush brush;
-            painter->fillRect(0, 0, width(), height(), brush);
-            delete painter;
-        }
-        dbg(lvl_debug, "size %dx%d", width(), height());
-        dbg(lvl_debug, "pixmap %p %dx%d", graphics_priv->pixmap, graphics_priv->pixmap->width(),
-            graphics_priv->pixmap->height());
-        /* if the root window got resized, tell navit about it */
-        if (graphics_priv->root)
-            resize_callback(graphics_priv, width(), height());
+    }
+    if (text != NULL)
+        callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)text);
+    else if (key[0])
+        callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)key);
+    else
+        dbg(lvl_debug, "keyval 0x%x", keycode);
+}
+
+void QNavitWidget::mousePressEvent(QMouseEvent* event) {
+    //        dbg(lvl_debug,"enter");
+    mouseEvent(1, event);
+}
+
+void QNavitWidget::mouseReleaseEvent(QMouseEvent* event) {
+    //        dbg(lvl_debug,"enter");
+    mouseEvent(0, event);
+}
+
+void QNavitWidget::mouseMoveEvent(QMouseEvent* event) {
+    struct point p;
+    //        dbg(lvl_debug,"enter");
+    p.x = event->x();
+    p.y = event->y();
+    callback_list_call_attr_1(graphics_priv->callbacks, attr_motion, (void*)&p);
+}
+
+void QNavitWidget::wheelEvent(QWheelEvent* event) {
+    struct point p;
+    int button;
+    dbg(lvl_debug, "enter");
+    p.x = event->x(); // xy-coordinates of the mouse pointer
+    p.y = event->y();
+
+    if (event->delta() > 0) // wheel movement away from the person
+        button = 4;
+    else if (event->delta() < 0) // wheel movement towards the person
+        button = 5;
+    else
+        button = -1;
+
+    if (button != -1) {
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button),
+                                  GINT_TO_POINTER(&p));
+        callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button),
+                                  GINT_TO_POINTER(&p));
     }
 
-    void QNavitWidget::mouseEvent(int pressed, QMouseEvent* event) {
-        struct point p;
-        //        dbg(lvl_debug,"enter");
-        p.x = event->x();
-        p.y = event->y();
-        switch (event->button()) {
-        case Qt::LeftButton:
-            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(1),
-                                      GINT_TO_POINTER(&p));
-            break;
-        case Qt::MidButton:
-            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(2),
-                                      GINT_TO_POINTER(&p));
-            break;
-        case Qt::RightButton:
-            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(pressed), GINT_TO_POINTER(3),
-                                      GINT_TO_POINTER(&p));
-            break;
-        default:
-            break;
-        }
-    }
-
-    void QNavitWidget::keyPressEvent(QKeyEvent* event) {
-        dbg(lvl_debug, "enter");
-        char key[2];
-        int keycode;
-        char* text = NULL;
-
-        keycode = event->key();
-        key[0] = '\0';
-        key[1] = '\0';
-        switch (keycode) {
-        case Qt::Key_Up:
-            key[0] = NAVIT_KEY_UP;
-            break;
-        case Qt::Key_Down:
-            key[0] = NAVIT_KEY_DOWN;
-            break;
-        case Qt::Key_Left:
-            key[0] = NAVIT_KEY_LEFT;
-            break;
-        case Qt::Key_Right:
-            key[0] = NAVIT_KEY_RIGHT;
-            break;
-        case Qt::Key_Backspace:
-            key[0] = NAVIT_KEY_BACKSPACE;
-            break;
-        case Qt::Key_Tab:
-            key[0] = NAVIT_KEY_TAB;
-            break;
-        case Qt::Key_Delete:
-            key[0] = NAVIT_KEY_DELETE;
-            break;
-        case Qt::Key_Escape:
-            key[0] = NAVIT_KEY_BACK;
-            break;
-        case Qt::Key_Return:
-        case Qt::Key_Enter:
-            key[0] = NAVIT_KEY_RETURN;
-            break;
-        case Qt::Key_ZoomIn:
-            key[0] = NAVIT_KEY_ZOOM_IN;
-            break;
-        case Qt::Key_ZoomOut:
-            key[0] = NAVIT_KEY_ZOOM_OUT;
-            break;
-        case Qt::Key_PageUp:
-            key[0] = NAVIT_KEY_PAGE_UP;
-            break;
-        case Qt::Key_PageDown:
-            key[0] = NAVIT_KEY_PAGE_DOWN;
-            break;
-        default:
-            QString str = event->text();
-            if ((str != NULL) && (str.size() != 0)) {
-                text = str.toUtf8().data();
-            }
-        }
-        if (text != NULL)
-            callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)text);
-        else if (key[0])
-            callback_list_call_attr_1(graphics_priv->callbacks, attr_keypress, (void*)key);
-        else
-            dbg(lvl_debug, "keyval 0x%x", keycode);
-    }
-
-    void QNavitWidget::mousePressEvent(QMouseEvent* event) {
-        //        dbg(lvl_debug,"enter");
-        mouseEvent(1, event);
-    }
-
-    void QNavitWidget::mouseReleaseEvent(QMouseEvent* event) {
-        //        dbg(lvl_debug,"enter");
-        mouseEvent(0, event);
-    }
-
-    void QNavitWidget::mouseMoveEvent(QMouseEvent* event) {
-        struct point p;
-        //        dbg(lvl_debug,"enter");
-        p.x = event->x();
-        p.y = event->y();
-        callback_list_call_attr_1(graphics_priv->callbacks, attr_motion, (void*)&p);
-    }
-
-    void QNavitWidget::wheelEvent(QWheelEvent* event) {
-        struct point p;
-        int button;
-        dbg(lvl_debug, "enter");
-        p.x = event->x(); // xy-coordinates of the mouse pointer
-        p.y = event->y();
-
-        if (event->delta() > 0) // wheel movement away from the person
-            button = 4;
-        else if (event->delta() < 0) // wheel movement towards the person
-            button = 5;
-        else
-            button = -1;
-
-        if (button != -1) {
-            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(1), GINT_TO_POINTER(button),
-                                      GINT_TO_POINTER(&p));
-            callback_list_call_attr_3(graphics_priv->callbacks, attr_button, GINT_TO_POINTER(0), GINT_TO_POINTER(button),
-                                      GINT_TO_POINTER(&p));
-        }
-
-        event->accept();
-    }
+    event->accept();
+}

--- a/navit/graphics/qt5/QNavitWidget.h
+++ b/navit/graphics/qt5/QNavitWidget.h
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #ifndef __QNavitWidget_h
 #define __QNavitWidget_h
@@ -30,10 +29,9 @@ class QNavitWidget;
 
 class QNavitWidget : public QWidget {
     Q_OBJECT
-public:
-    QNavitWidget(struct graphics_priv* my_graphics_priv,
-        QWidget* parent,
-        Qt::WindowFlags flags);
+public: QNavitWidget(struct graphics_priv* my_graphics_priv,
+                         QWidget* parent,
+                         Qt::WindowFlags flags);
 
 protected:
     virtual bool event(QEvent* event);

--- a/navit/graphics/qt5/event_qt5.cpp
+++ b/navit/graphics/qt5/event_qt5.cpp
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #include <glib.h>
 #include <stdio.h>

--- a/navit/graphics/qt5/event_qt5.h
+++ b/navit/graphics/qt5/event_qt5.h
@@ -16,15 +16,13 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #include <QObject>
 #include <glib.h>
 
 class qt5_navit_timer : public QObject {
     Q_OBJECT
-public:
-    qt5_navit_timer(QObject* parent = 0);
+public: qt5_navit_timer(QObject* parent = 0);
     GHashTable* timer_type;
     GHashTable* timer_callback;
     GHashTable* watches;

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -770,6 +770,16 @@ static void get_text_bbox(struct graphics_priv* gr, struct graphics_font_priv* f
 static void overlay_disable(struct graphics_priv* gr, int disable) {
     //dbg(lvl_error,"enter gr=%p, %d", gr, disable);
     gr->disable = disable;
+#if USE_QWIDGET
+    /* call repaint on widget */
+    if (gr->widget != NULL)
+        gr->widget->repaint(gr->x, gr->y, gr->pixmap->width(), gr->pixmap->height());
+#endif
+#if USE_QML
+    if (gr->GPriv != NULL)
+        gr->GPriv->emit_update();
+
+#endif
 }
 
 static void overlay_resize(struct graphics_priv* gr, struct point* p, int w, int h, int wraparound) {
@@ -787,6 +797,16 @@ static void overlay_resize(struct graphics_priv* gr, struct point* p, int w, int
     }
     if (gr->painter != NULL)
         gr->painter = new QPainter(gr->pixmap);
+#if USE_QWIDGET
+    /* call repaint on widget */
+    if (gr->widget != NULL)
+        gr->widget->repaint(gr->x, gr->y, gr->pixmap->width(), gr->pixmap->height());
+#endif
+#if USE_QML
+    if (gr->GPriv != NULL)
+        gr->GPriv->emit_update();
+
+#endif
 }
 
 static struct graphics_methods graphics_methods = {

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #include <glib.h>
 #ifdef HAVE_UNISTD_H
@@ -180,7 +179,8 @@ static const char* fontfamilies[] = {
  *
  * Allocates a font handle and returnes filled interface stucture
  */
-static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct graphics_font_methods* meth, char* font, int size, int flags) {
+static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct graphics_font_methods* meth, char* font,
+        int size, int flags) {
     int a = 0;
     struct graphics_font_priv* font_priv;
     dbg(lvl_debug, "enter (font %s, %d, 0x%x)", font, size, flags);
@@ -295,7 +295,8 @@ struct graphics_image_methods image_methods = {
     image_destroy
 };
 
-static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* path, int* w, int* h, struct point* hot, int rotation) {
+static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct graphics_image_methods* meth, char* path,
+        int* w, int* h, struct point* hot, int rotation) {
     struct graphics_image_priv* image_priv;
     //        dbg(lvl_debug,"enter %s, %d %d", path, *w, *h);
     if (path[0] == 0) {
@@ -448,7 +449,8 @@ static void draw_circle(struct graphics_priv* gr, struct graphics_gc_priv* gc, s
  *
  * Renders given text on gr surface. Draws nice contrast outline around text.
  */
-static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics_gc_priv* bg, struct graphics_font_priv* font, char* text, struct point* p, int dx, int dy) {
+static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct graphics_gc_priv* bg,
+                      struct graphics_font_priv* font, char* text, struct point* p, int dx, int dy) {
     dbg(lvl_debug, "enter gc=%p, fg=%p, bg=%p pos(%d,%d) d(%d, %d) %s", gr, fg, bg, p->x, p->y, dx, dy, text);
     QPainter* painter = gr->painter;
     if (painter == NULL)
@@ -539,7 +541,8 @@ static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, str
 #endif
 }
 
-static void draw_image(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct point* p, struct graphics_image_priv* img) {
+static void draw_image(struct graphics_priv* gr, struct graphics_gc_priv* fg, struct point* p,
+                       struct graphics_image_priv* img) {
     //        dbg(lvl_debug,"enter");
     if (gr->painter != NULL)
         gr->painter->drawPixmap(p->x, p->y, *img->pixmap);
@@ -639,7 +642,8 @@ static void draw_mode(struct graphics_priv* gr, enum draw_mode_num mode) {
     }
 }
 
-static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p, int w, int h, int wraparound);
+static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p,
+        int w, int h, int wraparound);
 
 void resize_callback(struct graphics_priv* gr, int w, int h) {
     //        dbg(lvl_debug,"enter (%d, %d)", w, h);
@@ -729,7 +733,8 @@ static void image_free(struct graphics_priv* gr, struct graphics_image_priv* pri
  *
  * Calculates the bounding box around the given text.
  */
-static void get_text_bbox(struct graphics_priv* gr, struct graphics_font_priv* font, char* text, int dx, int dy, struct point* ret, int estimate) {
+static void get_text_bbox(struct graphics_priv* gr, struct graphics_font_priv* font, char* text, int dx, int dy,
+                          struct point* ret, int estimate) {
     int i;
     struct point pt;
     QString tmp = QString::fromUtf8(text);
@@ -815,7 +820,8 @@ static struct graphics_methods graphics_methods = {
 };
 
 /* create new graphics context on given context */
-static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p, int w, int h, int wraparound) {
+static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphics_methods* meth, struct point* p,
+        int w, int h, int wraparound) {
     struct graphics_priv* graphics_priv = NULL;
     graphics_priv = g_new0(struct graphics_priv, 1);
     *meth = graphics_methods;
@@ -859,7 +865,8 @@ static struct graphics_priv* overlay_new(struct graphics_priv* gr, struct graphi
 }
 
 /* create application and initial graphics context */
-static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics_methods* meth, struct attr** attrs, struct callback_list* cbl) {
+static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics_methods* meth, struct attr** attrs,
+        struct callback_list* cbl) {
     struct graphics_priv* graphics_priv = NULL;
     struct attr* event_loop_system = NULL;
     struct attr* platform = NULL;

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -768,15 +768,8 @@ static void get_text_bbox(struct graphics_priv* gr, struct graphics_font_priv* f
 }
 
 static void overlay_disable(struct graphics_priv* gr, int disable) {
-    GHashTableIter iter;
-    struct graphics_priv *key, *value;
-    //        dbg(lvl_debug,"enter gr=%p, %d", gr, disable);
-
-    g_hash_table_iter_init(&iter, gr->overlays);
-    while (g_hash_table_iter_next(&iter, (void**)&key, (void**)&value)) {
-        /* disable or enable all overlays of this pane */
-        value->disable = disable;
-    }
+    //dbg(lvl_error,"enter gr=%p, %d", gr, disable);
+    gr->disable = disable;
 }
 
 static void overlay_resize(struct graphics_priv* gr, struct point* p, int w, int h, int wraparound) {

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -304,7 +304,11 @@ static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct gr
     }
     QString key(path);
     QString renderer_key(key);
-    QString extension = key.right(key.lastIndexOf("."));
+    int index = key.lastIndexOf(".");
+    QString extension;
+    if(index > 0) {
+        extension = key.right(index);
+    }
     QFile imagefile(key);
     if (!imagefile.exists()) {
         /* file doesn't exit. Either navit wants us to guess file name by
@@ -348,7 +352,7 @@ static struct graphics_image_priv* image_new(struct graphics_priv* gr, struct gr
     }
 
     /* check if we got image */
-    if (image_priv->pixmap->isNull()) {
+    if ((image_priv->pixmap == NULL) || (image_priv->pixmap->isNull())) {
         g_free(image_priv);
         return NULL;
     } else {
@@ -771,15 +775,18 @@ static void overlay_disable(struct graphics_priv* gr, int disable) {
 }
 
 static void overlay_resize(struct graphics_priv* gr, struct point* p, int w, int h, int wraparound) {
-    //        dbg(lvl_debug,"enter");
+    //        dbg(lvl_debug,"enter %d %d %d %d %d", p->x, p->y, w, h, wraparound);
     gr->x = p->x;
     gr->y = p->y;
     if (gr->painter != NULL) {
         delete (gr->painter);
     }
-    delete (gr->pixmap);
-    gr->pixmap = new QPixmap(w, h);
-    gr->pixmap->fill(Qt::transparent);
+    /* replacing the pixmap clears the content. Only neccesary if size actually changes */
+    if((gr->pixmap->height() != h) || (gr->pixmap->width() != w)) {
+        delete (gr->pixmap);
+        gr->pixmap = new QPixmap(w, h);
+        gr->pixmap->fill(Qt::transparent);
+    }
     if (gr->painter != NULL)
         gr->painter = new QPainter(gr->pixmap);
 }

--- a/navit/graphics/qt5/graphics_qt5.h
+++ b/navit/graphics/qt5/graphics_qt5.h
@@ -16,7 +16,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
-// style with: clang-format -style=WebKit -i *
 
 #ifndef __graphics_qt_h
 #define __graphics_qt_h
@@ -62,8 +61,7 @@ struct graphics_priv;
 #if USE_QML
 class GraphicsPriv : public QObject {
     Q_OBJECT
-public:
-    GraphicsPriv(struct graphics_priv* gp);
+public: GraphicsPriv(struct graphics_priv* gp);
     ~GraphicsPriv();
     void emit_update();
 


### PR DESCRIPTION
Do not clear overlay contents if resize is called for them, but the actual geometry doesn't change.
This happens on resize if the overlays are repositioned. Now OSD's do not loose elements any more.

Apply astyle to comply with coding style and to tame CI
