### PR TITLE
Issue/826

### DIFF
--- a/navit/track.c
+++ b/navit/track.c
@@ -635,7 +635,8 @@ void tracking_update(struct tracking *tr, struct vehicle *v, struct vehicleprofi
     }
     if (!vehicle_get_attr(tr->vehicle, attr_position_speed, &speed_attr, NULL) ||
             !vehicle_get_attr(tr->vehicle, attr_position_direction, &direction_attr, NULL) ||
-            !vehicle_get_attr(tr->vehicle, attr_position_coord_geo, &coord_geo, NULL)) {
+            !vehicle_get_attr(tr->vehicle, attr_position_coord_geo, &coord_geo,NULL) ||
+            !vehicle_get_attr(tr->vehicle, attr_position_time_iso8601, &time_attr, NULL)) {
         dbg(lvl_error,"failed to get position data %d %d %d",
             vehicle_get_attr(tr->vehicle, attr_position_speed, &speed_attr, NULL),
             vehicle_get_attr(tr->vehicle, attr_position_direction, &direction_attr, NULL),

--- a/navit/track.c
+++ b/navit/track.c
@@ -635,7 +635,7 @@ void tracking_update(struct tracking *tr, struct vehicle *v, struct vehicleprofi
     }
     if (!vehicle_get_attr(tr->vehicle, attr_position_speed, &speed_attr, NULL) ||
             !vehicle_get_attr(tr->vehicle, attr_position_direction, &direction_attr, NULL) ||
-            !vehicle_get_attr(tr->vehicle, attr_position_coord_geo, &coord_geo,NULL) ||
+            !vehicle_get_attr(tr->vehicle, attr_position_coord_geo, &coord_geo, NULL) ||
             !vehicle_get_attr(tr->vehicle, attr_position_time_iso8601, &time_attr, NULL)) {
         dbg(lvl_error,"failed to get position data %d %d %d",
             vehicle_get_attr(tr->vehicle, attr_position_speed, &speed_attr, NULL),


### PR DESCRIPTION
In bad case the function iso8601_to_secs(time_attr.u.str); is called with a NULL pointer.
The function dont check this...
The bad call of iso8601_to_secs is in navit/track.c line 683.

vehicle_get_attr(tr->vehicle, attr_position_time_iso8601, &time_attr, NULL));
was removed at
https://github.com/navit-gps/navit/commit/03f3aa8637fff3e8e09d3bde21b28654454011fd#diff-3cbc3b1f62b4a7f91ff8ea7691e63e64