### PR TITLE
CI:cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,6 @@ jobs:
           path: navit/android/build/outputs/apk
           destination: apk
       - store_artifacts:
-          name: Store translations
-          path: po
-          destination: translations
-      - store_artifacts:
           name: Store logs
           path: navit/android/build/outputs/logs
           destination: logs


### PR DESCRIPTION
Storing translations was added to the android build on CI a long time ago to debug a specific issue.
It takes up to 30 seconds but is not needed anymore.
relates to https://github.com/navit-gps/navit/issues/910