### PR TITLE
Refactoring:tools:minor Check exit code directly with e.g. "if mycmd;", not indirectly with $?

### DIFF
--- a/navit/script/cabify.sh
+++ b/navit/script/cabify.sh
@@ -2,8 +2,7 @@
 
 function check_pocketcab()
 {
-	which pocketpc-cab &> /dev/null
-	if [ $? -ne 0 ]
+	if ! which pocketpc-cab &> /dev/null
 	then
 		echo "You don't have pocketpc-cab installed or not in PATH"
 		exit

--- a/navit/startonce.sh
+++ b/navit/startonce.sh
@@ -21,9 +21,8 @@ NAVIT="./navit"
 
 function check_wmctrl()
 {
-	which wmctrl > /dev/null
-
-	if [ $? -ne 0 ] ; then
+	if ! which wmctrl > /dev/null
+	then
 		echo "I need the 'wmctrl' program. Exit."
 		exit 1
 	fi
@@ -39,9 +38,8 @@ function start_navit()
 
 	pid=$!
 
-	echo -n "$pid" > $PIDFILE
-
-	if [ $? -eq 0 ] ; then
+	if ! echo -n "$pid" > $PIDFILE
+	then
 		echo "Started navit with PID $pid."
 	else
 		kill $pid
@@ -59,12 +57,12 @@ function check_navit()
 {
 	if [ -f $PIDFILE ] ; then
     pid=$(cat $PIDFILE)
-		kill -0 $pid 2>/dev/null
-		if [ $? -eq 0 ] ; then
-			echo "Bringing Navit to front"
+		if ! kill -0 $pid 2>/dev/null
+		then
+            echo "Bringing Navit to front"
 
-      winid=$(wmctrl -l -p | grep -e "^[^:blank:]*[:blank:]*[^:blank:]*[:blank:]*$pid[:blank:]*" | sed 's/ .*//')
-			wmctrl -i -R $winid
+            winid=$(wmctrl -l -p | grep -e "^[^:blank:]*[:blank:]*[^:blank:]*[:blank:]*$pid[:blank:]*" | sed 's/ .*//')
+            wmctrl -i -R $winid
 
 			exit 0
 		fi

--- a/navit/tools/cleanattr.sh
+++ b/navit/tools/cleanattr.sh
@@ -20,8 +20,8 @@ if [ -f $TMPFILE ] ; then
 		exit 1;
 fi
 
-touch $TMPFILE
-if [ $? -ne 0 ] ; then
+if ! touch $TMPFILE
+then
 		echo "Could not write to temporary file $TEMPFILE."
 		echo "Please make sure you have write access to the temporary directory."
 		exit 1;
@@ -35,9 +35,8 @@ cp $ATTRFILE $TMPFILE
 for ATTRNAME in $ATTRLIST ; do
 		ATTR="attr_$ATTRNAME"
 
-		grep -rI $ATTR ./* > /dev/null
-
-		if [ $? -ne 0 ] ; then
+		if ! grep -rI $ATTR ./* > /dev/null
+		then
 				echo "Unused attribute: $ATTR"
 				grep -v "ATTR($ATTRNAME)" $TMPFILE > $TMPFILE2
 				mv $TMPFILE2 $TMPFILE

--- a/scripts/basic_upload_apks.py
+++ b/scripts/basic_upload_apks.py
@@ -79,4 +79,3 @@ def main(argv):
 
 if __name__ == '__main__':
   main(sys.argv)
-


### PR DESCRIPTION
This is a cleanup of the errors `Check exit code directly with e.g. 'if mycmd;', not indirectly with $?` found in codefactor: https://www.codefactor.io/repository/github/navit-gps/navit/issues/trunk?lang=1#
Nothing really exciting there.