### PR TITLE
Refactoring:xml: Fix a typo of the OpenStreetMap name in the shipped XML

### DIFF
--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -414,7 +414,7 @@ Waypoint</text></img>
 			<xi:include href="$NAVIT_SHAREDIR/maps/*.xml"/>
 		</mapset>
 
-		<!-- Mapset template for openstreetmaps -->
+		<!-- Mapset template for OpenStreetMap -->
 		<mapset enabled="no">
 			<map type="binfile" enabled="yes" data="/media/mmc2/MapsNavit/osm_europe.bin"/>
 		</mapset>


### PR DESCRIPTION
Fixes a typo on the tradermarked name of OpenStreetMap.
I was curious after seeing #849 to see if we had some in the code so I found this one.