### PR TITLE
fix:core: Correct default layout handling.

### DIFF
--- a/navit/main.c
+++ b/navit/main.c
@@ -328,10 +328,6 @@ static void win_set_nls(void) {
 }
 #endif
 
-void main_update_default_layout(struct navit *navit) {
-    navit_update_current_layout(navit, NULL);
-}
-
 void main_init(const char *program) {
     char *s;
 #ifdef _UNICODE		/* currently for wince */

--- a/navit/main.h
+++ b/navit/main.h
@@ -35,7 +35,6 @@ void main_add_navit(struct navit *nav);
 void main_remove_navit(struct navit *nav);
 int main_add_attr(struct attr *attr);
 int main_remove_attr(struct attr *attr);
-void main_update_default_layout(struct navit *navit);
 void main_init(const char *program);
 void main_init_nls(void);
 int main(int argc, char **argv);

--- a/navit/start_real.c
+++ b/navit/start_real.c
@@ -207,7 +207,6 @@ int main_real(int argc, char * const* argv) {
         dbg(lvl_error, "%s", _("Internal initialization failed, exiting. Check previous error messages."));
         exit(5);
     }
-    main_update_default_layout(navit.u.navit);
     conf.type=attr_config;
     conf.u.config=config;
     if (startup_file) {


### PR DESCRIPTION
This commit corrects the default layout handling broken when splitting
the layouts to own files. It restores the layout saving of the internal
gui. So now it starts again with the last selected layout honouring
gui_internal.txt

