### PR TITLE
Fix:core:Fix Warning in IDE for Items not found

### DIFF
--- a/navit/attr_def.h
+++ b/navit/attr_def.h
@@ -29,6 +29,12 @@
 /* prototypes */
 
 /* common */
+#ifndef ATTR
+#define ATTR(x) extern ##x;
+#endif
+#ifndef ATTR2
+#define ATTR2(x,y) extern ##y;
+#endif
 ATTR2(0x00000000,none)
 ATTR(any)
 ATTR(any_xml)


### PR DESCRIPTION
As discussed in #771 and requested by @mvglasow hers the same fix for attr_def.h
