### PR TITLE
Sync bookmarks 2

### DIFF
--- a/navit/bookmarks.c
+++ b/navit/bookmarks.c
@@ -362,6 +362,10 @@ static int bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit
         this_->bookmarks_list=g_list_next(this_->bookmarks_list);
     }
 
+#ifdef FlushFileBuffers
+	FlushFileBuffers(f)
+#endif FlushFileBuffers
+
     fclose(f);
 
     g_hash_table_destroy(dedup);
@@ -372,6 +376,9 @@ static int bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit
     }
 
     unlink(this_->bookmark_file);
+#ifdef _POSIX
+	sync();
+#endif _POSIX
     result=(rename(this_->working_file,this_->bookmark_file)==0);
     if (!result) {
         navit_add_message(this_->parent->u.navit,_("Failed to write bookmarks file"));

--- a/navit/bookmarks.c
+++ b/navit/bookmarks.c
@@ -363,7 +363,7 @@ static int bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit
     }
 
 #ifdef FlushFileBuffers
-	FlushFileBuffers(f)
+    FlushFileBuffers(f)
 #endif FlushFileBuffers
 
     fclose(f);
@@ -377,7 +377,7 @@ static int bookmarks_store_bookmarks_to_file(struct bookmarks *this_,  int limit
 
     unlink(this_->bookmark_file);
 #ifdef _POSIX
-	sync();
+    sync();
 #endif _POSIX
     result=(rename(this_->working_file,this_->bookmark_file)==0);
     if (!result) {


### PR DESCRIPTION
As a followup for #435 heres a version which fixes the Problem for all Plattforms. 
Original Text from @pgrandin:

> When using navit on some devices that could loose power without being properly shut down, the bookmark files was lost (content was empty).
> 
> This problem is reproduceable : running Navit on a buildroot image on the raspberry pi (for example one built using https://github.com/navit-gps/buildroot ), if the pi looses power and the bookmark file has been modified, the bookmark file will be lost everytime.
> 
> This simple fix ensures that the files get flushed to the disk when we write the bookmark files, and solves the issue according to my tests.

  
