### PR TITLE
add:doc: Migrate MacOS, Windows and WinCE Development pages to readthedocs

### DIFF
--- a/docs/development/commit_guidelines.rst
+++ b/docs/development/commit_guidelines.rst
@@ -24,29 +24,29 @@ Format of the commit log
 
 Since we are too lazy to maintain a Changelog, we have a script which parses the commit logs and generate a Changelog for us.
 
-We have agreed about using the following syntax : ` <Action>:<component>:<log message>[|Optional comments]`
+We have agreed about using the following syntax : `<Action>:<component>:<log message>[|Optional comments]`
 
 Examples :
- Fix:Core:Fixed nasty bug in ticket #134
- Fix:GTK:Fixed nasty bug about destination button|Thanks someguy for the patch!
+ * Fix:Core:Fixed nasty bug in ticket #134
+ * Fix:GTK:Fixed nasty bug about destination button|Thanks someguy for the patch!
 
 Action can be something like:
-* Fix (bug fix)
-* Add (new feature)
-* Patch
-* Refactoring (does not change behavior of the program)
+ * Fix (bug fix)
+ * Add (new feature)
+ * Patch
+ * Refactoring (does not change behavior of the program)
 
 It allows the changes to be sorted by categories
 
 The most common components are:
-* core
-* gui/gtk
-* gui/internal
-* graphics/gtk
-* graphics/qt_qpainter
-* graphics/opengl
-* mapdriver
-* tools
+ * core
+ * gui/gtk
+ * gui/internal
+ * graphics/gtk
+ * graphics/qt_qpainter
+ * graphics/opengl
+ * mapdriver
+ * tools
 
 The comment part is optional. Useful for when applying a patch for example, and giving credits.
 The part after `|` will not appear in the wiki.

--- a/docs/development/macos_development.rst
+++ b/docs/development/macos_development.rst
@@ -1,0 +1,109 @@
+=================
+MacOS Development
+=================
+
+Here are some notes about running navit under Apple Mac OSX.
+
+What you will need
+==================
+
+You need Xcode Tools and MacPorts in order to install navit.
+
+MacPorts developers suggest to install Xcode Tools from http://developer.apple.com/tools/xcode/ and not from the Mac OSX install disk.
+See `Mac-How <http://www.mac-how.net/>`_
+
+Make sure you don't have fink installed on your system, it can confuse MacPorts package building and installation.
+
+ * GTK Gui: You should only need gtk2 and glib2 via macPorts
+ * SDL Gui: Untested yet.
+
+Installation instruction
+========================
+
+Download Xcode Tools from http://developer.apple.com/tools/xcode/ and install it with X11 SDK
+
+Download and Install MacPorts from http://www.macports.org/, or update your version
+
+.. code-block:: bash
+
+    sudo port -d selfupdate
+
+Open up a terminal
+
+make sure your PATH variables has `/opt/local/bin` and `/opt/local/sbin` in it:
+
+.. code-block:: bash
+
+    echo $PATH
+
+
+Install automake, wget, libtool, gpsd (if you want gps support), gtk2 and glib2 (for gkt GUI) with
+
+.. code-block:: bash
+
+    sudo port install automake wget gpsd gtk2 glib2 libtool
+
+Download navit or checkout it from Git
+
+.. code-block:: bash
+
+    git clone git@github.com:navit-gps/navit.git
+
+You may also need a header file to handle endian issues (for PPC only)
+
+.. code-block:: bash
+
+    wget https://navit.svn.sourceforge.net/svnroot/navit/tags/R0_1_0/navit/projs/CodeBlocks/Win32Extra/byteswap.h
+
+If you want to install navit along the MacPorts packages, you need to use the /opt/local directory as prefix:
+
+.. code-block:: bash
+
+  ./autogen.sh && ./configure --prefix=/opt/local --disable-binding-python
+
+type `make` to build NavIt, and `sudo make install` to install it.
+
+Then, you may edit and adapt your `navit.xml` file. The XML maptype is not supported, however normal Navit binfile works perfectly.
+
+Speech
+======
+
+If you want (spoken) directions, get espeak from http://espeak.sourceforge.net, install as advised and use the following snippet in your navit.xml:
+
+.. code-block:: xml
+
+           <speech type="cmdline" data="speak -vde+f4 '%s'"/>
+
+This will tell speak to use a female (f) german (de) voice.
+
+
+Using xcode
+===========
+
+Download one of the `Git sources <https://github.com/navit-gps/navit>`_ that don't contain autogen.sh.
+
+Open X-Code and create a new project. Cocoa will suffice
+
+Add in a new target by clicking the triangle next to "Targets" and selected the location of the navit folder. Delete the previous target.
+
+Delete the default files, and add in the navit files.
+
+In a terminal, go into the navit folder.
+
+.. code-block:: bash
+
+ ./configure --disable-binding-python --disable-sample-map --disable-maptool
+
+xcode can now build the navit
+
+
+You can also use CMake.
+
+.. code-block:: bash
+
+ cd navit && cmake -G Xcode .
+
+Something went wrong?
+=====================
+
+Please let us know by filing an issue on Github or reach out on IRC.

--- a/docs/development/programming_guidelines.rst
+++ b/docs/development/programming_guidelines.rst
@@ -9,10 +9,10 @@ Coding Style
 ============
 
 We try to follow those simple rules:
-* indentation is done using 4 spaces
-* the return type of a function is specified on the same line as the function name
-* the open brackets should be at the end of the line (on the same line as the function name or the if/for/while statement)
-* out line length is of 120 characters
+ * indentation is done using 4 spaces
+ * the return type of a function is specified on the same line as the function name
+ * the open brackets should be at the end of the line (on the same line as the function name or the if/for/while statement)
+ * out line length is of 120 characters
 
 To help us keeping a coherent indentation, we use astyle on C, C++ and java files. Usage example:
 
@@ -36,8 +36,7 @@ C Standard
 ----------
 
 C95. That means:
-
-* No inline declarations of variables
+ * No inline declarations of variables
 
 Instead of
 
@@ -58,7 +57,7 @@ use
        a=do_something_else();
     }
 
-* No dynamic arrays
+ * No dynamic arrays
 
 Instead of
 
@@ -76,7 +75,7 @@ use
        struct mystruct *x=g_alloca(count*sizeof(struct mystruct));
     }
 
-* No empty initializers
+ * No empty initializers
 
 Instead of
 
@@ -90,7 +89,7 @@ use
 
     struct mystruct m={0,};
 
-* Use `/*` and `*/` for comments instead of `//`
+ * Use `/*` and `*/` for comments instead of `//`
 
 .. note::
 
@@ -100,12 +99,12 @@ use
 Use of libraries
 ----------------
 
-* Navit uses [GLIB](http://developer.gnome.org/glib/) extensively. In general, code should use GLib's functions in preference to functions from libc.
-  For example, use `g_new()` / `g_free()` / `g_realloc()`, rather than `malloc()` / `free()` / `realloc()`, `g_strdup()` rather than `strdup()`, `g_strcmp0()` rather than `strcmp()` etc.
-* Unfortunately, not all platforms that Navit runs on have a native GLib version.
-  For these platforms, there is code replacing these libraries under `navit/support/`.
-  Take care to only use functions from GLib (or other libraries), that is also present under `navit/support/`.
-  If you need something that is not present there, please discuss it on IRC - it may be possible to add it to the support code.
+ * Navit uses `GLIB <http://developer.gnome.org/glib/>`_ extensively. In general, code should use GLib's functions in preference to functions from libc.
+   For example, use `g_new()` / `g_free()` / `g_realloc()`, rather than `malloc()` / `free()` / `realloc()`, `g_strdup()` rather than `strdup()`, `g_strcmp0()` rather than `strcmp()` etc.
+ * Unfortunately, not all platforms that Navit runs on have a native GLib version.
+   For these platforms, there is code replacing these libraries under `navit/support/`.
+   Take care to only use functions from GLib (or other libraries), that is also present under `navit/support/`.
+   If you need something that is not present there, please discuss it on IRC - it may be possible to add it to the support code.
 
 Comments
 --------
@@ -113,10 +112,10 @@ Comments
 General guidelines
 ``````````````````
 
-* Comments for the entire `file` and `classes/structs/methods/functions` is the `'minimum requirement`'. Examples see below.
-* Please comment your code in a significant and reasonable way.
-* A quick description of (complicated) algorithms makes it easier for other developers and helps them to save a lot of time.
-* Please add a doxygen description for all function you should add. You are we1come to add it too to older functions. Doxygen result can be found [there](http://doxygen.navit-project.org)
+ * Comments for the entire `file` and `classes/structs/methods/functions` is the `'minimum requirement`'. Examples see below.
+ * Please comment your code in a significant and reasonable way.
+ * A quick description of (complicated) algorithms makes it easier for other developers and helps them to save a lot of time.
+ * Please add a doxygen description for all function you should add. You are we1come to add it too to older functions. Doxygen result can be found `there <http://doxygen.navit-project.org>`_
 
 Example :
 
@@ -138,7 +137,7 @@ Example :
 Templates
 `````````
 
-This is an example how you could (should) comment your files and functions. If you have any suggestions for improvement, please feel free to [[Talk:Programming_guidelines|discuss]] them with us. These templates should be doxygen-conform - if not, please correct them. A more comprehensive overview of possible documentation can be found [http://www.stack.nl/~dimitri/doxygen/manual.html here].
+This is an example how you could (should) comment your files and functions. If you have any suggestions for improvement, please feel free to [[Talk:Programming_guidelines|discuss]] them with us. These templates should be doxygen-conform - if not, please correct them. A more comprehensive overview of possible documentation can be found `here <http://www.stack.nl/~dimitri/doxygen/manual.html>`_.
 
 Files
 '''''

--- a/docs/development/wince_development.rst
+++ b/docs/development/wince_development.rst
@@ -32,22 +32,22 @@ Building Navit using Cmake
     #!/bin/bash
     export NAVIT_PATH="/usr/src/navit"
     export MINGW32CE_PATH="/opt/mingw32ce"
-    export PATH=$PATH:$MINGW32CE_PATH/bin 
-    
+    export PATH=$PATH:$MINGW32CE_PATH/bin
+
     cd $NAVIT_PATH
-    if [ ! -e build ]; then 
+    if [ ! -e build ]; then
       mkdir build;
     fi;
     cd build
-    
+
     cmake \
     -DCMAKE_TOOLCHAIN_FILE=$NAVIT_PATH/Toolchain/arm-mingw32ce.cmake \
     -Dsvg2png_scaling:STRING=0,16 \
     -Dsvg2png_scaling_nav:STRING=32 \
     -Dsvg2png_scaling_country:STRING=16 \
     $NAVIT_PATH
-    
-    make 
+
+    make
 
 For subsequential builds it is sufficient to issue "make" in the build directory.
 A rerun of cmake is only neccessary if parameters are changed.
@@ -256,7 +256,7 @@ Add to `navit\support\wordexp\glob.h`: `|| defined __CEGCC__`
 Change include in `navit\vehicle\wince\vehicle_wince.c`: `#include <sys/io.h>`
 
 Add to `navit\file.c`: `&& !defined __CEGCC__`
-   
+
 .. code-block:: bash
 
     make -j

--- a/docs/development/wince_development.rst
+++ b/docs/development/wince_development.rst
@@ -1,0 +1,262 @@
+=================
+WinCE Development
+=================
+
+This is a tutorial for Navit on WinCE/WinMobile. If want just want to download a cab file see [[WinCE]].
+
+This page explains how to build Navit for WinCE/WinMobile with `cegcc <http://cegcc.sourceforge.net>`_.
+
+In November 2009 versions compiled using arm-cegcc-gcc (both revision 1214 and release 0.59.1) had problems (threw exception_datatype_misalignment and caused access violations).
+
+Using the variant arm-mingw32ce of CeGCC 0.59.1 it was possible to build a working executable which can be debugged.
+
+The automatic builds from the subversion repository seem to use an adjusted? version arm-wince-mingw32ce (see `build logs <http://download.navit-project.org/logs/navit/wince/svn>`_).
+
+Building using arm-mingw32ce
+============================
+
+Install arm-mingw32ce
+
+.. code-block:: bash
+
+    mkdir -p navit
+    cd navit
+    export NAVIT_PATH=`pwd`
+    wget -c https://sourceforge.net/projects/cegcc/files/cegcc/0.59.1/mingw32ce-0.59.1.tar.bz2/download
+    tar xjf mingw32ce-0.59.1.tar.bz2
+
+Building Navit using Cmake
+
+.. code-block:: bash
+
+    #!/bin/bash
+    export NAVIT_PATH="/usr/src/navit"
+    export MINGW32CE_PATH="/opt/mingw32ce"
+    export PATH=$PATH:$MINGW32CE_PATH/bin 
+    
+    cd $NAVIT_PATH
+    if [ ! -e build ]; then 
+      mkdir build;
+    fi;
+    cd build
+    
+    cmake \
+    -DCMAKE_TOOLCHAIN_FILE=$NAVIT_PATH/Toolchain/arm-mingw32ce.cmake \
+    -Dsvg2png_scaling:STRING=0,16 \
+    -Dsvg2png_scaling_nav:STRING=32 \
+    -Dsvg2png_scaling_country:STRING=16 \
+    $NAVIT_PATH
+    
+    make 
+
+For subsequential builds it is sufficient to issue "make" in the build directory.
+A rerun of cmake is only neccessary if parameters are changed.
+
+Remote Debugging
+================
+
+Download the debugger provided by the CeGCC project:
+
+.. code-block:: bash
+
+    cd $NAVIT_PATH
+    wget -c https://sourceforge.net/projects/cegcc/files/cegcc/0.59.1/gdb-arm-0.59.1.tar.bz2/download
+    tar xjf gdb-arm-0.59.1.tar.bz2
+
+Start navit (from SD card) in debug server at target (using TCP port 9999):
+
+.. code-block:: bash
+
+    gdbserver :9999 "\Mounted Volume\navit\navit.exe"
+
+Execute remote debugger at host, if target's IP address was 192.168.1.112:
+
+.. code-block:: bash
+
+    $NAVIT_PATH/opt/mingw32ce/bin/arm-mingw32ce-gdbtui $NAVIT_PATH/navit/navit.exe -eval-command="target remote 192.168.1.112:9999"
+
+Building using arm-cegcc
+========================
+
+Building cegcc
+--------------
+
+Set the install path to where you want to install `cegcc <http://cegcc.sourceforge.net cegcc>`_:
+
+.. code-block:: bash
+
+    export CEGCC_PATH=/usr/local/cegcc
+    svn co -r 1214 https://cegcc.svn.sourceforge.net/svnroot/cegcc/trunk/cegcc
+    mkdir -p cegcc-builds
+    cd cegcc-builds
+    ../cegcc/src/build-cegcc.sh --prefix=$CEGCC_PATH --components="binutils bootstrap_gcc w32api newlib dummy_cegccdll gcc cegccdll cegccthrddll libstdcppdll profile"
+
+If you get an error like "'makekinfo' is missing on your system" although makeinfo is available (happened with openSUSE 11.2 and Debian Lenny, both 32 bit), add a workaround to the script src/newlib/missing. Insert a new line after the line "  makeinfo)":
+
+.. code-block:: bash
+
+     "$@" && exit 0
+
+If you get an error like `arm-cegcc-windres: Can't detect architecture`, apply the patch file you find on http://sourceforge.net/tracker/?func=detail&atid=865516&aid=2574606&group_id=173455
+
+Building libraries
+------------------
+
+November 2009: The libraries below are *not needed* anymore since navit brings its own version of glib.
+
+The libraries require additional (not published or not existing) patches to build. Just skip to section Building Navit.
+
+These are the libraries needed and versions which should work:
+ * zlib-1.2.3
+ * libiconv-1.9.1
+ * gettext-0.17
+ * libpng-1.2.34
+ * tiff-3.8.2
+ * glib-2.18.4
+
+The current versions of these libs don't need many changes, but they all don't know anything about cegcc. Until I found a way to upload the patches, you have to edit the code yourself. Just add `| -cegcc*` to the line containing `-cygwin*` of all files named config.sub. Here is the example for libiconv-1.9.1_cegcc.patch:
+
+.. code-block:: bash
+
+    diff -ur libiconv-1.9.1/autoconf/config.sub libiconv-1.9.1_cegcc/autoconf/config.sub
+    --- libiconv-1.9.1/autoconf/config.sub 2003-05-06 11:36:42.000000000 +0200
+    +++ libiconv-1.9.1_cegcc/autoconf/config.sub   2009-02-06 20:22:14.000000000 +0100
+    @@ -1121,7 +1121,7 @@
+             | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
+             | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
+             | -chorusos* | -chorusrdb* \
+    -        | -cygwin* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
+    +        | -cygwin* | -pe* | -psos* | -moss* | -proelf* | -rtems* | -cegcc* \
+             | -mingw32* | -linux-gnu* | -uxpv* | -beos* | -mpeix* | -udk* \
+             | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* | -opened* \
+             | -openstep* | -oskit* | -conix* | -pw32* | -nonstopux* \
+    diff -ur libiconv-1.9.1/libcharset/autoconf/config.sub libiconv-1.9.1_cegcc/libcharset/autoconf/config.sub
+    --- libiconv-1.9.1/libcharset/autoconf/config.sub  2003-05-06 11:36:42.000000000 +0200
+    +++ libiconv-1.9.1_cegcc/libcharset/autoconf/config.sub    2009-02-06 20:23:39.000000000 +0100
+    @@ -1121,7 +1121,7 @@
+             | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
+             | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
+             | -chorusos* | -chorusrdb* \
+    -        | -cygwin* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
+    +        | -cygwin* | -pe* | -psos* | -moss* | -proelf* | -rtems* | -cegcc* \
+             | -mingw32* | -linux-gnu* | -uxpv* | -beos* | -mpeix* | -udk* \
+             | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* | -opened* \
+             | -openstep* | -oskit* | -conix* | -pw32* | -nonstopux* \
+
+zlib
+''''
+
+.. code-block:: bash
+
+    wget http://www.zlib.net/zlib-1.2.3.tar.gz
+    tar xzf zlib-1.2.3.tar.gz
+    cd zlib-1.2.3
+    export PATH=$CEGCC_PATH/bin:$PATH
+    CC=arm-cegcc-gcc AR="arm-cegcc-ar r" RANLIB=arm--cegcc-ranlib ./configure --prefix=$CEGCC_PATH
+    make
+    make install
+
+libiconv
+''''''''
+
+
+.. code-block:: bash
+
+    wget http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.9.1.tar.gz
+    tar xzf libiconv-1.9.1.tar.gz
+    patch -d libiconv-1.9.1 -p1 < libiconv-1.9.1_cegcc.patch
+    cd libiconv-1.9.1
+    ./configure --host=arm-cegcc --prefix=$CEGCC_PATH
+    make
+    make install
+
+gettext
+'''''''
+
+workaround for `plural-eval.h:50: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'sigfpe_exit'`
+extend gettext-tools/src/plural-eval.h line 32 to `#if defined _MSC_VER || defined __MINGW32__ || defined __CEGCC__`
+dito for gettext-tools/gnulib-lib/wait-process.c line 31
+
+
+.. code-block:: bash
+
+    wget http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/gettext-0.17.tar.gz
+    tar xzf gettext-0.17.tar.gz
+    cd gettext-0.17
+    patch -p1 < ../gettext-0.17_cegcc.patch
+    ./configure --host=arm-cegcc --prefix=$CEGCC_PATH
+    make
+    make install
+
+libpng
+''''''
+
+.. code-block:: bash
+
+    wget http://prdownloads.sourceforge.net/libpng/libpng-1.2.34.tar.gz?download
+    tar xzf libpng-1.2.34.tar.gz
+    cd libpng-1.2.34
+    patch -p1 < ../libpng-1.2.34_cegcc.patch
+    ./configure --host=arm-cegcc --prefix=$CEGCC_PATH
+    CFLAG="-I $C_INCLUDE_PATH" make
+    make install
+
+libtiff
+'''''''
+
+.. code-block:: bash
+
+ libtool: link: CURRENT `' must be a nonnegative integer
+
+
+.. code-block:: bash
+
+    wget http://libtiff.maptools.org/dl/tiff-3.8.2.tar.gz
+    tar xzf tiff-3.8.2.tar.gz
+    cd tiff-3.8.2
+    patch -p1 < ../tiff-3.8.2_cegcc.patch
+    ./configure --host=arm-cegcc --prefix=$CEGCC_PATH
+    make
+    make install
+
+glib
+''''
+
+.. code-block:: bash
+
+ gatomic.c:570: Error: no such instruction: `swp %eax,%eax,[%esi]'
+
+
+.. code-block:: bash
+
+    wget http://ftp.gnome.org/pub/gnome/sources/glib/2.18/glib-2.18.4.tar.bz2
+    tar xjf glib-2.18.4.tar.bz2
+    cd glib-2.18.4
+    patch -p1 < ../glib-2.18.4_cegcc.patch
+    ./configure --host=arm-cegcc --prefix=$CEGCC_PATH
+    make
+    make install
+
+Building Navit
+==============
+
+.. code-block:: bash
+
+    git clone https://github.com/navit-gps/navit.git
+    cd navit/navit
+
+Add `| -cegcc*` to all files named `config.sub` as for the libraries.
+
+.. code-block:: bash
+
+ WINDRES=arm-cegcc-windres ./configure --disable-vehicle-file --host=arm-cegcc --prefix=$CEGCC_PATH 2>&1 | tee configure-cegcc.log
+
+Add to `navit\support\wordexp\glob.h`: `|| defined __CEGCC__`
+
+Change include in `navit\vehicle\wince\vehicle_wince.c`: `#include <sys/io.h>`
+
+Add to `navit\file.c`: `&& !defined __CEGCC__`
+   
+.. code-block:: bash
+
+    make -j

--- a/docs/development/windows_development.rst
+++ b/docs/development/windows_development.rst
@@ -1,0 +1,538 @@
+===================
+Windows Development
+===================
+
+Compiling using CMake
+=====================
+
+At the moment, compiling with [[CMake]] seems to be the only way to create a runnable binary in Windows.
+
+
+Compiling / debugging using CodeBlocks & mingw compiler
+=======================================================
+
+ Up to and including release 0.0.4 the Win32 builds were supported using the CodeBlocks/mingw development environment, 
+ in combination with the glade for win32 GTK devlopment toolkit. For release 0.1.0 and later use native mingw 
+ (see below) or cygwin (see below).
+
+Downloads
+---------
+
+In order to compile the win32 version of Navit, you need the following software development tools:
+ * Glade/gtk+ toolkit for win32 from `Glade 3.43 / Gtk 2.12.9 <http://sourceforge.net/project/showfiles.php?group_id=98754>`_
+   and `SourceForgeDownload: Gtk+ 2.10.11 <http://sourceforge.net/project/showfiles.php?group_id=98754&package_id=111411>`_
+ * ming compiler from `Website: mingw <http://www.mingw.org>`_ or `SourceForgeDownload: MinGW <http://sourceforge.net/project/showfiles.php?group_id=2435>`_ (select Automated MinGW installer).
+ * CodeBlocks IDE from `CodeBlocks download page <http://www.codeblocks.org/downloads.shtml>`_ (select recent development snapshot)
+   or `SourceForgeDownload: CodeBlocks <http://sourceforge.net/project/showfiles.php?group_id=126998&package_id=138996>`_
+
+Installation
+------------
+
+Install the packages mentioned above. After everything has been installed you can open the navit.workspace file in CodeBlocks:
+
+.. warning::
+
+    Not up to date! Directory projs\CodeBlocks was deleted in 2009
+
+Compiling
+---------
+
+.. warning::
+
+    Not up to date! Directory projs\CodeBlocks was deleted in 2009
+
+To compile:
+
+ * Start the CodeBlocks application
+ * Open the navit.workspace file (located in projs\CodeBlocks directory)
+ * Set the GTK_DIR enviroment variable in CodeBlocks (Setting/Environment, and select environments variables)
+ * the GTK_DIR should point to where you have installed the Glade/Gtk toolkit package (e.g. d:\gtk)
+
+Now you should be able to  build/debug the navit project:
+
+Note:
+
+**ZLIB -lzdll message** `Settings> Compiler and Debugger..> Global compiler settings` In the Linker settings TAB (Add) C:\MinGW\lib\libzdll.a
+
+**SAPI** You need to download and install the `Microsoft Speech SDK 5.1 <http://www.microsoft.com/downloads/details.aspx?FamilyID=5e86ec97-40a7-453f-b0ee-6583171b4530&displaylang=en>`_ for this project to build.
+
+Running from debugger
+---------------------
+
+In order to run navit from the CodeBlocks debugger, you have to:
+ * Copy the navit.xml file from the source directory into the projs\CodeBlocks directory
+ * Copy the xpm directory from the toplevel directory into the projs\CodeBlocks directory
+ * Modify the navit.xml to set the map (currently only OSM binary files are supported)
+
+Compiling and running using cygwin
+==================================
+
+Download cygwin
+---------------
+
+Download the cygwin setup.exe from http://cygwin.com/setup.exe
+
+.. note::
+    I have been unable to build with cygwin according to these instructions. I suggest you only try it if you are knowledgable
+    and can improve the instructions. --[[User:Nop|Nop]] 13:01, 7 November 2010 (UTC)
+
+Dependencies
+------------
+
+You will probably need the following packages from cygwin :
+
+ * automake
+ * autoconf
+ * gtk2-x11-devel
+ * libQt4Gui-devel
+ * libQtSql4--devel
+ * gcc
+ * g++ (for qt rendered)
+ * gettext-devel
+ * diffutils
+ * pkgconfig
+ * xorg-x11-devel
+ * glib2-devel
+ * pango-devel
+ * atk-devel
+ * libtool
+ * make
+ * rsvg
+ * wget
+ * cvs because of autopoint
+
+Prepare the build
+-----------------
+
+When using cygwin 1.7 you can skip this block and continue at cygwin 1.7
+
+Edit configure.in and add the following to CFLAGS at line 10:
+
+.. code-block:: bash
+
+    -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
+
+It should look like this :
+
+.. code-block:: bash
+
+         CFLAGS="$CFLAGS -Wall -Wcast-align -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wpointer-arith -Wreturn-type -D_GNU_SOURCE -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include"
+
+Now run `autogen.sh && ./configure`
+
+If you get: `checking for X... no`
+try adding the following parameters to ./configure :
+`--x-libraries=/usr/X11R6/lib  --x-include=/usr/X11R6/includes`
+
+Cygwin 1.7
+''''''''''
+
+With cygwin 1.7 is fairly easy to build navit. Install all the required packages(some has diffrent names now).
+Run the autogen script first `./autogen.sh`
+and then configure with the following options: `./configure --disable-binding-python --disable-plugins`
+
+Build navit
+-----------
+
+Skip for cygwin 1.7
+
+Currently, building navit will fail at this point, because we haven't found an implementation of the wordexp function for cygwin.
+
+Here's a message in that thread from an actual competent Cygwin user: http://www.mail-archive.com/cygwin@cygwin.com/msg16750.html
+
+The implication of that is a "C library". A "C library" is an "implementation" of reusable code. It consists of a library file that contains the compiled object code and a header file with the matching declarations that goes along with it. The library is implemented as a static archive at build time and simply linked into the app binary. There's nothing to include in that case -- it's already in there.
+
+
+Cygwin 1.7
+''''''''''
+
+Just type `make` and `make install`.  You can use stow for easy install and uninstall stuff without using packagemangement.
+
+Configuration GPS
+-----------------
+
+.. note::
+
+    If this works at all, it's only when running under cygwin. See above for the proper Win32 configuration. --[[User:Nop|Nop]] 13:04, 7 November 2010 (UTC)
+
+If you have a gps cable device which spits out NMEA data, you can configure it like under unix. Beware of the following enumeration:
+ * ComPort1==ttyS0
+ * ComPort2==ttyS1
+ * ...
+
+Example:
+
+.. code-block:: xml
+
+    <vehicle name="GPSOnCom3" profilename="car" enabled="yes" active="1" source="file:/dev/ttyS2" baudrate="38400" color="#0000ff"/>
+
+Running under Cygwin
+--------------------
+
+To run navit under cygwin you need to install the cygwin xorg-server. Than just run navit.
+
+
+
+Make a redistributable package
+------------------------------
+
+
+Please read and understand http://cygwin.com/licensing.html so that you don't infringe Cygwin's intellectual property rights (copyleft) when you distribute the package you've built.
+Then follows: http://cygwin.com/setup.html
+
+Compiling a native binary using mingw
+=====================================
+
+The main advantage of this method is that it will produce a redistributable binary.
+
+Downloads
+---------
+
+In order to compile the win32 version of Navit, you need the following software development tools
+ * GTK+ toolkit for win32 from `SourceForgeDownload: Glade/GTK+ <http://sourceforge.net/project/showfiles.php?group_id=98754>`_ (select gtk+-win32-devel)
+ * MinGW from `SourceForgeDownload: MinGW <http://sourceforge.net/project/showfiles.php?group_id=2435>`_ (select Automated MinGW installer)
+ * MSYS from `SourceForgeDownload: MSYS Base System <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=2496>`_
+ * msysCORE from `SourceForgeDownload: MSYS Base System <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=24963>`_
+ * diffutils from `SourceForgeDownload: MSYS Base System <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=24963>`_
+ * autoconf from `SourceForgeDownload: MSYS Supplementary Tools <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=67879>`_
+ * autogen from `SourceForgeDownload: MSYS Supplementary Tools <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=67879>`_
+ * automake from `SourceForgeDownload: MSYS Supplementary Tools <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=67879>`_
+ * gettext from `SourceForgeDownload: MSYS Supplementary Tools <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=67879>`_
+ * libtool from `SourceForgeDownload: MSYS Supplementary Tools <http://sourceforge.net/project/showfiles.php?group_id=2435&package_id=67879>`_
+ * libiconv from `SourceForgeDownload: MSYS Supplementary Tools <http://sourceforge.net/downloads/mingw/MinGW/libiconv>`_
+
+Probably the easiest way to obtain and install all the MSYS packages is to follow the instructions `here <http://www.mingw.org/wiki/msys>`_
+
+For speech support, one option is to use the "cmdline" speech type (refer to [[Configuration]]) and a utility such as a Windows port of `Say <http://krolik.net/wsvn/wsvn/public/Say%2B%2B/>`_
+
+TroubleShooting
+===============
+
+.. code-block::
+
+    /bin/m4: unrecognized option '--gnu'
+
+Wrong version of m4, use 1.4.13
+
+
+.. code-block::
+
+    Can't locate object method "path" via package "Request (perhaps you forgot to load "Request"?)
+
+Wrong version of Autoconf, make sure the latest version is installed, plus the wrapper (version 1.7). Also delete autom4te.cache.
+
+
+.. code-block::
+
+    command PKG_MODULE_EXISTS not recognized
+
+For some reason the necessary file "pkg.m4" containing various macros is missing. Find it and put it in ./m4
+
+Cross-Compiling win32 exe using Linux Ubuntu 14.04.1
+====================================================
+
+This is a quick walk-thru on compiling a win32 exe using Ubuntu as development machine.
+
+Set up Ubuntu to build Linux version
+------------------------------------
+
+First, setup compiling in linux ubuntu explained in https://navit.readthedocs.io/en/trunk/development/linux_development.html
+Here is a quick walk-thru:
+
+Get all the dependencies for Ubuntu in one command:
+
+.. code-block:: bash
+
+    sudo apt-get install cmake zlib1g-dev libpng12-dev libgtk2.0-dev librsvg2-bin \
+    g++ gpsd gpsd-clients libgps-dev libdbus-glib-1-dev freeglut3-dev libxft-dev \
+    libglib2.0-dev libfreeimage-dev gettext
+
+get the latest SVN-source.
+First, cd into root: `cd ~`
+
+Now, let's grab the code from SVN. This assumes that you have subversion installed.
+This will download the latest SVN source and put in in folder "navit-source".
+You can use any location you want for the source, just to keep it simple we place it right in the root.
+`svn co  svn://svn.code.sf.net/p/navit/code/trunk/navit/ navit-source`
+
+Create a directory to put the build in and cd into it:
+
+.. code-block:: bash
+
+    mkdir navit-build
+    cd navit-build
+
+Start compiling and build navit: `cmake ~/navit-source && make`
+
+At the end of the process navit is built into navit-build/.
+You can start navit to see if all worked well:
+
+.. code-block:: bash
+
+    cd ~/navit-build/navit/
+    ./navit
+
+Building the win32 exe
+----------------------
+
+Now that we have set up the basic building environment we can build a win32 exe using the next walk-thru.
+
+Install ming32 and the dependencies: `sudo apt-get install mingw32 libsaxonb-java librsvg2-bin  mingw32-binutils mingw32-runtime default-jdk`
+
+now cd into the source:
+
+.. code-block:: bash
+
+    cd ~
+    cd navit-source
+
+We are going to place the build directory within the source directory.
+First, make the build directory and cd into it:
+
+.. code-block:: bash
+
+    mkdir build
+    cd build
+
+From within the build directory start compiling and building:
+
+.. code-block:: bash
+
+    cmake -DCMAKE_TOOLCHAIN_FILE=../Toolchain/mingw32.cmake ../
+
+And then make the actual build:
+
+.. code-block:: bash
+
+    make -j4
+
+The -j4 part is used to define the amount of processors the process can use.
+So if you have a dual-core pc use -j2
+If -j4 fails, try -j2 and if that fails try "make" alone.
+
+Known "bugs"
+------------
+
+The "locale" folder is generated one level up.
+because of that the languages in navit are not working
+Cut and paste (or move) the "locale" folder to the navit folder.
+This should be investigated anf fixed so the folder is in the correct place after a build.
+So move `navit-source/build/locale/` to `navit-source/build/navit/locale`
+
+You can run `mv navit-source/build/locale/  navit-source/build/navit/`
+
+The country-flags images in the "town" search are not displayed.
+This could be due to a conversion error during build, has to be investigated and solved but doesn't inflict with the use of navit.
+
+There are a lot of empty folders that are not of use.
+Also there are cmake folders and files in every folder.
+You can delete those without any problem.
+
+Windows Mobile/Windows CE
+=========================
+
+[[WinCE_development]] may have details that are relevant for compilation on WindowsCE / Windows Mobile.
+
+You can download now
+[http://download.navit-project.org/navit/wince/svn/ cab or zip file for Windows Mobile and WindowsCE]!
+Highest number is the newest version of NavIt.
+
+Download it and save on your Storage Card. Install it.
+
+Now you have NavIt on your PDA or Mobile Phone.
+
+This is a manual for self compiling (navit.exe)
+
+
+You need to have a Linux (like Ubuntu).
+If you didn´t have Linux, start your Linux on Live-CD.
+
+Compiling navit for wince using http://cegcc.sourceforge.net/.
+Download latest cegcc release and install it.
+
+In November 2009 versions compiled using arm-cegcc-gcc (both revision 1214 and release 0.59.1) had problems (threw exception_datatype_misalignment and caused access violations).<br />
+Using the variant arm-mingw32ce of CeGCC 0.59.1 it was possible to build a working executable which can be debugged (see [[WinCE development]]).
+
+Source [http://www.archlinux.de/?page=PackageDetails;package=4837 cegcc-arm and mingw]  (TODO dead link)
+
+Current installs in /opt/cegcc.
+Setup a cross-compile environment:
+
+Example setcegccenv.sh:
+
+.. code-block:: bash
+
+    #! /bin/bash
+    export PATH=$PATH:/opt/cegcc/bin/
+    export CEGCC_PATH=/opt/cegcc
+    export WINCE_PATH=/opt/wince
+    export PATH=$CEGCC_PATH/bin:$PATH
+    export CPPFLAGS="-I$WINCE_PATH/include"
+    export LDFLAGS="-L$WINCE_PATH/lib -L$CEGCC_PATH/lib"
+    export LD_LIBRARY_PATH="$WINCE_PATH/bin"
+    export PKG_CONFIG_PATH="$WINCE_PATH/lib/pkgconfig"
+    export PKG_CONFIG_LIBDIR="$WINCE_PATH/lib/pkgconfig"
+ 
+
+For installation, compiling and configuring please see manual for NavIt on Linux.
+
+Then autogen.sh and configure navit. Example configure for wince:
+
+.. code-block:: bash
+
+    ./configure \
+    RANLIB=arm-cegcc-ranlib \
+    CXX=arm-cegcc-g++ \
+    CC=arm-cegcc-gcc \
+    --host=arm-pe-wince \
+    --disable-readline \
+    --disable-dynamic-extensions \
+    --disable-largefile \
+    --enable-tempstore \
+    CFLAGS="-I/opt/wince/include -mwin32 -DWIN32 -D_WIN32_WCE=0x0400 -D_WIN32_IE=0x0400 -Wl,--enable-auto-import" \
+    LDFLAGS="-L/opt/wince/lib" \
+    --prefix=/opt/wince/  \
+    WINDRES=arm-cegcc-windres \
+    --disable-vehicle-demo \
+    --disable-vehicle-file \
+    --disable-speech-cmdline \
+    --disable-speech-speech-dispatcher  \
+    --disable-postgresql \
+    --disable-plugins \
+    --prefix=/opt/wince \
+    --disable-graphics-qt-qpainter \
+    --disable-gui-sdl  \
+    --disable-samplemap \
+    --disable-gui-gtk \
+    --disable-gui-internal \
+    --disable-vehicle-gypsy \
+    --disable-vehicle-file \
+    --disable-vehicle-demo  \
+    --disable-binding-dbus \
+    --enable-avoid-unaligned \
+    --enable-avoid-float 
+
+If example did not run, do this:
+
+.. code-block:: bash
+
+    ./configure \
+     RANLIB=arm-mingw32ce-ranlib \
+     CXX=arm-mingw32ce-g++ \
+     CC=arm-mingw32ce-gcc \
+     --host=arm-pe-wince \
+     --disable-readline \
+     --disable-dynamic-extensions \
+     --disable-largefile \
+     --enable-tempstore ¸\
+     CFLAGS="-mwin32 -DWIN32 -D_WIN32_WCE=0x0400 -D_WIN32_IE=0x0400 -Wl,\
+     --enable-auto-import" WINDRES=arm-mingw32ce-windres \
+     --disable-vehicle-demo  \
+     --disable-vehicle-file \
+     --disable-speech-cmdline \
+     --disable-speech-speech-dispatcher  \
+     --disable-postgresql  \
+     --disable-plugins \
+     --prefix=/opt/wince \
+     --disable-graphics-qt-qpainter \
+     --disable-gui-sdl  \
+     --disable-samplemap \
+     --disable-gui-gtk \
+     --disable-gui-internal \
+     --disable-vehicle-gypsy \
+     --disable-vehicle-file \
+     --disable-vehicle-demo \
+     --disable-binding-dbus \
+     --enable-avoid-unaligned \
+     --enable-avoid-float \
+     --enable-support-libc \
+     PKG_CONFIG=arm-mingw32ce-pkgconfig 
+
+
+This is basic just to view the maps. Then: `make`
+As usual, osm2navit.exe will fail to compile. `cd navit && make navit.exe`
+You find navit.exe under (your directory)/navit/navit/navit.exe
+
+Install sync on your system. 
+ 
+
+----
+
+For installation you need packages librapi, liprapi2, pyrapi2, libsync.
+Package synce-0.9.0-1 contains librapi and libsync.
+You do not need to install it again!
+
+Sources: [http://sourceforge.net/project/showfiles.php?group_id=30550 Sync] If link is crashed, use this: [http://rpmfind.net/linux/rpm2html/search.php?query=librapi.so.2 Sync Link2]
+libsync: [http://sourceforge.net/project/mirror_picker.php?height=350&width=300&group_id=30550&use_mirror=puzzle&filesize=&filename=libsynce-0.12.tar.gz&abmode= libsync]
+pyrapi2: [http://rpmfind.net/linux/rpm2html/search.php?query=pyrapi2.so pyrapi2]
+librapi2 [http://repository.slacky.eu/slackware-12.0/libraries/synce-librapi/0.11.0/src/ librapi2]
+
+Once you have navit.exe ready, copy `/opt/cegcc/arm-cegcc/lib/device/*.dll` on your device.
+
+For Debian use:
+
+.. code-block::
+
+    synce-pcp /opt/cegcc/arm-cegcc/lib/device/cegcc.dll ":/windows/cegcc.dll"
+    synce-pcp /opt/cegcc/arm-cegcc/lib/device/cegccthrd.dll ":/windows/cegccthrd.dll"
+
+All other Linux/Unix systems use:
+
+.. code-block::
+
+    pcp /opt/cegcc/arm-cegcc/lib/device/cegcc.dll ":/windows/cegcc.dll"
+    pcp /opt/cegcc/arm-cegcc/lib/device/cegccthrd.dll ":/windows/cegccthrd.dll"
+
+
+Synchronisation with a grahic surface, if connection to device failed:
+
+Packages RAKI and RAPIP you can use.
+
+RAKI you have in packages synce-kde (see Synce).
+
+RAKI is like Active Sync, RAPIP is a little bit like fish:// under Konquerror.
+
+Under SuSE Linux you can run kitchensync (not for all PDA).
+
+For synchronisation you can also use kpilot under Suse Linux (runs not with all PDA) or Microsoft Active Sync under Windows (free download at Microsoft homepage).
+
+You can put your memory card in card reader and copy data. Over console you must type in `sync` before you remove memory card.
+ 
+Install navit.exe.
+
+Debian:
+
+.. code-block::
+
+    synce-pcp navit.exe ":/Storage Card/navit.exe"
+ 
+All other:
+
+.. code-block::
+
+    pcp navit.exe ":/Storage Card/navit.exe"
+ 
+
+Prepare a navit.xml.wince
+
+Change gui to win32 and graphics to win32.
+
+Fix the paths to your maps "/Storage Card/binfilemap.bin"
+
+Debian: 
+
+.. code-block::
+
+    synce-pcp binfilemap.bin ":/Storage Card/binfilemap.bin"
+    synce-pcp navit.xml.wince ":/Storage Card/navit.xml"
+
+All other:
+
+.. code-block::
+
+    pcp binfilemap.bin ":/Storage Card/binfilemap.bin"
+    pcp navit.xml.wince ":/Storage Card/navit.xml"
+
+
+For a start best use the samplemap.
+Now you can launch navit.exe on the device.

--- a/docs/development/windows_development.rst
+++ b/docs/development/windows_development.rst
@@ -11,8 +11,8 @@ At the moment, compiling with [[CMake]] seems to be the only way to create a run
 Compiling / debugging using CodeBlocks & mingw compiler
 =======================================================
 
- Up to and including release 0.0.4 the Win32 builds were supported using the CodeBlocks/mingw development environment, 
- in combination with the glade for win32 GTK devlopment toolkit. For release 0.1.0 and later use native mingw 
+ Up to and including release 0.0.4 the Win32 builds were supported using the CodeBlocks/mingw development environment,
+ in combination with the glade for win32 GTK devlopment toolkit. For release 0.1.0 and later use native mingw
  (see below) or cygwin (see below).
 
 Downloads
@@ -372,7 +372,7 @@ Example setcegccenv.sh:
     export LD_LIBRARY_PATH="$WINCE_PATH/bin"
     export PKG_CONFIG_PATH="$WINCE_PATH/lib/pkgconfig"
     export PKG_CONFIG_LIBDIR="$WINCE_PATH/lib/pkgconfig"
- 
+
 
 For installation, compiling and configuring please see manual for NavIt on Linux.
 
@@ -410,7 +410,7 @@ Then autogen.sh and configure navit. Example configure for wince:
     --disable-vehicle-demo  \
     --disable-binding-dbus \
     --enable-avoid-unaligned \
-    --enable-avoid-float 
+    --enable-avoid-float
 
 If example did not run, do this:
 
@@ -446,15 +446,15 @@ If example did not run, do this:
      --enable-avoid-unaligned \
      --enable-avoid-float \
      --enable-support-libc \
-     PKG_CONFIG=arm-mingw32ce-pkgconfig 
+     PKG_CONFIG=arm-mingw32ce-pkgconfig
 
 
 This is basic just to view the maps. Then: `make`
 As usual, osm2navit.exe will fail to compile. `cd navit && make navit.exe`
 You find navit.exe under (your directory)/navit/navit/navit.exe
 
-Install sync on your system. 
- 
+Install sync on your system.
+
 
 ----
 
@@ -497,7 +497,7 @@ Under SuSE Linux you can run kitchensync (not for all PDA).
 For synchronisation you can also use kpilot under Suse Linux (runs not with all PDA) or Microsoft Active Sync under Windows (free download at Microsoft homepage).
 
 You can put your memory card in card reader and copy data. Over console you must type in `sync` before you remove memory card.
- 
+
 Install navit.exe.
 
 Debian:
@@ -505,13 +505,13 @@ Debian:
 .. code-block::
 
     synce-pcp navit.exe ":/Storage Card/navit.exe"
- 
+
 All other:
 
 .. code-block::
 
     pcp navit.exe ":/Storage Card/navit.exe"
- 
+
 
 Prepare a navit.xml.wince
 
@@ -519,7 +519,7 @@ Change gui to win32 and graphics to win32.
 
 Fix the paths to your maps "/Storage Card/binfilemap.bin"
 
-Debian: 
+Debian:
 
 .. code-block::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,3 +48,4 @@ Navit is highly customizable, from map layouts and on-screen display to the deta
    development/programming_guidelines
    development/commit_guidelines
    development/linux_development
+   development/macos_development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,3 +49,4 @@ Navit is highly customizable, from map layouts and on-screen display to the deta
    development/commit_guidelines
    development/linux_development
    development/macos_development
+   development/wince_development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,3 +50,4 @@ Navit is highly customizable, from map layouts and on-screen display to the deta
    development/linux_development
    development/macos_development
    development/wince_development
+   development/windows_development


### PR DESCRIPTION
Migrating
https://wiki.navit-project.org/index.php/MacOS_development
https://wiki.navit-project.org/index.php/WinCE_development
https://wiki.navit-project.org/index.php/Windows_development

And fixing some formatting.