### PR TITLE
update:doc: add the submit patches section from the old wiki close to the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,38 @@ When pushing a pull request, please make sure you follow our:
 * [commit message guidelines](https://wiki.navit-project.org/index.php/Commit_guidelines)
 
 For more information on our developement process, see: https://wiki.navit-project.org/index.php/Development
+## Submitting patches
+
+We are very happy that you like to participate and help the [[team]] to improve Navit :) To make this teamwork a pleasure for all, we will try to guide you trough this process:
+
+### Preparation
+
+Make sure you are familar with our (development tips)[https://wiki.navit-project.org/index.php/Development], learned about the codebase and our guidelines.
+If you found a bug, please open a [GitHub issue](https://github.com/navit-gps/navit/issues) and bring up all details so others can check them and help you on isolating the defective code.
+Point out that you like to submit a patch.
+
+### Process
+
+ * Fork the [Github repository](https://github.com/navit-gps/navit) and clone it using `git clone`
+ * Find the bug (and please address only one issue per patch!) and try to fix it
+ * Test test test if still compiles and the behaviour is as expected
+ * Think about possible side effects (as performance, different settings, ...)
+ * Get the newest Git Navit version (see [this documentation](https://help.github.com/en/articles/syncing-a-fork) on how to sync your fork) and apply your changes once more
+ * Test if everything still works fine
+ * [Create a pull request](https://help.github.com/articles/creating-a-pull-request/) on github
+ * Wait to verify that all the tests in our CI finish succesfully
+
+
+### Review
+
+It might take some time until somebody reviews the pull request (maybe try to reach out using one of the various ccontact methods [listed in the wiki](https://wiki.navit-project.org/index.php/Contacts)).
+If your changes are more complex, catch up new ideas, or still have some minor problems, it might be discussed and we might ask you to submit an updated version/adapt your changes.
+
+So that's it, you helped Navit to go one step forward. Thank you very much :)
+
+## See also
+
+ * [programming guidelines](https://wiki.navit-project.org/index.php/Programming_guidelines)
+ * [commit message guidelines](https://wiki.navit-project.org/index.php/Commit_guidelines)
+ * [Reporting Bugs](https://wiki.navit-project.org/index.php/Reporting_Bugs)
+ * [Translations](https://wiki.navit-project.org/index.php/Translations)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ When pushing a pull request, please make sure you follow our:
 * [programming guidelines](https://wiki.navit-project.org/index.php/Programming_guidelines)
 * [commit message guidelines](https://wiki.navit-project.org/index.php/Commit_guidelines)
 
-For more information on our developement process, see: https://wiki.navit-project.org/index.php/Development
+For more information on our development process, see: https://wiki.navit-project.org/index.php/Development
 ## Submitting patches
 
 We are very happy that you like to participate and help the [[team]] to improve Navit :) To make this teamwork a pleasure for all, we will try to guide you trough this process:
@@ -27,7 +27,7 @@ Point out that you like to submit a patch.
  * Get the newest Git Navit version (see [this documentation](https://help.github.com/en/articles/syncing-a-fork) on how to sync your fork) and apply your changes once more
  * Test if everything still works fine
  * [Create a pull request](https://help.github.com/articles/creating-a-pull-request/) on github
- * Wait to verify that all the tests in our CI finish succesfully
+ * Wait to verify that all the tests in our CI finish successfully
 
 
 ### Review


### PR DESCRIPTION
I think it makes sense to start putting elements to contribute to the code inside the `CONTRIBUTING.md` document to centralise that a bit more like every other project do.
This PR migrate the https://wiki.navit-project.org/index.php/Submitting_patches document from the wiki to here and do some updates on it.