### PR TITLE
android:fix mapdownload

### DIFF
--- a/navit/android/AndroidManifest.xml
+++ b/navit/android/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <application android:label="@string/app_name"
+    <application android:usesCleartextTraffic="true" android:label="@string/app_name"
         android:icon="@drawable/icon"
         android:name=".NavitAppConfig"
         android:theme="@style/NavitBaseTheme">


### PR DESCRIPTION
Errormessage on android 9 when downloading a map as mentioned in https://github.com/navit-gps/navit/issues/853
`E/org.navitproject.navit.NavitMapDownloader: Error reading from server: java.io.IOException: Cleartext HTTP traffic to maps.navit-project.org not permitted`

When Google released Android Marshmallow (API level 23), it provided a configuration to disable clear text traffic, which would prevent your app from making clear HTTP requests. With the release of Android Pie (API level 28), clear text traffic is disabled by default.

This PR enables cleartext traffic.