### PR TITLE
Enable traffic plugins by default

### DIFF
--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -185,6 +185,9 @@ Waypoint</text></img>
 		<osd enabled="no" type="button" x="-96" y="-96" command="zoom_in()" src="zoom_in.png"/>
 		<osd enabled="no" type="button" x="0" y="-96" command="zoom_out()" src="zoom_out.png"/>
 
+		<!-- Traffic -->
+		<traffic type="null"/>
+
 		<!-- Vehicle with GPS enabled for gpsd on unix -->
 		<vehicle name="Local GPS" profilename="car" enabled="yes" active="1" source="gpsd://localhost" gpsd_query="w+xj">
 		<!-- Vehicle with GPS enabled for direct communication on windows. Remove the line above if you use this. -->

--- a/navit/xslt/android.xslt
+++ b/navit/xslt/android.xslt
@@ -44,6 +44,9 @@
 			&lt;img src=''gui_rules'' onclick=''navit.graphics.set_map_location();''>&lt;text>Set map location&lt;/text>&lt;/img>
 			&lt;img src=''gui_rules'' onclick=''navit.graphics.backup_restore_dialog();''>&lt;text>Backup / Restore&lt;/text>&lt;/img>')"/>
    </xsl:template>
+   <xsl:template match="/config/navit/traffic">
+      <traffic type="traff_android"/>
+   </xsl:template>
 
    <xsl:template match="/config/navit[1]">
       <xsl:copy>


### PR DESCRIPTION
This enables the traffic plugin by default on all platforms via the XML config file.

On Android, the `traff_android` plugin is used and any traffic updates received via TraFF broadcasts are processed.

On all other platforms, the `null` plugin is used. This plugin enables traffic message processing but will never supply any messages. On Linux this allows injection of TraFF messages via dbus (while this functionality could be [ab]used for a traffic supplier, it is intended as a test interface).

Users with a custom navit.xml will not be affected by these changes until they adapt their configuration accordingly.

So far these plugins have been tested on Linux and Android. Tests on other platforms would be welcome (though I expect regressions to be quite unlikely here).