### PR TITLE
Fix:core:Fix item_def.h when used whithout defined macros (like in IDE)

### DIFF
--- a/navit/item_def.h
+++ b/navit/item_def.h
@@ -18,6 +18,13 @@
  */
 
 /* This file is generated from http://wiki.navit-project.org/index.php/Item_def.h, do not edit it, edit the wiki page instead */
+#ifndef ITEM
+#define ITEM(x) extern ##x;
+#endif
+#ifndef ITEM2
+#define ITEM2(x,y) extern ##x;
+#endif
+
 ITEM2(0x00000000,none)
 ITEM2(0x00000001,point_unspecified)
 ITEM(town_streets)

--- a/navit/item_def.h
+++ b/navit/item_def.h
@@ -22,7 +22,7 @@
 #define ITEM(x) extern ##x;
 #endif
 #ifndef ITEM2
-#define ITEM2(x,y) extern ##x;
+#define ITEM2(x,y) extern ##y;
 #endif
 
 ITEM2(0x00000000,none)


### PR DESCRIPTION
Hi, 

always when in a IDE like Eclipse i head the problem that all attr_* definitions where not found by the IDE and therefore where marked as error, so my approach now is to declare them as extern so the IDE does not get annoyed by this. This also fixes auto competition. 
