### PR TITLE
Add:doc:Migrate the commit guidelines document to readthedocs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Thanks for contributing to Navit!
 Before opening a pull request on navit, make sure your commit message follows our guidelines:
-https://wiki.navit-project.org/index.php/Commit_guidelines
+https://navit.readthedocs.io/en/trunk/development/commit_guidelines.html
 
 and that your code is compliant with out coding style guidelines:
 https://navit.readthedocs.io/en/trunk/development/programming_guidelines.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and our [ReadTheDocs space](https://navit.readthedocs.io)
 
 When pushing a pull request, please make sure you follow our:
 * [programming guidelines](https://navit.readthedocs.io/en/trunk/development/programming_guidelines.html)
-* [commit message guidelines](https://wiki.navit-project.org/index.php/Commit_guidelines)
+* [commit message guidelines](https://navit.readthedocs.io/en/trunk/development/commit_guidelines.html)
 
 For more information on our development process, see: https://wiki.navit-project.org/index.php/Development
 
@@ -41,7 +41,7 @@ Submit your work:
  * Get the newest Git Navit version (see [this documentation](https://help.github.com/en/articles/syncing-a-fork) on how to sync your fork) and apply your changes once more
  * Test if everything still works fine
  * double check that you are on the correct branch with git status
- * commit your change using our [commit message guidelines](https://wiki.navit-project.org/index.php/Commit_guidelines)
+ * commit your change using our [commit message guidelines](https://navit.readthedocs.io/en/trunk/development/commit_guidelines.html)
  * push your branch (`git push origin <name of your branch>`)
  * [Create a pull request](https://help.github.com/articles/creating-a-pull-request/) on github
  * Wait to verify that all the tests in our CI finish successfully
@@ -58,6 +58,6 @@ So that's it, you helped Navit to go one step forward. Thank you very much :)
 ## See also
 
  * [programming guidelines](https://navit.readthedocs.io/en/trunk/development/programming_guidelines.html)
- * [commit message guidelines](https://wiki.navit-project.org/index.php/Commit_guidelines)
+ * [commit message guidelines](https://navit.readthedocs.io/en/trunk/development/commit_guidelines.html)
  * [Reporting Bugs](https://wiki.navit-project.org/index.php/Reporting_Bugs)
  * [Translations](https://wiki.navit-project.org/index.php/Translations)

--- a/docs/development/commit_guidelines.rst
+++ b/docs/development/commit_guidelines.rst
@@ -1,0 +1,54 @@
+======================
+Commit guidelines
+======================
+
+Here are the current guidelines if you want to commit something. Please also read the [programming guidelines](../programming_guidelines.html)
+
+'Core' components changes
+=========================
+
+Do not modify a 'core' component without discussing it first with the project leads.
+
+Core components include data structures, configuration handling. If you are unsure, just ask.
+
+Commit per feature
+==================
+
+When committing, try to have one commit per feature (or per meaningful part of a larger feature). The goal is to always have working code; at least make sure each commit leaves the repository in a compilable state.
+
+Also avoid putting multiple, independent changes into one commit.
+Thus if you have multiple, independent changes in your local working copy, avoid committing a whole folder at once, especially Navit's Sourcecode root. Instead, explicitly select the files for each commit.
+
+Format of the commit log
+========================
+
+Since we are too lazy to maintain a Changelog, we have a script which parses the commit logs and generate a Changelog for us.
+
+We have agreed about using the following syntax : ` <Action>:<component>:<log message>[|Optional comments]`
+
+Examples :
+ Fix:Core:Fixed nasty bug in ticket #134
+ Fix:GTK:Fixed nasty bug about destination button|Thanks someguy for the patch!
+
+Action can be something like:
+* Fix (bug fix)
+* Add (new feature)
+* Patch
+* Refactoring (does not change behavior of the program)
+
+It allows the changes to be sorted by categories
+
+The most common components are:
+* core
+* gui/gtk
+* gui/internal
+* graphics/gtk
+* graphics/qt_qpainter
+* graphics/opengl
+* mapdriver
+* tools
+
+The comment part is optional. Useful for when applying a patch for example, and giving credits.
+The part after `|` will not appear in the wiki.
+
+About the log message, it's up to you :)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,3 +46,4 @@ Navit is highly customizable, from map layouts and on-screen display to the deta
    :caption: Navit's developer documentation
 
    development/programming_guidelines
+   development/commit_guidelines


### PR DESCRIPTION
Migrates https://wiki.navit-project.org/index.php/Commit_guidelines to readthedocs