### PR TITLE
Add watch after reopen the gps file

### DIFF
--- a/navit/vehicle/file/vehicle_file.c
+++ b/navit/vehicle/file/vehicle_file.c
@@ -684,6 +684,7 @@ static void vehicle_file_io(struct vehicle_priv *priv) {
         case 0:
             vehicle_file_close(priv);
             vehicle_file_open(priv);
+            vehicle_file_enable_watch(priv);    
             break;
         case 1:
             vehicle_file_disable_watch(priv);

--- a/navit/vehicle/file/vehicle_file.c
+++ b/navit/vehicle/file/vehicle_file.c
@@ -684,7 +684,7 @@ static void vehicle_file_io(struct vehicle_priv *priv) {
         case 0:
             vehicle_file_close(priv);
             vehicle_file_open(priv);
-            vehicle_file_enable_watch(priv);    
+            vehicle_file_enable_watch(priv);
             break;
         case 1:
             vehicle_file_disable_watch(priv);


### PR DESCRIPTION
vehicle_file_close(priv) disables watch of the file.
vehicle_file_open(priv) dont reenable it. So the gps position was frozen

In my case it is suspend/resume which lead to GPS the reopen.
