### PR TITLE
fix crosscompilation without PkgConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,8 @@ if(PKG_CONFIG_FOUND)
 	if(IMLIB2_FOUND)
 		set(HAVE_IMLIB2 1)
 	endif(IMLIB2_FOUND)
+else(PKG_CONFIG_FOUND)
+        set_with_reason(support/glib "Glib not found" TRUE ${INTL_LIBS})
 endif(PKG_CONFIG_FOUND)
 
 #find_package(Iconv)


### PR DESCRIPTION
Since https://github.com/navit-gps/navit/commit/4e5b35a97ea2f2e15b9b5f361ebd3bb9094a4be1 a dependency on PkgConfig creeped in for crosscompiling.

It is typical not to have gtk stuff installed if not compiling for linux, so PkgConfig isn't there either.

I fixed it in the first way that came to mind, anybody feel free to change.