### PR TITLE
Fix:port/Android:Create notification channel on API 26+

### DIFF
--- a/navit/android/res/values/strings.xml
+++ b/navit/android/res/values/strings.xml
@@ -7,6 +7,7 @@
   <string name="cancel">Cancel</string>
 
 	<!-- NOTIFICATION -->
+	<string name="channel_name">Navit</string>
 	<string name="notification_ticker">Navit started</string>
 	<string name="notification_event_default">Navit running</string>
 

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -26,6 +26,7 @@ import android.app.AlertDialog;
 import android.app.Application;
 import android.app.Dialog;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -90,6 +91,7 @@ public class Navit extends Activity {
     private static final int           NavitSelectStorage_id           = 43;
     private static String              NavitLanguage;
     private static Resources            NavitResources                  = null;
+    private static final String        CHANNEL_ID                      = "org.navitproject.navit";
     private static final String        NAVIT_PACKAGE_NAME              = "org.navitproject.navit";
     private static final String        TAG                             = "Navit";
     static String                      map_filename_path               = null;
@@ -118,6 +120,25 @@ public class Navit extends Activity {
         }
     }
 
+    private void createNotificationChannel() {
+        /*
+         * Create the NotificationChannel, but only on API 26+ because
+         * the NotificationChannel class is new and not in the support library
+         */
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = getString(R.string.channel_name);
+            //String description = getString(R.string.channel_description);
+            int importance = NotificationManager.IMPORTANCE_LOW;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            //channel.setDescription(description);
+            /*
+             * Register the channel with the system; you can't change the importance
+             * or other notification behaviors after this
+             */
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
 
     public void removeFileIfExists(String source) {
         File file = new File(source);
@@ -343,10 +364,16 @@ public class Navit extends Activity {
         // NOTIFICATION
         // Setup the status bar notification
         // This notification is removed in the exit() function
+        if (isLaunch)
+            createNotificationChannel();
         nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);  // Grab a handle to the NotificationManager
         PendingIntent appIntent = PendingIntent.getActivity(getApplicationContext(), 0, getIntent(), 0);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
+        Notification.Builder builder;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            builder = new Notification.Builder(getApplicationContext(), CHANNEL_ID);
+        else
+            builder = new Notification.Builder(getApplicationContext());
         builder.setContentIntent(appIntent);
         builder.setAutoCancel(false).setOngoing(true);
         builder.setContentTitle(getTstring(R.string.app_name));

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -369,17 +369,25 @@ public class Navit extends Activity {
         nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);  // Grab a handle to the NotificationManager
         PendingIntent appIntent = PendingIntent.getActivity(getApplicationContext(), 0, getIntent(), 0);
 
-        Notification.Builder builder;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder builder;
             builder = new Notification.Builder(getApplicationContext(), CHANNEL_ID);
-        else
-            builder = new Notification.Builder(getApplicationContext());
-        builder.setContentIntent(appIntent);
-        builder.setAutoCancel(false).setOngoing(true);
-        builder.setContentTitle(getTstring(R.string.app_name));
-        builder.setContentText(getTstring(R.string.notification_event_default));
-        builder.setSmallIcon(R.drawable.ic_notify);
-        Notification NavitNotification = builder.build();
+            builder.setContentIntent(appIntent);
+            builder.setAutoCancel(false).setOngoing(true);
+            builder.setContentTitle(getTstring(R.string.app_name));
+            builder.setContentText(getTstring(R.string.notification_event_default));
+            builder.setSmallIcon(R.drawable.ic_notify);
+            Notification NavitNotification = builder.build();
+        } else {
+            NotificationCompat.Builder builder;
+            builder = new NotificationCompat.Builder(getApplicationContext());
+            builder.setContentIntent(appIntent);
+            builder.setAutoCancel(false).setOngoing(true);
+            builder.setContentTitle(getTstring(R.string.app_name));
+            builder.setContentText(getTstring(R.string.notification_event_default));
+            builder.setSmallIcon(R.drawable.ic_notify);
+            Notification NavitNotification = builder.build();
+        }
         nm.notify(R.string.app_name, NavitNotification);// Show the notification
 
         if ((ContextCompat.checkSelfPermission(this,

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -369,6 +369,7 @@ public class Navit extends Activity {
         nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);  // Grab a handle to the NotificationManager
         PendingIntent appIntent = PendingIntent.getActivity(getApplicationContext(), 0, getIntent(), 0);
 
+        Notification NavitNotification;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Notification.Builder builder;
             builder = new Notification.Builder(getApplicationContext(), CHANNEL_ID);
@@ -377,7 +378,7 @@ public class Navit extends Activity {
             builder.setContentTitle(getTstring(R.string.app_name));
             builder.setContentText(getTstring(R.string.notification_event_default));
             builder.setSmallIcon(R.drawable.ic_notify);
-            Notification NavitNotification = builder.build();
+            NavitNotification = builder.build();
         } else {
             NotificationCompat.Builder builder;
             builder = new NotificationCompat.Builder(getApplicationContext());
@@ -386,7 +387,7 @@ public class Navit extends Activity {
             builder.setContentTitle(getTstring(R.string.app_name));
             builder.setContentText(getTstring(R.string.notification_event_default));
             builder.setSmallIcon(R.drawable.ic_notify);
-            Notification NavitNotification = builder.build();
+            NavitNotification = builder.build();
         }
         nm.notify(R.string.app_name, NavitNotification);// Show the notification
 


### PR DESCRIPTION
Fixes #640. This restores the notification icon on API 26+ (Oreo and up).

I had to change the `NotificationCompat.Builder` in `Navit.java` to `Notification.Builder` as the latter allows us to specify a notification channel on API26+. `NotificationCompat.Builder` would require us to use version 26+ of the compatibility library (we currently use version 24), requiring us to increase the minimum SDK version.

`Notification.Builder` seems to work (tested on LineageOS 15.1), so I would stick with that unless someone can give me a compelling reason why we need `NotificationCompat.Builder`.