### PR TITLE
add:graphics:dpi scaling support

### DIFF
--- a/navit/attr_def.h
+++ b/navit/attr_def.h
@@ -200,6 +200,8 @@ ATTR(turn_around_penalty)
 ATTR(turn_around_penalty2)
 ATTR(autozoom_max)
 ATTR(nav_status)
+ATTR(virtual_dpi)
+ATTR(real_dpi)
 ATTR2(0x00027500,type_rel_abs_begin)
 /* These attributes are int that can either hold relative or absolute values. See the
  * documentation of ATTR_REL_RELSHIFT for details.

--- a/navit/callback.c
+++ b/navit/callback.c
@@ -23,6 +23,7 @@
 #include "debug.h"
 #include "callback.h"
 
+
 struct callback {
     /* func has variable number of arguments, not (void),
      * but we must declare something... */
@@ -34,6 +35,8 @@ struct callback {
 };
 
 struct callback_list {
+    callback_patch patch;
+    void * patch_context;
     GList *list;
 };
 
@@ -115,6 +118,13 @@ void callback_list_remove_destroy(struct callback_list *l, struct callback *cb) 
     g_free(cb);
 }
 
+void callback_list_add_patch_function (struct callback_list *l, callback_patch patch, void * context) {
+    if(!l)
+        return;
+    l->patch = patch;
+    l->patch_context = context;
+}
+
 void callback_call(struct callback *cb, int pcount, void **p) {
     int i;
     void *pf[8];
@@ -193,6 +203,8 @@ void callback_list_call_attr(struct callback_list *l, enum attr_type type, int p
     if (!l) {
         return;
     }
+    if(l->patch != NULL)
+        l->patch(l, type, pcount, p, l->patch_context);
 
     cbi=l->list;
     while (cbi) {

--- a/navit/callback.h
+++ b/navit/callback.h
@@ -30,6 +30,7 @@ extern "C" {
 enum attr_type;
 struct callback;
 struct callback_list;
+typedef void (*callback_patch) (struct callback_list *l, enum attr_type type, int pcount, void **p, void * context);
 struct callback_list *callback_list_new(void);
 struct callback *callback_new_attr(void (*func)(void), enum attr_type type, int pcount, void **p);
 struct callback *callback_new_attr_args(void (*func)(void), enum attr_type type, int count, ...);
@@ -41,6 +42,7 @@ void callback_list_add(struct callback_list *l, struct callback *cb);
 struct callback *callback_list_add_new(struct callback_list *l, void (*func)(void), int pcount, void **p);
 void callback_list_remove(struct callback_list *l, struct callback *cb);
 void callback_list_remove_destroy(struct callback_list *l, struct callback *cb);
+void callback_list_add_patch_function (struct callback_list *l, callback_patch patch, void * context);
 void callback_call(struct callback *cb, int pcount, void **p);
 void callback_call_args(struct callback *cb, int count, ...);
 void callback_list_call_attr(struct callback_list *l, enum attr_type type, int pcount, void **p);

--- a/navit/graphics.h
+++ b/navit/graphics.h
@@ -24,6 +24,7 @@
 
 #ifndef NAVIT_GRAPHICS_H
 #define NAVIT_GRAPHICS_H
+#include "coord.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +43,7 @@ struct mapset;
 
 /* This enum must be synchronized with the constants in NavitGraphics.java. */
 enum draw_mode_num {
-	draw_mode_begin, draw_mode_end
+    draw_mode_begin, draw_mode_end
 };
 
 struct graphics_priv;
@@ -54,14 +55,14 @@ struct graphics_gc_methods;
 struct graphics_image_methods;
 
 enum graphics_image_type {
-	graphics_image_type_unknown=0,
+    graphics_image_type_unknown=0,
 };
 
 struct graphics_image_buffer {
-	char magic[8]; /* buffer:\0 */
-	enum graphics_image_type type;
-	void *start;
-	int len;
+    char magic[8]; /* buffer:\0 */
+    enum graphics_image_type type;
+    void *start;
+    int len;
 };
 
 struct graphics_keyboard_priv;
@@ -70,20 +71,20 @@ struct graphics_keyboard_priv;
  * Describes an instance of the native on-screen keyboard or other input method.
  */
 struct graphics_keyboard {
-	int w;										/**< The width of the area obscured by the keyboard (-1 for full width) */
-	int h;										/**< The height of the area obscured by the keyboard (-1 for full height) */
-	/* TODO mode is currently a copy of the respective value in the internal GUI and uses the same values.
-	 * This may need to be changed to something with globally available enum, possibly with revised values.
-	 * The Android implementation (the first to support a native on-screen keyboard) does not use this field
-	 * due to limitations of the platform. */
-	int mode;									/**< Mode flags for the keyboard */
-	char *lang;									/**< The preferred language for text input, may be {@code NULL}. */
-	void *gui_priv;								/**< Private data determined by the GUI. The GUI may store
+    int w;										/**< The width of the area obscured by the keyboard (-1 for full width) */
+    int h;										/**< The height of the area obscured by the keyboard (-1 for full height) */
+    /* TODO mode is currently a copy of the respective value in the internal GUI and uses the same values.
+     * This may need to be changed to something with globally available enum, possibly with revised values.
+     * The Android implementation (the first to support a native on-screen keyboard) does not use this field
+     * due to limitations of the platform. */
+    int mode;									/**< Mode flags for the keyboard */
+    char *lang;									/**< The preferred language for text input, may be {@code NULL}. */
+    void *gui_priv;								/**< Private data determined by the GUI. The GUI may store
 												 *   a pointer to a data structure of its choice here. It is
 												 *   the responsibility of the GUI to free the data structure
 												 *   when it is no longer needed. The graphics plugin should
 												 *   not access this member. */
-	struct graphics_keyboard_priv *gra_priv;	/**< Private data determined by the graphics plugin. The
+    struct graphics_keyboard_priv *gra_priv;	/**< Private data determined by the graphics plugin. The
 												 *   graphics plugin is responsible for its management. If it
 												 *   uses this member, it must free the associated data in
 												 *   its {@code hide_native_keyboard} method. */
@@ -108,67 +109,75 @@ struct graphics_keyboard {
  * to be visible as long as Navit is in the foreground.
  */
 struct padding {
-	int left;
-	int top;
-	int right;
-	int bottom;
+    int left;
+    int top;
+    int right;
+    int bottom;
 };
 
 struct graphics_methods {
-	void (*graphics_destroy)(struct graphics_priv *gr);
-	void (*draw_mode)(struct graphics_priv *gr, enum draw_mode_num mode);
-	void (*draw_lines)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count);
-	void (*draw_polygon)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count);
-	void (*draw_rectangle)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h);
-	void (*draw_circle)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r);
-	void (*draw_text)(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg, struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy);
-	void (*draw_image)(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, struct graphics_image_priv *img);
-	void (*draw_image_warp)(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count, struct graphics_image_priv *img);
-	void (*draw_drag)(struct graphics_priv *gr, struct point *p);
-	struct graphics_font_priv *(*font_new)(struct graphics_priv *gr, struct graphics_font_methods *meth, char *font,  int size, int flags);
-	struct graphics_gc_priv *(*gc_new)(struct graphics_priv *gr, struct graphics_gc_methods *meth);
-	void (*background_gc)(struct graphics_priv *gr, struct graphics_gc_priv *gc);
-	struct graphics_priv *(*overlay_new)(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w, int h, int wraparound);
-	/** @brief Load an image from a file.
-	 *
-	 * @param gr graphics object
-	 * @param meth output parameter for graphics methods object
-	 * @param path file name/path of image to load
-	 * @param w In: width to scale image to, or IMAGE_W_H_UNSET for original width.
-	 * Out: Actual width of returned image.
-	 * @param h heigth; see w
-	 * @param hot output parameter for image hotspot
-	 * @param rotate angle to rotate the image, in 90 degree steps (not supported by all plugins).
-	 * @return pointer to allocated image, to be freed by image_free()
-	 * @see image_free()
-	 */
-	struct graphics_image_priv *(*image_new)(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path, int *w, int *h, struct point *hot, int rotation);
-	void *(*get_data)(struct graphics_priv *gr, const char *type);
-	void (*image_free)(struct graphics_priv *gr, struct graphics_image_priv *priv);
-	void (*get_text_bbox)(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy, struct point *ret, int estimate);
-	void (*overlay_disable)(struct graphics_priv *gr, int disable);
-	void (*overlay_resize)(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound);
-	int (*set_attr)(struct graphics_priv *gr, struct attr *attr);
-	int (*show_native_keyboard)(struct graphics_keyboard *kbd);
-	void (*hide_native_keyboard)(struct graphics_keyboard *kbd);
+    void (*graphics_destroy)(struct graphics_priv *gr);
+    void (*draw_mode)(struct graphics_priv *gr, enum draw_mode_num mode);
+    void (*draw_lines)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count);
+    void (*draw_polygon)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int count);
+    void (*draw_rectangle)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int w, int h);
+    void (*draw_circle)(struct graphics_priv *gr, struct graphics_gc_priv *gc, struct point *p, int r);
+    void (*draw_text)(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct graphics_gc_priv *bg,
+                      struct graphics_font_priv *font, char *text, struct point *p, int dx, int dy);
+    void (*draw_image)(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p,
+                       struct graphics_image_priv *img);
+    void (*draw_image_warp)(struct graphics_priv *gr, struct graphics_gc_priv *fg, struct point *p, int count,
+                            struct graphics_image_priv *img);
+    void (*draw_drag)(struct graphics_priv *gr, struct point *p);
+    struct graphics_font_priv *(*font_new)(struct graphics_priv *gr, struct graphics_font_methods *meth, char *font,
+                                           int size, int flags);
+    struct graphics_gc_priv *(*gc_new)(struct graphics_priv *gr, struct graphics_gc_methods *meth);
+    void (*background_gc)(struct graphics_priv *gr, struct graphics_gc_priv *gc);
+    struct graphics_priv *(*overlay_new)(struct graphics_priv *gr, struct graphics_methods *meth, struct point *p, int w,
+                                         int h, int wraparound);
+    /** @brief Load an image from a file.
+     *
+     * @param gr graphics object
+     * @param meth output parameter for graphics methods object
+     * @param path file name/path of image to load
+     * @param w In: width to scale image to, or IMAGE_W_H_UNSET for original width.
+     * Out: Actual width of returned image.
+     * @param h heigth; see w
+     * @param hot output parameter for image hotspot
+     * @param rotate angle to rotate the image, in 90 degree steps (not supported by all plugins).
+     * @return pointer to allocated image, to be freed by image_free()
+     * @see image_free()
+     */
+    struct graphics_image_priv *(*image_new)(struct graphics_priv *gr, struct graphics_image_methods *meth, char *path,
+            int *w, int *h, struct point *hot, int rotation);
+    void *(*get_data)(struct graphics_priv *gr, const char *type);
+    void (*image_free)(struct graphics_priv *gr, struct graphics_image_priv *priv);
+    void (*get_text_bbox)(struct graphics_priv *gr, struct graphics_font_priv *font, char *text, int dx, int dy,
+                          struct point *ret, int estimate);
+    void (*overlay_disable)(struct graphics_priv *gr, int disable);
+    void (*overlay_resize)(struct graphics_priv *gr, struct point *p, int w, int h, int wraparound);
+    int (*set_attr)(struct graphics_priv *gr, struct attr *attr);
+    int (*show_native_keyboard)(struct graphics_keyboard *kbd);
+    void (*hide_native_keyboard)(struct graphics_keyboard *kbd);
+    navit_float (*get_dpi)(struct graphics_priv * gr);
 };
 
 
 struct graphics_font_methods {
-	void (*font_destroy)(struct graphics_font_priv *font);
+    void (*font_destroy)(struct graphics_font_priv *font);
 };
 
 struct graphics_font {
-	struct graphics_font_priv *priv;
-	struct graphics_font_methods meth;
+    struct graphics_font_priv *priv;
+    struct graphics_font_methods meth;
 };
 
 struct graphics_gc_methods {
-	void (*gc_destroy)(struct graphics_gc_priv *gc);
-	void (*gc_set_linewidth)(struct graphics_gc_priv *gc, int width);
-	void (*gc_set_dashes)(struct graphics_gc_priv *gc, int width, int offset, unsigned char dash_list[], int n);
-	void (*gc_set_foreground)(struct graphics_gc_priv *gc, struct color *c);
-	void (*gc_set_background)(struct graphics_gc_priv *gc, struct color *c);
+    void (*gc_destroy)(struct graphics_gc_priv *gc);
+    void (*gc_set_linewidth)(struct graphics_gc_priv *gc, int width);
+    void (*gc_set_dashes)(struct graphics_gc_priv *gc, int width, int offset, unsigned char dash_list[], int n);
+    void (*gc_set_foreground)(struct graphics_gc_priv *gc, struct color *c);
+    void (*gc_set_background)(struct graphics_gc_priv *gc, struct color *c);
 };
 
 /**
@@ -177,26 +186,26 @@ struct graphics_gc_methods {
  * linewidth and drawing color.
  */
 struct graphics_gc {
-	struct graphics_gc_priv *priv;
-	struct graphics_gc_methods meth;
-	struct graphics *gra;
+    struct graphics_gc_priv *priv;
+    struct graphics_gc_methods meth;
+    struct graphics *gra;
 };
 
 struct graphics_image_methods {
-	void (*image_destroy)(struct graphics_image_priv *img);
+    void (*image_destroy)(struct graphics_image_priv *img);
 };
 
 struct graphics_image {
-	struct graphics_image_priv *priv;
-	struct graphics_image_methods meth;
-	int width;
-	int height;
-	struct point hot;
+    struct graphics_image_priv *priv;
+    struct graphics_image_methods meth;
+    int width;
+    int height;
+    struct point hot;
 };
 
 struct graphics_data_image {
-	void *data;
-	int size;
+    void *data;
+    int size;
 };
 
 /* prototypes */
@@ -250,9 +259,12 @@ void graphics_draw_mode(struct graphics *this_, enum draw_mode_num mode);
 void graphics_draw_lines(struct graphics *this_, struct graphics_gc *gc, struct point *p, int count);
 void graphics_draw_circle(struct graphics *this_, struct graphics_gc *gc, struct point *p, int r);
 void graphics_draw_rectangle(struct graphics *this_, struct graphics_gc *gc, struct point *p, int w, int h);
-void graphics_draw_rectangle_rounded(struct graphics *this_, struct graphics_gc *gc, struct point *plu, int w, int h, int r, int fill);
-void graphics_draw_text(struct graphics *this_, struct graphics_gc *gc1, struct graphics_gc *gc2, struct graphics_font *font, char *text, struct point *p, int dx, int dy);
-void graphics_get_text_bbox(struct graphics *this_, struct graphics_font *font, char *text, int dx, int dy, struct point *ret, int estimate);
+void graphics_draw_rectangle_rounded(struct graphics *this_, struct graphics_gc *gc, struct point *plu, int w, int h,
+                                     int r, int fill);
+void graphics_draw_text(struct graphics *this_, struct graphics_gc *gc1, struct graphics_gc *gc2,
+                        struct graphics_font *font, char *text, struct point *p, int dx, int dy);
+void graphics_get_text_bbox(struct graphics *this_, struct graphics_font *font, char *text, int dx, int dy,
+                            struct point *ret, int estimate);
 void graphics_overlay_disable(struct graphics *this_, int disable);
 int  graphics_is_disabled(struct graphics *this_);
 void graphics_draw_image(struct graphics *this_, struct graphics_gc *gc, struct point *p, struct graphics_image *img);
@@ -261,8 +273,10 @@ void graphics_background_gc(struct graphics *this_, struct graphics_gc *gc);
 void graphics_draw_text_std(struct graphics *this_, int text_size, char *text, struct point *p);
 char *graphics_icon_path(const char *icon);
 void graphics_draw_itemgra(struct graphics *gra, struct itemgra *itm, struct transformation *t, char *label);
-void graphics_displaylist_draw(struct graphics *gra, struct displaylist *displaylist, struct transformation *trans, struct layout *l, int flags);
-void graphics_draw(struct graphics *gra, struct displaylist *displaylist, struct mapset *mapset, struct transformation *trans, struct layout *l, int async, struct callback *cb, int flags);
+void graphics_displaylist_draw(struct graphics *gra, struct displaylist *displaylist, struct transformation *trans,
+                               struct layout *l, int flags);
+void graphics_draw(struct graphics *gra, struct displaylist *displaylist, struct mapset *mapset,
+                   struct transformation *trans, struct layout *l, int async, struct callback *cb, int flags);
 int graphics_draw_cancel(struct graphics *gra, struct displaylist *displaylist);
 struct displaylist_handle *graphics_displaylist_open(struct displaylist *displaylist);
 struct displayitem *graphics_displaylist_next(struct displaylist_handle *dlh);
@@ -276,14 +290,17 @@ int graphics_displayitem_get_coord_count(struct displayitem *di);
 char *graphics_displayitem_get_label(struct displayitem *di);
 int graphics_displayitem_get_displayed(struct displayitem *di);
 int graphics_displayitem_get_z_order(struct displayitem *di);
-int graphics_displayitem_within_dist(struct displaylist *displaylist, struct displayitem *di, struct point *p, int dist);
+int graphics_displayitem_within_dist(struct displaylist *displaylist, struct displayitem *di, struct point *p,
+                                     int dist);
 void graphics_add_selection(struct graphics *gra, struct item *item, enum item_type type, struct displaylist *dl);
 void graphics_remove_selection(struct graphics *gra, struct item *item, enum item_type type, struct displaylist *dl);
 void graphics_clear_selection(struct graphics *gra, struct displaylist *dl);
 int graphics_show_native_keyboard (struct graphics *this_, struct graphics_keyboard *kbd);
 int graphics_hide_native_keyboard (struct graphics *this_, struct graphics_keyboard *kbd);
 void graphics_draw_polygon_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pin, int count_in);
-void graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pa, int count, int *width, int poly);
+void graphics_draw_polyline_clipped(struct graphics *gra, struct graphics_gc *gc, struct point *pa, int count,
+                                    int *width, int poly);
+navit_float graphics_get_dpi(struct graphics *gra);
 
 /* end of prototypes */
 #ifdef __cplusplus

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -813,6 +813,20 @@ static void overlay_resize(struct graphics_priv* gr, struct point* p, int w, int
 #endif
 }
 
+/**
+ * @brief Return number of dots per inch
+ * @param gr self handle
+ * @return dpi value
+ */
+static navit_float get_dpi(struct graphics_priv * gr) {
+    qreal dpi = 96;
+    QScreen* primary = navit_app->primaryScreen();
+    if (primary != NULL) {
+        dpi = primary->logicalDotsPerInch();
+    }
+    return (navit_float)dpi;
+}
+
 static struct graphics_methods graphics_methods = {
     graphics_destroy,
     draw_mode,
@@ -834,6 +848,10 @@ static struct graphics_methods graphics_methods = {
     get_text_bbox,
     overlay_disable,
     overlay_resize,
+    NULL, //set_attr
+    NULL, //show_native_keyboard
+    NULL, //hide_native_keyboard
+    get_dpi
 };
 
 /* create new graphics context on given context */

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -536,11 +536,11 @@ static void draw_text(struct graphics_priv* gr, struct graphics_gc_priv* fg, str
         shadow.setColor(bg->pen->color());
         shadow.setWidth(3);
         painter->setPen(shadow);
-        path.addText(0, 0, *font->font, tmp);
+        path.addText(0, (font->font->pixelSize()/2) * -1, *font->font, tmp);
         painter->drawPath(path);
     }
     painter->setPen(*fg->pen);
-    painter->drawText(0, 0, tmp);
+    painter->drawText(0, (font->font->pixelSize()/2) *-1, tmp);
     painter->setWorldMatrix(sav);
 #endif
 }

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -822,7 +822,7 @@ static navit_float get_dpi(struct graphics_priv * gr) {
     qreal dpi = 96;
     QScreen* primary = navit_app->primaryScreen();
     if (primary != NULL) {
-        dpi = primary->logicalDotsPerInch();
+        dpi = primary->physicalDotsPerInch();
     }
     return (navit_float)dpi;
 }

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -209,7 +209,7 @@ static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct grap
     }
 
     /* Convert silly font size to pixels. by 64 is to convert fixpoint to int. */
-    dbg(lvl_error, "(font %s, %d=%f, %d)", font, size,((float)size)/64.0, ((size * 300) / 72) / 64);
+    dbg(lvl_debug, "(font %s, %d=%f, %d)", font, size,((float)size)/64.0, ((size * 300) / 72) / 64);
     font_priv->font->setPixelSize(((size * 300) / 72) / 64);
     //font_priv->font->setStyleStrategy(QFont::NoSubpixelAntialias);
     /* Check for bold font */

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -172,7 +172,10 @@ static const char* fontfamilies[] = {
  * @param	gr	own private context
  * @param	meth	fill this structure with correct functions to be called with handle as interface to font
  * @param	font	font family e.g. "Arial"
- * @param	size	Font size in ???
+ * @param	size	Font size in 16.6 fractional points @ 300dpi. This is bullsh***. The encoding is freetypes
+ *          16.6 fixed point format usually giving points. One point is usually 72th part of an inch. But
+ *          navit does not honor dpi correct. It's traditionally used freetype backend is fixed to 300 dpi.
+ *          So this value is (300/72) pixels
  * @param	flags	Font flags (currently 1 if bold and 0 if not)
  *
  * @return	font handle
@@ -205,8 +208,9 @@ static struct graphics_font_priv* font_new(struct graphics_priv* gr, struct grap
         dbg(lvl_debug, "No matching font. Resort to: %s", font_priv->font->family().toUtf8().data());
     }
 
-    /* No clue why factor 20. Found this by comparing to Freetype rendering. */
-    font_priv->font->setPointSize(size / 20);
+    /* Convert silly font size to pixels. by 64 is to convert fixpoint to int. */
+    dbg(lvl_error, "(font %s, %d=%f, %d)", font, size,((float)size)/64.0, ((size * 300) / 72) / 64);
+    font_priv->font->setPixelSize(((size * 300) / 72) / 64);
     //font_priv->font->setStyleStrategy(QFont::NoSubpixelAntialias);
     /* Check for bold font */
     if (flags) {

--- a/navit/xslt/sailfish_cursor.xslt
+++ b/navit/xslt/sailfish_cursor.xslt
@@ -12,7 +12,7 @@
       </xsl:copy>
    </xsl:template>
 
-   <xsl:template match="/config/navit/layout[@name='Car' or @name='Car-dark']/cursor">
+   <xsl:template match="/layout[@name='Car' or @name='Car-dark']/cursor">
       <cursor w="57" h="57">
         <xsl:text>&#x0A;				</xsl:text>
         <itemgra speed_range="-2">

--- a/navit/xslt/sailfish_qt5.xslt
+++ b/navit/xslt/sailfish_qt5.xslt
@@ -13,7 +13,7 @@
    </xsl:template>
 
    <xsl:template match="/config/navit/graphics[1]">
-      <graphics type="qt5" qt5_platform="wayland"/>
+      <graphics type="qt5" qt5_platform="wayland" virtual_dpi="245"/>
       <xsl:text>&#x0A; 		</xsl:text>
       <xsl:copy>
          <xsl:apply-templates select="@*"/>


### PR DESCRIPTION
This pull request adds dpi scaling to navit's graphics layer. It basically allows to convert the internal measurement unit (traditionally 1:1 pixels) into something virtual. You can specify the dpi value your layout / OSD was designed against in virtual_dpi, effectively assigning the internal pixel a human unit.
Then it will get the screen dpi value (or you can override that in config) to scale your setup to your real hardware dpi. Hardware dpi support is given for qt5 and gtk, but not widely tested yet.

Of course best results if real_dpi is a even multiple of virtual_dpi 

This can be used as a basis for supporting human units (like millimeters, inches, android dip) in config files as well, since these can be converted using virtual_dpi.

This is the second attempt after #810 . But #810 was the wrong attempt do do what is done here.