### PR TITLE
fix android 64

### DIFF
--- a/navit/support/glib/fake.h
+++ b/navit/support/glib/fake.h
@@ -1,4 +1,4 @@
-#include "../config.h"
+#include "config.h"
 #ifndef HAVE_API_WIN32_BASE
 #define USE_POSIX_THREADS 1
 #endif

--- a/navit/support/glib/fake.h
+++ b/navit/support/glib/fake.h
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "../config.h"
 #ifndef HAVE_API_WIN32_BASE
 #define USE_POSIX_THREADS 1
 #endif
@@ -6,6 +6,7 @@
 #include <pthread.h>
 #endif
 #include "debug.h"
+#include "gtypes.h"
 
 #define g_return_if_fail
 
@@ -20,6 +21,11 @@
 #  define g_private_new(xd) g_private_new_navit()
 #  define g_private_get(xd) pthread_getspecific(xd)
 #  define g_private_set(a,b) pthread_setspecific(a, b)
+
+pthread_mutex_t* g_mutex_new_navit(void);
+void g_get_current_time (GTimeVal *result);
+GPrivate g_private_new_navit ();
+
 #else
 # if HAVE_API_WIN32_BASE
 #  define GMutex CRITICAL_SECTION

--- a/navit/support/glib/glibconfig.h
+++ b/navit/support/glib/glibconfig.h
@@ -69,7 +69,7 @@ typedef unsigned __int64 guint64;
 #define G_GINT64_FORMAT "I64i"
 #define G_GUINT64_FORMAT "I64u"
 
-#if defined(_WIN64) || defined(_M_X64) || defined(_M_AMD64)
+#if defined(_WIN64) || defined(_M_X64) || defined(_M_AMD64) || defined(__LP64__)
 
 #define GLIB_SIZEOF_VOID_P 8
 #define GLIB_SIZEOF_LONG   4
@@ -107,7 +107,7 @@ typedef gint64 goffset;
 #define G_MINOFFSET	G_MININT64
 #define G_MAXOFFSET	G_MAXINT64
 
-#ifndef _WIN64
+#if !defined (_WIN64) && !defined (__LP64__)
 
 #define GPOINTER_TO_INT(p)	((gint)   (p))
 #define GPOINTER_TO_UINT(p)	((guint)  (p))

--- a/navit/support/glib/glibconfig.h
+++ b/navit/support/glib/glibconfig.h
@@ -107,7 +107,7 @@ typedef gint64 goffset;
 #define G_MINOFFSET	G_MININT64
 #define G_MAXOFFSET	G_MAXINT64
 
-#if !defined (_WIN64) && !defined (__LP64__)
+#if !defined(_WIN64) && !defined(__LP64__)
 
 #define GPOINTER_TO_INT(p)	((gint)   (p))
 #define GPOINTER_TO_UINT(p)	((guint)  (p))

--- a/navit/support/glib/gslice.c
+++ b/navit/support/glib/gslice.c
@@ -34,6 +34,7 @@
 #include "gthreadprivate.h"
 #include "glib.h"
 #include "galias.h"
+#include "fake.h"
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>             /* sysconf() */
 #endif

--- a/navit/support/glib/gslice.c
+++ b/navit/support/glib/gslice.c
@@ -1265,17 +1265,17 @@ smc_notify_free (void   *pointer,
   found_one = smc_tree_lookup (adress, &real_size);
   if (!found_one)
     {
-      fprintf (stderr, "GSlice: MemChecker: attempt to release non-allocated block: %p size=%" G_GSIZE_FORMAT "\n", pointer, size);
+//      fprintf (stderr, "GSlice: MemChecker: attempt to release non-allocated block: %p size=%" G_GSIZE_FORMAT "\n", pointer, size);
       return 0;
     }
   if (real_size != size && (real_size || size))
     {
-      fprintf (stderr, "GSlice: MemChecker: attempt to release block with invalid size: %p size=%" G_GSIZE_FORMAT " invalid-size=%" G_GSIZE_FORMAT "\n", pointer, real_size, size);
+//      fprintf (stderr, "GSlice: MemChecker: attempt to release block with invalid size: %p size=%" G_GSIZE_FORMAT " invalid-size=%" G_GSIZE_FORMAT "\n", pointer, real_size, size);
       return 0;
     }
   if (!smc_tree_remove (adress))
     {
-      fprintf (stderr, "GSlice: MemChecker: attempt to release non-allocated block: %p size=%" G_GSIZE_FORMAT "\n", pointer, size);
+//      fprintf (stderr, "GSlice: MemChecker: attempt to release non-allocated block: %p size=%" G_GSIZE_FORMAT "\n", pointer, size);
       return 0;
     }
   return 1; /* all fine */


### PR DESCRIPTION
The first step in fixing https://github.com/navit-gps/navit/issues/828

Glib from support already worked for 64 bits on windows but just needed a small tweak to get it going on android 64 as well.
Before fixing this I tested it with a glib built from latest glib sources (glib-2.61.2) to get a view of what other work there is to do in navit to fix it for arm64 but it is too much to build libglib-2.0.so just for distribution of navit apk's.

After this it still crashes on arm64 as there are a bunch of fixes to follow in the android specific navit code, but I thought to commit this first seperatly so it can bet tested for regressions on other platforms before committing the rest of the fixes.

The rest of the fixes are in android code, so those can't have sideffects on other platforms.

tested with a version including the most essential fixes in the android code on
android 8.1 arm64-v8a
android 9 x86_64
