### PR TITLE
Fix:Speech:Android: Replace hyphens with white spaces when using android speech

### DIFF
--- a/navit/speech/android/speech_android.c
+++ b/navit/speech/android/speech_android.c
@@ -36,7 +36,14 @@ struct speech_priv {
 static int speech_android_say(struct speech_priv *this, const char *text) {
     char *str=g_strdup(text);
     jstring string;
-    int i;
+    char *tok = str;
+
+    /* Replace hyphens with white spaces, or some Android speech SDK will pronounce "hyphen" */
+    while (*tok) {
+        if (*tok=='-')
+            *tok=' ';
+        tok++;
+    }
 
     string = (*jnienv)->NewStringUTF(jnienv, str);
     dbg(lvl_debug,"enter %s",str);


### PR DESCRIPTION
On some versions of Android, I found out that hyphens were pronounced textually by the speech processor.
For example, on Android 5.1, in french, I get "Saint ... trait d'union ... Germain" pronounced for "Saint-Germain".
This patches the text before getting into the speech processor, so that there are no hyphens anymore.