### PR TITLE
Android:feature settings

### DIFF
--- a/navit/android/AndroidManifest.xml
+++ b/navit/android/AndroidManifest.xml
@@ -10,7 +10,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <application android:usesCleartextTraffic="true" android:label="@string/app_name"
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <application android:usesCleartextTraffic="true"
+        android:label="@string/app_name"
         android:icon="@drawable/icon"
         android:name=".NavitAppConfig"
         android:theme="@style/NavitTheme">
@@ -23,12 +25,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="geo"/>
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="google.navigation" />
             </intent-filter>
         </activity>
         <activity android:name=".NavitAddressSearchActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden">
+        </activity>
+        <activity
+            android:name=".NavitSettingsActivity"
             android:configChanges="orientation|screenSize|keyboardHidden">
         </activity>
         <activity android:name=".NavitDownloadSelectMapActivity"></activity>

--- a/navit/android/build.gradle
+++ b/navit/android/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "org.navitproject.navit"
-        minSdkVersion 9
+        minSdkVersion 10
         targetSdkVersion 28
         versionCode gitVersionCode
         versionName gitVersionName

--- a/navit/android/res/values-v19/styles.xml
+++ b/navit/android/res/values-v19/styles.xml
@@ -1,8 +1,5 @@
 <resources>
     <style name="NavitTheme" parent="android:Theme.DeviceDefault.NoActionBar">
-
         <!-- API 19 theme customizations can go here. -->
-        <item name="android:windowTranslucentNavigation">true</item>
-        <item name="android:windowTranslucentStatus">true</item>
     </style>
 </resources>

--- a/navit/android/res/values-v21/styles.xml
+++ b/navit/android/res/values-v21/styles.xml
@@ -1,21 +1,5 @@
 <resources>
     <style name="NavitTheme" parent="android:Theme.DeviceDefault.NoActionBar">
-
         <!-- API 21 theme customizations can go here. -->
-        <!--
-            Don't use translucent system bars on API 21 as they are drawn with a semitransparent
-            black background which can't be changed.
-        -->
-        <item name="android:windowTranslucentNavigation">false</item>
-        <item name="android:windowTranslucentStatus">false</item>
-
-        <!--
-            We could set any semi-transparent color here (or change it in code), but this would not
-            be available on API 19/20. Simply specifying full transparency allows us to implement a
-            separate mechanism that will work on all versions.
-        -->
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
 </resources>

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -415,7 +415,7 @@ public class Navit extends Activity {
     public void onResume() {
         super.onResume();
         Log.d(TAG, "OnResume");
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             /* Required to make system bars fully transparent */
             getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                     | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -46,7 +46,6 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Message;
 import android.os.PowerManager;
-import android.support.annotation.RequiresApi;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
@@ -648,6 +647,7 @@ public class Navit extends Activity {
      * <p>Calling this method has the same effect as pressing the hardware Menu button, or touching
      * the overflow button in the Action bar.</p>
      */
+    @SuppressWarnings("unused")
     void showMenu() {
         openOptionsMenu();
     }
@@ -658,6 +658,7 @@ public class Navit extends Activity {
      *
      * @return 1 if keyboard is software, 0 if hardware
      */
+    @SuppressWarnings("unused")
     int showNativeKeyboard() {
         Log.d(TAG, "showNativeKeyboard");
         Configuration config = getResources().getConfiguration();
@@ -679,6 +680,7 @@ public class Navit extends Activity {
     /**
      * Hides the native keyboard or other input method.
      */
+    @SuppressWarnings("unused")
     void hideNativeKeyboard() {
         ((InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE))
         .hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
@@ -794,30 +796,23 @@ public class Navit extends Activity {
     }
 
 
-    @RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    @SuppressWarnings("unused")
     void fullscreen(int fullscreen) {
-
-        View decorView = getWindow().getDecorView();
-
-        mIsFullscreen = (fullscreen != 0);
-        if (mIsFullscreen) {
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+        if(fullscreen != 0) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-                int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
-                decorView.setSystemUiVisibility(uiOptions);
-            }
-
-        } else {
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        }
+        else {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                decorView.setSystemUiVisibility(0);
-            }
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
         }
     }
 
-    public void disableSuspend() {
+
+    void disableSuspend() {
         mWakeLock.acquire();
         mWakeLock.release();
     }

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -294,9 +294,18 @@ public class Navit extends Activity {
         }
         Log.d(TAG, "Language " + lang);
 
-        SharedPreferences prefs = getSharedPreferences(NavitAppConfig.NAVIT_PREFS,MODE_PRIVATE);
+        SharedPreferences settings = getSharedPreferences(NavitAppConfig.NAVIT_PREFS,MODE_PRIVATE);
         sNavitDataDir = getApplicationContext().getFilesDir().getPath();
-        sMapFilenamePath = prefs.getString("filenamePath", sNavitDataDir + '/');
+
+        String candidateFileNamePath = getApplicationContext().getExternalFilesDir(null).toString();
+        boolean firstStart = settings.getBoolean("firstStart", true);
+        if (firstStart) {
+            Log.e(TAG, "set to " + candidateFileNamePath);
+            SharedPreferences.Editor preferenceEditor = settings.edit();
+            preferenceEditor.putString("filenamePath", candidateFileNamePath);
+            preferenceEditor.apply();
+        }
+        sMapFilenamePath = settings.getString("filenamePath", candidateFileNamePath );
         Log.i(TAG,"NavitDataDir = " + sNavitDataDir);
         Log.i(TAG,"mapFilenamePath = " + sMapFilenamePath);
         // make sure the new path for the navitmap.bin file(s) exist!!
@@ -545,7 +554,7 @@ public class Navit extends Activity {
 
         menu.add(1, 6, 500, getTstring(R.string.optionsmenu_address_search)); //TRANS
         menu.add(1, 10, 600, getTstring(R.string.optionsmenu_set_map_location));
-
+        menu.add(1, 11, 601, "experimental settings");
         menu.add(1, 99, 900, getTstring(R.string.optionsmenu_exit_navit)); //TRANS
 
         /* Only show the Backup to SD-Card Option if we really have one */
@@ -629,6 +638,9 @@ public class Navit extends Activity {
                 break;
             case 10:
                 setMapLocation();
+                break;
+            case 11:
+                setMapLocationNew();
                 break;
             case 99 :
                 // exit
@@ -776,6 +788,14 @@ public class Navit extends Activity {
         fileExploreIntent
             .putExtra(FileBrowserActivity.startDirectoryParameter, "/mnt")
             .setAction(FileBrowserActivity.INTENT_ACTION_SELECT_DIR);
+        startActivityForResult(fileExploreIntent,NavitSelectStorage_id);
+    }
+
+    private void setMapLocationNew() {
+        Intent fileExploreIntent = new Intent(this,NavitSettingsActivity.class);
+        fileExploreIntent
+                .putExtra(FileBrowserActivity.startDirectoryParameter, "/mnt")
+                .setAction(FileBrowserActivity.INTENT_ACTION_SELECT_DIR);
         startActivityForResult(fileExploreIntent,NavitSelectStorage_id);
     }
 

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -38,6 +38,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
+import android.graphics.Color;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
@@ -370,6 +371,19 @@ public class Navit extends Activity {
                 this.getActionBar().hide();
             }
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                getWindow().getDecorView().setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
+                getWindow().setStatusBarColor(Color.TRANSPARENT);
+                getWindow().setNavigationBarColor(Color.TRANSPARENT);
+            } else {
+                getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+                getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+            }
+        }
     }
 
     /* uses NAVIT_PACKAGE_NAME as id */
@@ -415,12 +429,6 @@ public class Navit extends Activity {
     public void onResume() {
         super.onResume();
         Log.d(TAG, "OnResume");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            /* Required to make system bars fully transparent */
-            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
-        }
         //InputMethodManager sInputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         // DEBUG
         // intent_data = "google.navigation:q=Wien Burggasse 27";

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -801,11 +801,10 @@ public class Navit extends Activity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             return;
         }
-        if(fullscreen != 0) {
+        if (fullscreen != 0) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-        }
-        else {
+        } else {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
             getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
         }

--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -305,7 +305,7 @@ public class Navit extends Activity {
             preferenceEditor.putString("filenamePath", candidateFileNamePath);
             preferenceEditor.apply();
         }
-        sMapFilenamePath = settings.getString("filenamePath", candidateFileNamePath );
+        sMapFilenamePath = settings.getString("filenamePath", candidateFileNamePath);
         Log.i(TAG,"NavitDataDir = " + sNavitDataDir);
         Log.i(TAG,"mapFilenamePath = " + sMapFilenamePath);
         // make sure the new path for the navitmap.bin file(s) exist!!

--- a/navit/android/src/org/navitproject/navit/NavitCamera.java
+++ b/navit/android/src/org/navitproject/navit/NavitCamera.java
@@ -52,19 +52,16 @@ class NavitCamera extends SurfaceView implements SurfaceHolder.Callback {
      * <p>acquire the camera and tell it where to draw.</p>
      */
     public void surfaceCreated(SurfaceHolder holder) {
-        if (mCamera != null) {
-            try {
-                mCamera = Camera.open();
-                mCamera.setPreviewDisplay(holder);
-            } catch (IOException exception) {
-                mCamera.release();
-                mCamera = null;
-                Log.e(TAG, "IOException");
-            }
-            Log.i(TAG, "surfaceCreated");
-        } else {
-            Log.e(TAG, "null camera");
+        try {
+            mCamera = Camera.open();
+            mCamera.setPreviewDisplay(holder);
+        } catch (IOException exception) {
+            mCamera.release();
+            mCamera = null;
+            Log.e(TAG, "IOException");
         }
+        Log.i(TAG, "surfaceCreated");
+
     }
 
 
@@ -74,9 +71,11 @@ class NavitCamera extends SurfaceView implements SurfaceHolder.Callback {
      * <p>stop the preview and release the camera.</p>
      */
     public void surfaceDestroyed(SurfaceHolder holder) {
-        mCamera.stopPreview();
-        mCamera = null;
-        Log.e(TAG,"surfaceDestroyed");
+        if (mCamera != null) {
+            mCamera.stopPreview();
+            mCamera = null;
+            Log.e(TAG, "surfaceDestroyed");
+        }
     }
 
 
@@ -87,11 +86,13 @@ class NavitCamera extends SurfaceView implements SurfaceHolder.Callback {
      */
     public void surfaceChanged(SurfaceHolder holder, int format, int w, int h) {
         Log.e(TAG,"surfaceChanged " + w + "x " + h);
-        mCamera.stopPreview();
-        Camera.Parameters parameters = mCamera.getParameters();
-        parameters.setPreviewSize(w, h);
-        mCamera.setParameters(parameters);
-        mCamera.startPreview();
+        if (mCamera != null) {
+            mCamera.stopPreview();
+            Camera.Parameters parameters = mCamera.getParameters();
+            parameters.setPreviewSize(w, h);
+            mCamera.setParameters(parameters);
+            mCamera.startPreview();
+        }
     }
 }
 

--- a/navit/android/src/org/navitproject/navit/NavitGraphics.java
+++ b/navit/android/src/org/navitproject/navit/NavitGraphics.java
@@ -1053,7 +1053,7 @@ class NavitGraphics {
             return;
         }
         Log.v(TAG,"workaround gui internal");
-        
+
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT && !inMap) {
             mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);

--- a/navit/android/src/org/navitproject/navit/NavitGraphics.java
+++ b/navit/android/src/org/navitproject/navit/NavitGraphics.java
@@ -1048,25 +1048,18 @@ class NavitGraphics {
         }
     }
 
-    private void workAroundForGuiInternal(Boolean inMap) {
+    private void workAroundForGuiInternal(boolean inMap) {
         if (!mTinting) {
             return;
         }
         Log.v(TAG,"workaround gui internal");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !inMap) {
-            mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            return;
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            return;
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && !inMap) {
+        
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT && !inMap) {
             mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
             return;
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
             mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
         }

--- a/navit/android/src/org/navitproject/navit/NavitGraphics.java
+++ b/navit/android/src/org/navitproject/navit/NavitGraphics.java
@@ -73,7 +73,6 @@ class NavitGraphics {
     private int                            mPosY;
     private int                            mPosWraparound;
     private int                            mOverlayDisabled;
-    private int                            mBgColor;
     private float                          mTrackballX;
     private float                          mTrackballY;
     private int                            mPaddingLeft;
@@ -94,8 +93,8 @@ class NavitGraphics {
     private boolean                        mTinting;
 
 
+    @SuppressWarnings("unused")
     void setBackgroundColor(int bgcolor) {
-        this.mBgColor = bgcolor;
         if (mLeftTintView != null) {
             mLeftTintView.setBackgroundColor(bgcolor);
         }
@@ -537,13 +536,13 @@ class NavitGraphics {
 
         public SystemBarTintView(Context context) {
             super(context);
-            this.setBackgroundColor(mBgColor);
         }
 
     }
 
+    @SuppressWarnings("unused")
     NavitGraphics(final Activity navit, NavitGraphics parent, int x, int y, int w, int h,
-                         int wraparound, int useCamera) {
+                  int wraparound, int useCamera) {
         if (parent == null) {
             mOverlays = new ArrayList<>();
             if (useCamera != 0) {
@@ -817,6 +816,7 @@ class NavitGraphics {
      *
      * <p>Note that this method is not aware of non-standard mechanisms on some customized builds of Android</p>
      */
+    @SuppressWarnings("unused")
     boolean hasMenuButton() {
         if (Build.VERSION.SDK_INT <= 10) {
             return true;
@@ -829,30 +829,36 @@ class NavitGraphics {
         }
     }
 
+    @SuppressWarnings("unused")
     void setSizeChangedCallback(long id) {
         mSizeChangedCallbackID = id;
     }
 
+    @SuppressWarnings("unused")
     void setPaddingChangedCallback(long id) {
         mPaddingChangedCallbackID = id;
     }
 
+    @SuppressWarnings("unused")
     void setButtonCallback(long id) {
         Log.v(TAG,"set Buttononcallback");
         mButtonCallbackID = id;
     }
 
+    @SuppressWarnings("unused")
     void setMotionCallback(long id) {
         mMotionCallbackID = id;
         Log.v(TAG,"set Motioncallback");
     }
 
+    @SuppressWarnings("unused")
     void setKeypressCallback(long id) {
         Log.v(TAG,"set Keypresscallback");
         mKeypressCallbackID = id;
     }
 
 
+    @SuppressWarnings("unused")
     protected void draw_polyline(Paint paint, int[] c) {
         paint.setStrokeWidth(c[0]);
         paint.setARGB(c[1],c[2],c[3],c[4]);
@@ -883,6 +889,7 @@ class NavitGraphics {
         paint.setPathEffect(null);
     }
 
+    @SuppressWarnings("unused")
     protected void draw_polygon(Paint paint, int[] c) {
         paint.setStrokeWidth(c[0]);
         paint.setARGB(c[1],c[2],c[3],c[4]);
@@ -898,6 +905,7 @@ class NavitGraphics {
         mDrawCanvas.drawPath(path, paint);
     }
 
+    @SuppressWarnings("unused")
     protected void draw_rectangle(Paint paint, int x, int y, int w, int h) {
         Rect r = new Rect(x, y, x + w, y + h);
         paint.setStyle(Paint.Style.FILL);
@@ -906,11 +914,13 @@ class NavitGraphics {
         mDrawCanvas.drawRect(r, paint);
     }
 
+    @SuppressWarnings("unused")
     protected void draw_circle(Paint paint, int x, int y, int r) {
         paint.setStyle(Paint.Style.STROKE);
         mDrawCanvas.drawCircle(x, y, r / 2, paint);
     }
 
+    @SuppressWarnings("unused")
     protected void draw_text(Paint paint, int x, int y, String text, int size, int dx, int dy, int bgcolor) {
         int oldcolor = paint.getColor();
         Path path = null;
@@ -997,6 +1007,7 @@ class NavitGraphics {
     /* Used by the pedestrian plugin, draws without a mapbackground */
     private static final int DRAW_MODE_BEGIN_CLEAR = 2;
 
+    @SuppressWarnings("unused")
     protected void draw_mode(int mode) {
         if (mode == DRAW_MODE_END) {
             if (mParentGraphics == null) {
@@ -1011,11 +1022,13 @@ class NavitGraphics {
 
     }
 
+    @SuppressWarnings("unused")
     protected void draw_drag(int x, int y) {
         mPosX = x;
         mPosY = y;
     }
 
+    @SuppressWarnings("unused")
     protected void overlay_disable(int disable) {
         Log.v(TAG,"overlay_disable: " + disable + ", Parent: " + (mParentGraphics != null));
         if (mParentGraphics == null) {
@@ -1046,6 +1059,7 @@ class NavitGraphics {
         }
     }
 
+    @SuppressWarnings("unused")
     protected void overlay_resize(int x, int y, int w, int h, int wraparound) {
         mDrawBitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
         mBitmapWidth = w;

--- a/navit/android/src/org/navitproject/navit/NavitGraphics.java
+++ b/navit/android/src/org/navitproject/navit/NavitGraphics.java
@@ -971,11 +971,6 @@ class NavitGraphics {
      * @param p2x and p2y   specifying the bottom left point, not yet used but kept
      *                      for compatibility with the linux port
      * @param bitmap    Bitmap object holding the image to draw
-     *
-     * TODO make it work with 4 points specified to make it work for 3D mapview, so it can be used
-     *      for small but very detailed maps as well as for large maps with very little detail but large
-     *      coverage.
-     * TODO make it work with rectangular tiles as well ?
      */
     protected void draw_image_warp(Paint paint, int count, int p0x, int p0y, int p1x, int p1y, int p2x, int p2y,
             Bitmap bitmap) {

--- a/navit/android/src/org/navitproject/navit/NavitMapDownloader.java
+++ b/navit/android/src/org/navitproject/navit/NavitMapDownloader.java
@@ -539,7 +539,7 @@ public class NavitMapDownloader extends Thread {
 
         if (success || mStopMe) {
             NavitDialogs.sendDialogMessage(NavitDialogs.MSG_MAP_DOWNLOAD_FINISHED,
-                    mMapFilenamePath + mMapValues.mMapName + ".bin", null, -1, success ? 1 : 0, mMapId);
+                    mMapFilenamePath + '/' + mMapValues.mMapName + ".bin", null, -1, success ? 1 : 0, mMapId);
         }
     }
 

--- a/navit/android/src/org/navitproject/navit/NavitSensors.java
+++ b/navit/android/src/org/navitproject/navit/NavitSensors.java
@@ -46,8 +46,10 @@ class NavitSensors implements SensorEventListener {
     }
 
     public void onSensorChanged(SensorEvent sev) {
-        Log.v("NavitSensor","Type:" + sev.sensor.getType() + " X:" + sev.values[0] + " Y:"
-                + sev.values[1] + " Z:" + sev.values[2]);
+        // type TYPE_MAGNETIC_FIELD = 2
+        // type TYPE_ACCELEROMETER = 1
+        //Log.v("NavitSensor","Type:" + sev.sensor.getType() + " X:" + sev.values[0] + " Y:"
+        //        + sev.values[1] + " Z:" + sev.values[2]);
         sensorCallback(mCallbackid, sev.sensor.getType(), sev.values[0], sev.values[1], sev.values[2]);
     }
 }

--- a/navit/android/src/org/navitproject/navit/NavitSettingsActivity.java
+++ b/navit/android/src/org/navitproject/navit/NavitSettingsActivity.java
@@ -2,6 +2,8 @@ package org.navitproject.navit;
 
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
+import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
@@ -29,6 +31,24 @@ public class NavitSettingsActivity extends PreferenceActivity {
         Log.e(TAG,"onCreateHierarchy");
         PreferenceScreen root = getPreferenceManager().createPreferenceScreen(this);
 
+        final CheckBoxPreference checkboxPref = new CheckBoxPreference(this);
+        checkboxPref.setTitle("Unlock developer options");
+        checkboxPref.setEnabled(false);
+        checkboxPref.setSummary("placeholder for an upcoming setting");
+        root.addPreference(checkboxPref);
+
+        final CheckBoxPreference checkboxPref2 = new CheckBoxPreference(this);
+        checkboxPref2.setTitle("Unlock large map download");
+        checkboxPref2.setEnabled(false);
+        checkboxPref2.setSummary("placeholder for an upcoming setting");
+        root.addPreference(checkboxPref2);
+
+        final EditTextPreference customMapserver = new EditTextPreference(this);
+        customMapserver.setEnabled(false);
+        customMapserver.setTitle("custom mapserver");
+        customMapserver.setSummary("upcoming option to select a local share as mapserver");
+        root.addPreference(customMapserver);
+
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             ListPreference listPref = new ListPreference(this);
             File[] candidateDirs = getExternalFilesDirs(null);
@@ -48,6 +68,7 @@ public class NavitSettingsActivity extends PreferenceActivity {
             listPref.setSummary("choose where the maps will be stored");
             root.addPreference(listPref);
         }
+
         return root;
     }
 }

--- a/navit/android/src/org/navitproject/navit/NavitSettingsActivity.java
+++ b/navit/android/src/org/navitproject/navit/NavitSettingsActivity.java
@@ -1,0 +1,53 @@
+package org.navitproject.navit;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.ListPreference;
+import android.preference.PreferenceActivity;
+import android.preference.PreferenceManager;
+import android.preference.PreferenceScreen;
+import android.util.Log;
+import java.io.File;
+
+
+
+public class NavitSettingsActivity extends PreferenceActivity {
+
+    private static final String TAG = "Settings";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.e(TAG,"onCreate");
+        PreferenceManager prefMgr = getPreferenceManager();
+        prefMgr.setSharedPreferencesName("NavitPrefs");
+        prefMgr.setSharedPreferencesMode(MODE_PRIVATE);
+        setPreferenceScreen(createPreferenceHierarchy());
+    }
+
+    private PreferenceScreen createPreferenceHierarchy() {
+        Log.e(TAG,"onCreateHierarchy");
+        PreferenceScreen root = getPreferenceManager().createPreferenceScreen(this);
+
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            ListPreference listPref = new ListPreference(this);
+            File[] candidateDirs = getExternalFilesDirs(null);
+            CharSequence[] entries = new CharSequence[candidateDirs.length];
+            CharSequence[] entryValues = new CharSequence[candidateDirs.length];
+            for (int i = 0; i < candidateDirs.length; i++) {
+                File candidateDir = candidateDirs[i];
+                entries[i] = candidateDir.toString(); // entries is the human readable form
+                entryValues[i] = entries[i];
+                Log.e(TAG,"candidate Dir ");
+            }
+            listPref.setEntries(entries);
+            listPref.setEntryValues(entryValues);
+            listPref.setDialogTitle("map location");
+            listPref.setKey("filenamePath");
+            listPref.setTitle("map location");
+            listPref.setSummary("choose where the maps will be stored");
+            root.addPreference(listPref);
+        }
+        return root;
+    }
+}

--- a/navit/android/src/org/navitproject/navit/NavitSettingsActivity.java
+++ b/navit/android/src/org/navitproject/navit/NavitSettingsActivity.java
@@ -29,7 +29,7 @@ public class NavitSettingsActivity extends PreferenceActivity {
 
     private PreferenceScreen createPreferenceHierarchy() {
         Log.e(TAG,"onCreateHierarchy");
-        PreferenceScreen root = getPreferenceManager().createPreferenceScreen(this);
+        final PreferenceScreen root = getPreferenceManager().createPreferenceScreen(this);
 
         final CheckBoxPreference checkboxPref = new CheckBoxPreference(this);
         checkboxPref.setTitle("Unlock developer options");

--- a/navit/graphics/android/graphics_android.c
+++ b/navit/graphics/android/graphics_android.c
@@ -485,7 +485,7 @@ static void resize_callback(struct graphics_priv *gra, int w, int h) {
 
 static void padding_changed_callback(struct graphics_priv *gra, int left, int top, int right,
                                      int bottom) {
-    dbg(lvl_error, "win.padding left=%d top=%d right=%d bottom=%d", left, top, right, bottom);
+    dbg(lvl_debug, "win.padding left=%d top=%d right=%d bottom=%d", left, top, right, bottom);
     gra->padding->left = left;
     gra->padding->top = top;
     gra->padding->right = right;


### PR DESCRIPTION
Serves as an illustration for https://github.com/navit-gps/navit/issues/548 and since this is for testing only this PR will never leave Draft status.



Adds an `experimental settings` entry in the Android menu.
The only implemented one is a test for devices troubled by https://github.com/navit-gps/navit/issues/548

This is a very minimalistic implementation with the following properties
- in an updrage install where a custom location was used, this location will be pciked up
and further used, but once you change to one of the suggestions in the settings menu, there is no way to go back to the original custom location (yet).
- unfortunatly it still requires a restart after changing the map location
- the suggested location for SD is supposed to fix it for all devices in  https://github.com/navit-gps/navit/issues/548
- for Marshmallow and up only
- no need for permission storage to use the suggested locations
- you can have maps in both the suggested locations and switch between them (with the restart inbetween ofcourse)

![Screenshot_1570896439](https://user-images.githubusercontent.com/9937104/66704373-9880f980-ed1b-11e9-9419-bc10347bcebb.png)