### PR TITLE
fix:graphics:Fix issue when try to close the SDL window ion non webos

### DIFF
--- a/navit/graphics/sdl/graphics_sdl.c
+++ b/navit/graphics/sdl/graphics_sdl.c
@@ -1183,6 +1183,8 @@ static gboolean graphics_sdl_idle(void *data) {
 #ifdef USE_WEBOS
             quit_event_loop = 1;
             navit_destroy(gr->nav);
+#else
+            callback_list_call_attr_0(gr->cbl, attr_window_closed);
 #endif
             break;
         }


### PR DESCRIPTION
Currenty the window created by the SDL driver cant be closed with wihe window X button.

This fixes this issue
