### PR TITLE
qt5: Remove unnecessary moc includes.

### DIFF
--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -41,7 +41,7 @@ extern "C" {
 #include <windows.h>
 #endif
 #include "QNavitWidget.h"
-#include "QNavitWidget.moc"
+//#include "QNavitWidget.moc"
 #include "graphics_qt5.h"
 
 QNavitWidget::QNavitWidget(struct graphics_priv* my_graphics_priv,

--- a/navit/graphics/qt5/event_qt5.cpp
+++ b/navit/graphics/qt5/event_qt5.cpp
@@ -44,7 +44,7 @@ extern "C" {
 #endif
 
 #include "event_qt5.h"
-#include "event_qt5.moc"
+//#include "event_qt5.moc"
 #include "graphics_qt5.h"
 #include <QSocketNotifier>
 

--- a/navit/speech/qt5_espeak/Qt5EspeakAudioOut.cpp
+++ b/navit/speech/qt5_espeak/Qt5EspeakAudioOut.cpp
@@ -81,8 +81,9 @@ void Qt5EspeakAudioOut::handleStateChanged(QAudio::State newState) {
         break;
     case QAudio::StoppedState:
         break;
-    case QAudio::InterruptedState:
-        break;
+// Sailfish's QT version doesn't have this. Doesn't do anything either.
+//    case QAudio::InterruptedState:
+//        break;
     case QAudio::IdleState:
         /*remove all data that was already read*/
         data->remove(0, buffer->pos());

--- a/navit/speech/qt5_espeak/Qt5EspeakAudioOut.cpp
+++ b/navit/speech/qt5_espeak/Qt5EspeakAudioOut.cpp
@@ -82,7 +82,7 @@ void Qt5EspeakAudioOut::handleStateChanged(QAudio::State newState) {
     case QAudio::StoppedState:
         break;
     case QAudio::InterruptedState:
-    	break;
+        break;
     case QAudio::IdleState:
         /*remove all data that was already read*/
         data->remove(0, buffer->pos());

--- a/navit/speech/qt5_espeak/Qt5EspeakAudioOut.cpp
+++ b/navit/speech/qt5_espeak/Qt5EspeakAudioOut.cpp
@@ -81,6 +81,8 @@ void Qt5EspeakAudioOut::handleStateChanged(QAudio::State newState) {
         break;
     case QAudio::StoppedState:
         break;
+    case QAudio::InterruptedState:
+    	break;
     case QAudio::IdleState:
         /*remove all data that was already read*/
         data->remove(0, buffer->pos());

--- a/navit/vehicle/qt5/vehicle_qt5.cpp
+++ b/navit/vehicle/qt5/vehicle_qt5.cpp
@@ -38,7 +38,7 @@ extern "C" {
 #include <time.h>
 
 #include "vehicle_qt5.h"
-#include "vehicle_qt5.moc"
+//#include "vehicle_qt5.moc"
 #include <QDateTime>
 
 /**


### PR DESCRIPTION
This commit removes moc file includes for some classes which do not
define new qt classes. This caused a long standing warning which seems
to be treated as error on some setups.

Additionally a small fix to make nit-picky gcc 8 happy.