### PR TITLE
Android: Do not reinitialize everything when the activity is recreated

### DIFF
--- a/navit/android.h
+++ b/navit/android.h
@@ -1,6 +1,7 @@
 #include <jni.h>
 extern JNIEnv *jnienv;
 extern jobject *android_activity;
+extern jobject *android_application;
 extern int android_version;
 int android_find_class_global(char *name, jclass *ret);
 int android_find_method(jclass class, char *name, char *args, jmethodID *ret);

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -23,6 +23,7 @@ import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Application;
 import android.app.Dialog;
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -71,6 +72,7 @@ import java.util.regex.Pattern;
 
 public class Navit extends Activity {
 
+    protected static NavitGraphics     graphics                        = null;
     private NavitDialogs               dialogs;
     private PowerManager.WakeLock      wl;
     private NavitActivityResult[]      ActivityResults;
@@ -97,7 +99,7 @@ public class Navit extends Activity {
     Boolean                            isFullscreen                    = false;
     private static final int           MY_PERMISSIONS_REQUEST_ALL      = 101;
     private static NotificationManager nm;
-    private static Navit               navit;
+    private static Navit               navit                           = null;
 
     public static Navit getInstance() {
         return navit;
@@ -316,6 +318,9 @@ public class Navit extends Activity {
     /** Called when the activity is first created. */
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        /* Whether this is the first launch of Navit (as opposed to the activity being recreated) */
+        boolean isLaunch = (navit == null);
+
         super.onCreate(savedInstanceState);
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.HONEYCOMB) {
             this.requestWindowFeature(Window.FEATURE_NO_TITLE);
@@ -442,8 +447,10 @@ public class Navit extends Activity {
         }
 
         Log.d(TAG, "android.os.Build.VERSION.SDK_INT=" + Integer.valueOf(android.os.Build.VERSION.SDK));
-        NavitMain(this, NavitLanguage, Integer.valueOf(android.os.Build.VERSION.SDK), my_display_density,
-                NAVIT_DATA_DIR + "/bin/navit", map_filename_path);
+        NavitMain(this, getApplication(), NavitLanguage, Integer.valueOf(android.os.Build.VERSION.SDK), my_display_density,
+                NAVIT_DATA_DIR + "/bin/navit", map_filename_path, isLaunch);
+        if (graphics != null)
+            graphics.setActivity(this);
 
         showInfos();
 
@@ -833,7 +840,8 @@ public class Navit extends Activity {
                 }
                 break;
             default :
-                ActivityResults[requestCode].onActivityResult(requestCode, resultCode, data);
+                if (ActivityResults[requestCode] != null)
+                    ActivityResults[requestCode].onActivityResult(requestCode, resultCode, data);
                 break;
         }
     }
@@ -908,8 +916,8 @@ public class Navit extends Activity {
         NavitDestroy();
     }
 
-    public native void NavitMain(Navit x, String lang, int version, String display_density_string, String path,
-            String path2);
+    public native void NavitMain(Navit x, Application application, String lang, int version,
+            String display_density_string, String path, String path2, boolean isLaunch);
 
     public native void NavitDestroy();
 

--- a/navit/android/src/org/navitproject/navit/NavitGraphics.java
+++ b/navit/android/src/org/navitproject/navit/NavitGraphics.java
@@ -632,6 +632,8 @@ public class NavitGraphics {
      * @param activity The main activity.
      */
     protected void setActivity(final Activity activity) {
+        if (Navit.graphics == null)
+            Navit.graphics = this;
         this.activity = (Navit) activity;
         view = new NavitView(activity);
         view.setClickable(false);

--- a/navit/android/src/org/navitproject/navit/NavitGraphics.java
+++ b/navit/android/src/org/navitproject/navit/NavitGraphics.java
@@ -78,7 +78,7 @@ public class NavitGraphics {
     private SystemBarTintView              bottomTintView;
     private FrameLayout                    frameLayout;
     private RelativeLayout                 relativelayout;
-    private NavitCamera                    camera;
+    private NavitCamera                    camera                          = null;
     private Navit                          activity;
     private static Boolean                 in_map = false;
     // for menu key
@@ -106,7 +106,28 @@ public class NavitGraphics {
     private void SetCamera(int use_camera) {
         if (use_camera != 0 && camera == null) {
             // activity.requestWindowFeature(Window.FEATURE_NO_TITLE);
-            camera = new NavitCamera(activity);
+            addCamera();
+            addCameraView();
+        }
+    }
+
+    /**
+     * @brief Adds a camera.
+     *
+     * This method does not create the view for the camera. This must be done separately by calling
+     * {@link #addCameraView()}.
+     */
+    private void addCamera() {
+        camera = new NavitCamera(activity);
+    }
+
+    /**
+     * @brief Adds a view for the camera.
+     *
+     * If {@link #camera} is null, this method is a no-op.
+     */
+    private void addCameraView() {
+        if (camera != null) {
             relativelayout.addView(camera);
             relativelayout.bringChildToFront(view);
         }
@@ -588,37 +609,10 @@ public class NavitGraphics {
     public NavitGraphics(final Activity activity, NavitGraphics parent, int x, int y, int w, int h,
             int wraparound, int use_camera) {
         if (parent == null) {
-            this.activity = (Navit) activity;
-            view = new NavitView(activity);
-            //activity.registerForContextMenu(view);
-            view.setClickable(false);
-            view.setFocusable(true);
-            view.setFocusableInTouchMode(true);
-            view.setKeepScreenOn(true);
-            relativelayout = new RelativeLayout(activity);
             if (use_camera != 0) {
-                SetCamera(use_camera);
+                addCamera();
             }
-            relativelayout.addView(view);
-
-            /* The navigational and status bar tinting code is meaningful only on API19+ */
-            if (Build.VERSION.SDK_INT >= 19) {
-                frameLayout = new FrameLayout(activity);
-                frameLayout.addView(relativelayout);
-                leftTintView = new SystemBarTintView(activity);
-                rightTintView = new SystemBarTintView(activity);
-                topTintView = new SystemBarTintView(activity);
-                bottomTintView = new SystemBarTintView(activity);
-                frameLayout.addView(leftTintView);
-                frameLayout.addView(rightTintView);
-                frameLayout.addView(topTintView);
-                frameLayout.addView(bottomTintView);
-                activity.setContentView(frameLayout);
-            } else {
-                activity.setContentView(relativelayout);
-            }
-
-            view.requestFocus();
+            setActivity(activity);
         } else {
             draw_bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
             bitmap_w = w;
@@ -630,6 +624,42 @@ public class NavitGraphics {
             parent.overlays.add(this);
         }
         parent_graphics = parent;
+    }
+
+    /**
+     * @brief Sets up the main activity.
+     *
+     * @param activity The main activity.
+     */
+    protected void setActivity(final Activity activity) {
+        this.activity = (Navit) activity;
+        view = new NavitView(activity);
+        view.setClickable(false);
+        view.setFocusable(true);
+        view.setFocusableInTouchMode(true);
+        view.setKeepScreenOn(true);
+        relativelayout = new RelativeLayout(activity);
+        addCameraView();
+        relativelayout.addView(view);
+
+        /* The navigational and status bar tinting code is meaningful only on API19+ */
+        if (Build.VERSION.SDK_INT >= 19) {
+            frameLayout = new FrameLayout(activity);
+            frameLayout.addView(relativelayout);
+            leftTintView = new SystemBarTintView(activity);
+            rightTintView = new SystemBarTintView(activity);
+            topTintView = new SystemBarTintView(activity);
+            bottomTintView = new SystemBarTintView(activity);
+            frameLayout.addView(leftTintView);
+            frameLayout.addView(rightTintView);
+            frameLayout.addView(topTintView);
+            frameLayout.addView(bottomTintView);
+            activity.setContentView(frameLayout);
+        } else {
+            activity.setContentView(relativelayout);
+        }
+
+        view.requestFocus();
     }
 
     public enum msg_type {

--- a/navit/android/src/org/navitproject/navit/NavitSpeech2.java
+++ b/navit/android/src/org/navitproject/navit/NavitSpeech2.java
@@ -44,7 +44,7 @@ public class NavitSpeech2 implements TextToSpeech.OnInitListener, NavitActivityR
             navit.startActivityForResult(checkIntent, MY_DATA_CHECK_CODE);
         } else {
             Log.e(TAG, "ACTION_CHECK_TTS_DATA not available, assume tts is working");
-            mTts = new TextToSpeech(navit, this);
+            mTts = new TextToSpeech(navit.getApplication(), this);
         }
     }
 
@@ -57,7 +57,7 @@ public class NavitSpeech2 implements TextToSpeech.OnInitListener, NavitActivityR
         if (requestCode == MY_DATA_CHECK_CODE) {
             if (resultCode == TextToSpeech.Engine.CHECK_VOICE_DATA_PASS) {
                 // success, create the TTS instance
-                mTts = new TextToSpeech(navit, this);
+                mTts = new TextToSpeech(navit.getApplication(), this);
             } else {
                 // missing data, ask to install it
                 AlertDialog.Builder builder = new AlertDialog.Builder(navit);

--- a/navit/plugin/pedestrian/pedestrian.c
+++ b/navit/plugin/pedestrian/pedestrian.c
@@ -1223,7 +1223,7 @@ static void pedestrian_navit_init(struct navit *nav) {
         dbg(lvl_debug,"cid=%p",cid);
         if (cid) {
             cb=callback_new_1(callback_cast(android_sensors), nav);
-            navitsensors=(*jnienv)->NewObject(jnienv, navitsensorsclass, cid, android_activity, cb);
+            navitsensors=(*jnienv)->NewObject(jnienv, navitsensorsclass, cid, android_application, cb);
             dbg(lvl_debug,"object=%p",navitsensors);
             if (navitsensors)
                 navitsensors = (*jnienv)->NewGlobalRef(jnienv, navitsensors);

--- a/navit/traffic/traff_android/traffic_traff_android.c
+++ b/navit/traffic/traff_android/traffic_traff_android.c
@@ -122,7 +122,7 @@ static int traffic_traff_android_init(struct traffic_priv * this_) {
         dbg(lvl_error,"no method found");
         return 0; /* exception thrown */
     }
-    this_->NavitTraff=(*jnienv)->NewObject(jnienv, this_->NavitTraffClass, cid, android_activity,
+    this_->NavitTraff=(*jnienv)->NewObject(jnienv, this_->NavitTraffClass, cid, android_application,
                                            (int) this_->cbid);
     dbg(lvl_debug,"result=%p", this_->NavitTraff);
     if (!this_->NavitTraff)

--- a/navit/vehicle/android/vehicle_android.c
+++ b/navit/vehicle/android/vehicle_android.c
@@ -238,8 +238,8 @@ static int vehicle_android_init(struct vehicle_priv *ret) {
         dbg(lvl_error,"no method found");
         return 0; /* exception thrown */
     }
-    dbg(lvl_debug, "at 4 android_activity=%p", android_activity);
-    ret->NavitVehicle=(*jnienv)->NewObject(jnienv, ret->NavitVehicleClass, cid, android_activity,
+    dbg(lvl_debug, "at 4 android_application=%p", android_application);
+    ret->NavitVehicle=(*jnienv)->NewObject(jnienv, ret->NavitVehicleClass, cid, android_application,
                                            (int) ret->pcb, (int) ret->scb, (int) ret->fcb);
     dbg(lvl_debug,"result=%p",ret->NavitVehicle);
     if (!ret->NavitVehicle)


### PR DESCRIPTION
Fixes #750. This significantly improves performance when the window dimensions change (as happens when entering or leaving split-screen mode, or when rotating the device), and also fixes some resource leaks and potentially a race condition.

Developed and tested on Anbox, as well as some brief tests on a real device.