### PR TITLE
Disable maptool if protobuf-c not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,13 @@ if(CMAKE_SIZEOF_VOID_P LESS 8)
 	set_with_reason(BUILD_MAPTOOL "maptool works only on 64 bit architectures" FALSE)
 endif()
 
+if(BUILD_MAPTOOL)
+	find_package(Protobuf-c REQUIRED)
+	if(NOT PROTOBUF_C_FOUND)
+		set_with_reason(BUILD_MAPTOOL "PROTOBUF-C not found" FALSE)
+	endif()
+endif()
+
 set(LOCALEDIR "${LOCALE_DIR}")
 
 find_program(BZCAT NAMES bzcat)


### PR DESCRIPTION
After updating I noticed that now maptool seems to hard depend on protobuf-c. This fix disables maptool if protobuf-c is not found, but allows to build the rest of navit as usual.
