### PR TITLE
fix/enhancement:graphics/layout:get default icon size from layout + draw tunnels transparent + mark oneway streets

### DIFF
--- a/navit/attr_def.h
+++ b/navit/attr_def.h
@@ -263,6 +263,7 @@ ATTR(waypoints_flag) /* toggle for "set as destination" to switch between start 
 ATTR(no_warning_if_map_file_missing)
 ATTR(duplicate)
 ATTR(has_menu_button)
+ATTR(oneway)
 ATTR2(0x0002ffff,type_int_end)
 ATTR2(0x00030000,type_string_begin)
 ATTR(type)

--- a/navit/attr_def.h
+++ b/navit/attr_def.h
@@ -202,6 +202,7 @@ ATTR(autozoom_max)
 ATTR(nav_status)
 ATTR(virtual_dpi)
 ATTR(real_dpi)
+ATTR(underground_alpha)
 ATTR2(0x00027500,type_rel_abs_begin)
 /* These attributes are int that can either hold relative or absolute values. See the
  * documentation of ATTR_REL_RELSHIFT for details.

--- a/navit/color.h
+++ b/navit/color.h
@@ -21,7 +21,7 @@
 #define NAVIT_COLOR_H
 
 struct color {
-	int r,g,b,a;
+    int r,g,b,a;
 };
 
 #define COLOR_BITDEPTH 16
@@ -34,6 +34,8 @@ struct color {
 #define COLOR_TRANSPARENT ((struct color) {COLOR_TRANSPARENT_})
 #define COLOR_FMT "0x%x,0x%x,0x%x,0x%x"
 #define COLOR_ARGS(c) (c).r,(c).g,(c).b,(c).a
+/*default alpha value to apply for all things flagged AF_UNDERGROUND*/
+#define UNDERGROUND_ALPHA_ 0x3333
 
 #define COLOR_IS_SAME(c1,c2) ((c1).r==(c2).r && (c1).g==(c2).g && (c1).b==(c2).b && (c1).a==(c2).a)
 #define COLOR_IS_WHITE(c) COLOR_IS_SAME(c, COLOR_WHITE)

--- a/navit/color.h
+++ b/navit/color.h
@@ -34,8 +34,9 @@ struct color {
 #define COLOR_TRANSPARENT ((struct color) {COLOR_TRANSPARENT_})
 #define COLOR_FMT "0x%x,0x%x,0x%x,0x%x"
 #define COLOR_ARGS(c) (c).r,(c).g,(c).b,(c).a
-/*default alpha value to apply for all things flagged AF_UNDERGROUND*/
-#define UNDERGROUND_ALPHA_ 0x3333
+/*default alpha value to apply for all things flagged AF_UNDERGROUND
+ *use solid color to not change default behaviour*/
+#define UNDERGROUND_ALPHA_ 0xFFFF
 
 #define COLOR_IS_SAME(c1,c2) ((c1).r==(c2).r && (c1).g==(c2).g && (c1).b==(c2).b && (c1).a==(c2).a)
 #define COLOR_IS_WHITE(c) COLOR_IS_SAME(c, COLOR_WHITE)

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -1570,7 +1570,6 @@ static void display_draw_arrows(struct graphics *gra, struct display_context *dc
                                 int *width, int filled) {
     long i,dx,dy,l;
     struct point p;
-    struct element *e=dc->e;
     for (i = 0 ; i < count-1 ; i++) {
         dx=pnt[i+1].x-pnt[i].x;
         dy=pnt[i+1].y-pnt[i].y;
@@ -2720,8 +2719,8 @@ static void displayitem_draw(struct displayitem *di, struct layout *l, struct di
         di->z_order=++(gra->current_z_order);
 
         /* Skip elements that are to be drawn on oneway streets only
-         * if street is not oneway */
-        if((e->oneway) && (!(di->flags & AF_ONEWAY))) {
+         * if street is not oneway or roundabout */
+        if((e->oneway) && ((!(di->flags & AF_ONEWAY)) || (di->flags & AF_ROUNDABOUT))) {
             di=di->next;
             continue;
         }

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -2608,11 +2608,20 @@ static inline void displayitem_draw_text(struct displayitem *di,struct display_c
 }
 
 static inline void displayitem_draw_icon(struct displayitem *di,struct display_context *dc, struct element * e,
-        struct graphics * gra, struct point * pa, int count) {
+        struct graphics * gra, struct point * pa, int count, struct layout * l) {
     if (count) {
         struct graphics_image *img=dc->img;
         if (!img || item_is_custom_poi(di->item)) {
+            int icon_width =  e->u.icon.width;
+            int icon_height = e->u.icon.height;
             char *path;
+            /* get the standard icon size out of the layout if unset */
+            if(l != NULL) {
+                if(icon_height==-1)
+                    icon_height=l->icon_h;
+                if(icon_width==-1)
+                    icon_width=l->icon_w;
+            }
             if (item_is_custom_poi(di->item)) {
                 char *icon;
                 char *src;
@@ -2626,7 +2635,7 @@ static inline void displayitem_draw_icon(struct displayitem *di,struct display_c
                 g_free(icon);
             } else
                 path=graphics_icon_path(e->u.icon.src);
-            img=graphics_image_new_scaled_rotated(gra, path, e->u.icon.width, e->u.icon.height, e->u.icon.rotation);
+            img=graphics_image_new_scaled_rotated(gra, path, icon_width, icon_height, e->u.icon.rotation);
             if (img)
                 dc->img=img;
             else
@@ -2732,7 +2741,7 @@ static void displayitem_draw(struct displayitem *di, struct layout *l, struct di
             displayitem_draw_text(di, dc, e, gra, pa,  count, &t_holes);
             break;
         case element_icon:
-            displayitem_draw_icon(di, dc, e, gra, pa, count);
+            displayitem_draw_icon(di, dc, e, gra, pa, count, l);
             break;
         case element_image:
             displayitem_draw_image (di, dc,  gra, pa, count);

--- a/navit/graphics.c
+++ b/navit/graphics.c
@@ -1558,6 +1558,7 @@ static void display_draw_arrow(struct point *p, long dx, long dy, int width, str
     pnt[2].x+=-dx*width/65536-dy*width/65536;
     pnt[2].y+=-dy*width/65536+dx*width/65536;
     if(filled) {
+        /* close the loop */
         pnt[3]=pnt[0];
         graphics_draw_polygon(gra, dc->gc, pnt, 4);
     } else {
@@ -1571,18 +1572,26 @@ static void display_draw_arrows(struct graphics *gra, struct display_context *dc
     long i,dx,dy,l;
     struct point p;
     for (i = 0 ; i < count-1 ; i++) {
+        /* get the X and Y size */
         dx=pnt[i+1].x-pnt[i].x;
         dy=pnt[i+1].y-pnt[i].y;
+        /* calculate the length of the way segment */
         l=sqrt(dx*dx+dy*dy);
         if (l) {
+            /* length is not zero */
+            /* calculate the vector per length */
             dx=dx*65536/l;
             dy=dy*65536/l;
+            /* way starts at starting point */
             p=pnt[i];
+            /* different behaviour for oneway arrows than for routing graph ones */
             if(filled) {
-                /* print arrow at middle point */
-                p.x+=dx*(l/2)/65536;
-                p.y+=dy*(l/2)/65536;
-                display_draw_arrow(&p, dx, dy, width[i], dc, gra, filled);
+                if(l > (2*width[i])) {
+                    /* print arrow at middle point */
+                    p.x+=dx*(l/2)/65536;
+                    p.y+=dy*(l/2)/65536;
+                    display_draw_arrow(&p, dx, dy, width[i], dc, gra, filled);
+                }
                 /* if line is quite long, print arrows at 1/4 and 3/4 length */
                 if(l > (20*width[i])) {
                     p.x+=dx*(l/4)/65536;
@@ -1593,9 +1602,12 @@ static void display_draw_arrows(struct graphics *gra, struct display_context *dc
                     display_draw_arrow(&p, dx, dy, width[i], dc, gra, filled);
                 }
             } else {
+                /*FIXME: what if line length was smaller than 15?*/
+                /* print arrow 15 units from start */
                 p.x+=dx*15/65536;
                 p.y+=dy*15/65536;
                 display_draw_arrow(&p, dx, dy, 20, dc, gra, filled);
+                /* print arrow 15 units before end */
                 p=pnt[i+1];
                 p.x-=dx*15/65536;
                 p.y-=dy*15/65536;

--- a/navit/layout.c
+++ b/navit/layout.c
@@ -39,7 +39,9 @@ layout_new(struct attr *parent, struct attr **attrs) {
     struct layout *l;
     struct navit *navit;
     struct color def_color = {COLOR_BACKGROUND_};
-    struct attr *name_attr,*color_attr,*order_delta_attr,*font_attr,*day_attr,*night_attr,*active_attr;
+    int def_underground_alpha = UNDERGROUND_ALPHA_;
+    struct attr *name_attr,*color_attr,*order_delta_attr,*font_attr,*day_attr,*night_attr,*active_attr,
+               *underground_alpha_attr,*icon_attr;
 
     if (! (name_attr=attr_search(attrs, NULL, attr_name)))
         return NULL;
@@ -67,6 +69,21 @@ layout_new(struct attr *parent, struct attr **attrs) {
         l->color = *color_attr->u.color;
     else
         l->color = def_color;
+    if ((underground_alpha_attr=attr_search(attrs, NULL, attr_underground_alpha))) {
+        int a = underground_alpha_attr->u.num;
+        /* for convenience, the alpha value is just 8 bit as usual if using
+        * corresponding attr. therefore we need to shift that up */
+        l->underground_alpha = (a << 8) | a;
+    } else
+        l->underground_alpha = def_underground_alpha;
+    if ((icon_attr=attr_search(attrs, NULL, attr_icon_w)))
+        l->icon_w = icon_attr->u.num;
+    else
+        l->icon_w = -1;
+    if ((icon_attr=attr_search(attrs, NULL, attr_icon_h)))
+        l->icon_h = icon_attr->u.num;
+    else
+        l->icon_h = -1;
     if ((order_delta_attr=attr_search(attrs, NULL, attr_order_delta)))
         l->order_delta=order_delta_attr->u.num;
     if ((active_attr=attr_search(attrs, NULL, attr_active)))

--- a/navit/layout.c
+++ b/navit/layout.c
@@ -406,6 +406,13 @@ int itemgra_add_attr(struct itemgra *itemgra, struct attr *attr) {
     }
 }
 
+static void element_set_oneway(struct element *e, struct attr **attrs) {
+    struct attr *oneway;
+    oneway=attr_search(attrs, NULL, attr_oneway);
+    if (oneway)
+        e->oneway=oneway->u.num;
+}
+
 static void element_set_color(struct element *e, struct attr **attrs) {
     struct attr *color;
     color=attr_search(attrs, NULL, attr_color);
@@ -427,6 +434,15 @@ static void element_set_text_size(struct element *e, struct attr **attrs) {
     text_size=attr_search(attrs, NULL, attr_text_size);
     if (text_size)
         e->text_size=text_size->u.num;
+}
+
+static void element_set_arrows_width(struct element *e, struct attr **attrs) {
+    struct attr *width;
+    width=attr_search(attrs, NULL, attr_width);
+    if (width)
+        e->u.arrows.width=width->u.num;
+    else
+        e->u.arrows.width=10;
 }
 
 static void element_set_polyline_width(struct element *e, struct attr **attrs) {
@@ -485,6 +501,7 @@ polygon_new(struct attr *parent, struct attr **attrs) {
     e = g_new0(struct element, 1);
     e->type=element_polygon;
     element_set_color(e, attrs);
+    element_set_oneway(e, attrs);
 
     return (struct polygon *)e;
 }
@@ -496,6 +513,7 @@ polyline_new(struct attr *parent, struct attr **attrs) {
     e = g_new0(struct element, 1);
     e->type=element_polyline;
     element_set_color(e, attrs);
+    element_set_oneway(e, attrs);
     element_set_polyline_width(e, attrs);
     element_set_polyline_directed(e, attrs);
     element_set_polyline_dash(e, attrs);
@@ -515,6 +533,7 @@ circle_new(struct attr *parent, struct attr **attrs) {
     e->u.circle.background_color = color_white;
     element_set_color(e, attrs);
     element_set_background_color(&e->u.circle.background_color, attrs);
+    element_set_oneway(e, attrs);
     element_set_text_size(e, attrs);
     element_set_circle_width(e, attrs);
     element_set_circle_radius(e, attrs);
@@ -535,6 +554,7 @@ text_new(struct attr *parent, struct attr **attrs) {
     e->u.text.background_color = color_white;
     element_set_color(e, attrs);
     element_set_background_color(&e->u.text.background_color, attrs);
+    element_set_oneway(e, attrs);
 
     return (struct text *)e;
 }
@@ -589,6 +609,8 @@ arrows_new(struct attr *parent, struct attr **attrs) {
     e = g_malloc0(sizeof(*e));
     e->type=element_arrows;
     element_set_color(e, attrs);
+    element_set_oneway(e, attrs);
+    element_set_arrows_width(e, attrs);
     return (struct arrows *)e;
 }
 

--- a/navit/layout.h
+++ b/navit/layout.h
@@ -37,6 +37,7 @@ struct element {
     enum { element_point, element_polyline, element_polygon, element_circle, element_text, element_icon, element_image, element_arrows } type;
     struct color color;
     int text_size;
+    int oneway;
     union {
         struct element_point {
             char stub;
@@ -67,6 +68,9 @@ struct element {
         struct element_text {
             struct color background_color;
         } text;
+        struct element_arrows {
+            int width;
+        } arrows;
     } u;
     int coord_count;
     struct coord *coord;

--- a/navit/layout.h
+++ b/navit/layout.h
@@ -105,6 +105,9 @@ struct layout {
     char* nightname;
     char *font;
     struct color color;
+    int underground_alpha;
+    int icon_w;
+    int icon_h;
     GList *layers;
     GList *cursors;
     int order_delta;

--- a/navit/navit_layout_bike_shipped.xml
+++ b/navit/navit_layout_bike_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Bike" color="#ffefb7" font="Liberation Sans">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Bike" color="#ffefb7" icon_w="22" icon_h="22" font="Liberation Sans">
 	<cursor w="26" h="26">
 		<itemgra>
 			<circle color="#0000ff" radius="24" width="2">

--- a/navit/navit_layout_car_android_shipped.xml
+++ b/navit/navit_layout_car_android_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car-Android" color="#fef9ee" font="Liberation Sans">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car-Android" color="#fef9ee" icon_w="22" icon_h="22" font="Liberation Sans">
 	<cursor w="57" h="57">
 		<itemgra speed_range="-2">
 			<polyline color="#00BC00" radius="0" width="4">

--- a/navit/navit_layout_car_dark_shipped.xml
+++ b/navit/navit_layout_car_dark_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car-dark" daylayout="Car" color="#011001">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car-dark" daylayout="Car" icon_w="22" icon_h="22" color="#011001">
 	<cursor w="57" h="57">
 		<itemgra speed_range="-2">
 			<polyline color="#0000BC" radius="0" width="4">

--- a/navit/navit_layout_car_shipped.xml
+++ b/navit/navit_layout_car_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car" nightlayout="Car-dark" color="#ffefb7" font="Liberation Sans">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car" nightlayout="Car-dark" color="#ffefb7" icon_w="22" icon_h="22" underground_alpha="0x33" font="Liberation Sans">
 	<cursor w="57" h="57">
 		<itemgra speed_range="-2">
 			<polyline color="#00BC00" radius="0" width="4">

--- a/navit/navit_layout_car_shipped.xml
+++ b/navit/navit_layout_car_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car" nightlayout="Car-dark" color="#ffefb7" icon_w="22" icon_h="22" underground_alpha="0x33" font="Liberation Sans">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car" nightlayout="Car-dark" color="#ffefb7" icon_w="22" icon_h="22" underground_alpha="0x77" font="Liberation Sans">
 	<cursor w="57" h="57">
 		<itemgra speed_range="-2">
 			<polyline color="#00BC00" radius="0" width="4">
@@ -787,22 +787,27 @@
 		<itemgra item_types="street_pedestrian,living_street" order="14">
 			<polyline color="#d2d2d2" width="13"/>
 			<polyline color="#dddddd" width="9"/>
+			<arrows color="#0000FF" width="7" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_pedestrian,living_street" order="15">
 			<polyline color="#d2d2d2" width="18"/>
 			<polyline color="#dddddd" width="14"/>
+			<arrows color="#0000FF" width="12" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_pedestrian,living_street" order="16">
 			<polyline color="#d2d2d2" width="21"/>
 			<polyline color="#dddddd" width="17"/>
+			<arrows color="#0000FF" width="15" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_pedestrian,living_street" order="17">
 			<polyline color="#d2d2d2" width="25"/>
 			<polyline color="#dddddd" width="21"/>
+			<arrows color="#0000FF" width="19" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_pedestrian,living_street" order="18">
 			<polyline color="#d2d2d2" width="40"/>
 			<polyline color="#dddddd" width="34"/>
+			<arrows color="#0000FF" width="32" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_service" order="10">
 			<polyline color="#d2d2d2" width="4"/>
@@ -823,22 +828,27 @@
 		<itemgra item_types="street_service" order="14">
 			<polyline color="#d2d2d2" width="7"/>
 			<polyline color="#fefefe" width="5"/>
+			<arrows color="#0000FF" width="4" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_service" order="15">
 			<polyline color="#d2d2d2" width="8"/>
 			<polyline color="#fefefe" width="6"/>
+			<arrows color="#0000FF" width="5" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_service" order="16">
 			<polyline color="#d2d2d2" width="9"/>
 			<polyline color="#fefefe" width="7"/>
+			<arrows color="#0000FF" width="7" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_service" order="17">
 			<polyline color="#d2d2d2" width="10"/>
 			<polyline color="#fefefe" width="8"/>
+			<arrows color="#0000FF" width="7" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_service" order="18">
 			<polyline color="#d2d2d2" width="11"/>
 			<polyline color="#fefefe" width="9"/>
+			<arrows color="#0000FF" width="7" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_parking_lane" order="12">
 			<polyline color="#d2d2d2" width="4"/>
@@ -855,18 +865,22 @@
 		<itemgra item_types="street_parking_lane" order="15">
 			<polyline color="#d2d2d2" width="6"/>
 			<polyline color="#fefefe" width="4"/>
+			<arrows color="#0000FF" width="4" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_parking_lane" order="16">
 			<polyline color="#d2d2d2" width="7"/>
 			<polyline color="#fefefe" width="5"/>
+			<arrows color="#0000FF" width="4" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_parking_lane" order="17">
 			<polyline color="#d2d2d2" width="8"/>
 			<polyline color="#fefefe" width="6"/>
+			<arrows color="#0000FF" width="4" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_parking_lane" order="18">
 			<polyline color="#d2d2d2" width="9"/>
 			<polyline color="#fefefe" width="7"/>
+			<arrows color="#0000FF" width="5" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_0,street_1_city,street_1_land" order="10">
 			<polyline color="#d2d2d2" width="4"/>
@@ -887,22 +901,27 @@
 		<itemgra item_types="street_0,street_1_city,street_1_land" order="14">
 			<polyline color="#d2d2d2" width="17"/>
 			<polyline color="#ffffff" width="13"/>
+			<arrows color="#0000FF" width="12" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_0,street_1_city,street_1_land" order="15">
 			<polyline color="#d2d2d2" width="18"/>
 			<polyline color="#ffffff" width="14"/>
+			<arrows color="#0000FF" width="12" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_0,street_1_city,street_1_land" order="16">
 			<polyline color="#d2d2d2" width="30"/>
 			<polyline color="#ffffff" width="26"/>
+			<arrows color="#0000FF" width="24" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_0,street_1_city,street_1_land" order="17">
 			<polyline color="#d2d2d2" width="67"/>
 			<polyline color="#ffffff" width="61"/>
+			<arrows color="#0000FF" width="59" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_0,street_1_city,street_1_land" order="18">
 			<polyline color="#d2d2d2" width="132"/>
 			<polyline color="#ffffff" width="126"/>
+			<arrows color="#0000FF" width="124" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_2_city,street_2_land,ramp" order="7-8">
 			<polyline color="#c0c0c0" width="2"/>
@@ -930,22 +949,27 @@
 		<itemgra item_types="street_2_city,street_2_land,ramp" order="14">
 			<polyline color="#c0c0c0" width="14"/>
 			<polyline color="#ffff00" width="11"/>
+			<arrows color="#0000FF" width="9" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_2_city,street_2_land,ramp" order="15">
 			<polyline color="#c0c0c0" width="19"/>
 			<polyline color="#ffff00" width="15"/>
+			<arrows color="#0000FF" width="13" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_2_city,street_2_land,ramp" order="16">
 			<polyline color="#c0c0c0" width="30"/>
 			<polyline color="#ffff00" width="26"/>
+			<arrows color="#0000FF" width="24" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_2_city,street_2_land,ramp" order="17">
 			<polyline color="#c0c0c0" width="63"/>
 			<polyline color="#ffff00" width="57"/>
+			<arrows color="#0000FF" width="55" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_2_city,street_2_land,ramp" order="18">
 			<polyline color="#c0c0c0" width="100"/>
 			<polyline color="#ffff00" width="90"/>
+			<arrows color="#0000FF" width="88" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_3_city,street_3_land,roundabout" order="7-8">
 			<polyline color="#a0a0a0" width="3"/>
@@ -974,22 +998,27 @@
 		<itemgra item_types="street_3_city,street_3_land,roundabout" order="14">
 			<polyline color="#a0a0a0" width="21"/>
 			<polyline color="#ffff00" width="17"/>
+			<arrows color="#0000FF" width="15" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_3_city,street_3_land,roundabout" order="15">
 			<polyline color="#a0a0a0" width="25"/>
 			<polyline color="#ffff00" width="21"/>
+			<arrows color="#0000FF" width="19" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_3_city,street_3_land,roundabout" order="16">
 			<polyline color="#a0a0a0" width="40"/>
 			<polyline color="#ffff00" width="34"/>
+			<arrows color="#0000FF" width="32" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_3_city,street_3_land,roundabout" order="17">
 			<polyline color="#a0a0a0" width="79"/>
 			<polyline color="#ffff00" width="73"/>
+			<arrows color="#0000FF" width="70" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_3_city,street_3_land,roundabout" order="18">
 			<polyline color="#a0a0a0" width="156"/>
 			<polyline color="#ffff00" width="150"/>
+			<arrows color="#0000FF" width="148" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_4_city,street_4_land,street_n_lanes" order="2-6">
 			<polyline color="#404040" width="1"/>
@@ -1021,22 +1050,27 @@
 		<itemgra item_types="street_4_city,street_4_land,street_n_lanes" order="14">
 			<polyline color="#000000" width="21"/>
 			<polyline color="#ff0000" width="17"/>
+			<arrows color="#0000FF" width="15" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_4_city,street_4_land,street_n_lanes" order="15">
 			<polyline color="#000000" width="24"/>
 			<polyline color="#ff0000" width="20"/>
+			<arrows color="#0000FF" width="18" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_4_city,street_4_land,street_n_lanes" order="16">
 			<polyline color="#000000" width="39"/>
 			<polyline color="#ff0000" width="33"/>
+			<arrows color="#0000FF" width="30" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_4_city,street_4_land,street_n_lanes" order="17">
 			<polyline color="#000000" width="78"/>
 			<polyline color="#ff0000" width="72"/>
+			<arrows color="#0000FF" width="70" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="street_4_city,street_4_land,street_n_lanes" order="18">
 			<polyline color="#000000" width="156"/>
 			<polyline color="#ff0000" width="150"/>
+			<arrows color="#0000FF" width="148" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="highway_city,highway_land" order="2">
 			<polyline color="#ff0000" width="1"/>
@@ -1093,11 +1127,13 @@
 			<polyline color="#ff0000" width="133"/>
 			<polyline color="#ffff00" width="127"/>
 			<polyline color="#ff0000" width="1"/>
+			<arrows color="#0000FF" width="125" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="highway_city,highway_land" order="18">
 			<polyline color="#ff0000" width="264"/>
 			<polyline color="#ffff00" width="258"/>
 			<polyline color="#ff0000" width="1"/>
+			<arrows color="#0000FF" width="256" oneway="1"/>
 		</itemgra>
 		<itemgra item_types="tracking_0" order="0-">
 			<polyline color="#000000" width="3"/>

--- a/navit/navit_layout_car_simple_shipped.xml
+++ b/navit/navit_layout_car_simple_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car-simple" color="#839ea9">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="Car-simple" icon_w="22" icon_h="22" color="#839ea9">
 	<layer name="polygon">
 		<itemgra item_types="poly_town" order="8-">
 			<polygon color="#6b8091"/>

--- a/navit/navit_layout_th_shipped.xml
+++ b/navit/navit_layout_th_shipped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="T@H" font="Liberation Sans">
+<layout xmlns:xi="http://www.w3.org/2001/XInclude" name="T@H" icon_w="22" icon_h="22" font="Liberation Sans">
 	<cursor w="26" h="26">
 		<itemgra>
 			<circle color="#0000ff" radius="24" width="2">

--- a/navit/xslt/sailfish_svg.xslt
+++ b/navit/xslt/sailfish_svg.xslt
@@ -12,6 +12,17 @@
       </xsl:copy>
    </xsl:template>
 
+   <!-- Force default cursor size of all layouts, force tunnel transparency -->
+   <xsl:template match="/layout">
+      <xsl:copy>
+         <xsl:apply-templates select="@*"/>
+         <xsl:attribute name="icon_w">16</xsl:attribute>
+         <xsl:attribute name="icon_h">16</xsl:attribute>
+         <xsl:attribute name="underground_alpha">0x33</xsl:attribute>
+         <xsl:apply-templates select="node()"/>
+      </xsl:copy>
+   </xsl:template>
+
    <!-- Force all png icons to svg and add w and h if not exist -->
    <xsl:template match="icon">
       <xsl:copy>
@@ -20,12 +31,6 @@
          <xsl:attribute name="src">
             <xsl:value-of select="concat(substring(@src,1, string-length(@src)-3),'svg')"/>
          </xsl:attribute>
-         </xsl:if>
-         <xsl:if test="not(@h)">
-            <xsl:attribute name="h">15</xsl:attribute>
-         </xsl:if>
-         <xsl:if test="not(@w)">
-            <xsl:attribute name="w">15</xsl:attribute>
          </xsl:if>
          <xsl:apply-templates select="node()"/>
       </xsl:copy>


### PR DESCRIPTION
This pull request adds the possibility to globally set a default for icon size of a layout.
You can now give "icon_h" and "icon_w" properties in "layout" tag. This causes navit to not use the real size of an icon but to scale it to have the requested size. Guessing prescaled icons (the name_w_h.png's of course works. Default size of 22x22px which is the default size hint on most of the svg's is used. This fixes #819.

This pull request adds the property "underground_alpha" to the "graphics" tag giving the alpha value to use as transparency if ways are flagged with AF_UNDERGROUND. This effectively renders tunnels in transparent.

This pull request adds a "oneway" tag to itemgras in layouts. Together with the enhancements of the "arrows" itemgra used for drawing the route graph one can print nice arrows on oneway roads.
