### PR TITLE
Disable building of navit for sailfish on i586 platform

### DIFF
--- a/contrib/sailfish/build_sailfish_ci.sh
+++ b/contrib/sailfish/build_sailfish_ci.sh
@@ -17,6 +17,6 @@ mkdir $HOME/rpmbuild
 sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-install -R zypper --non-interactive in $(grep "^BuildRequires: " navit-sailfish.spec | sed -e "s/BuildRequires: //")
 sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir /home/nemo/rpmbuild" --define "navit_source ${SCRIPTPATH}/../.." -bb navit-sailfish.spec
 #intel devices
-sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-install -R zypper --non-interactive in $(grep "^BuildRequires: " navit-sailfish.spec | sed -e "s/BuildRequires: //")
-sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-build rpmbuild --define "_topdir /home/nemo/rpmbuild" --define "navit_source ${SCRIPTPATH}/../.." -bb navit-sailfish.spec
+#sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-install -R zypper --non-interactive in $(grep "^BuildRequires: " navit-sailfish.spec | sed -e "s/BuildRequires: //")
+#sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-build rpmbuild --define "_topdir /home/nemo/rpmbuild" --define "navit_source ${SCRIPTPATH}/../.." -bb navit-sailfish.spec
 


### PR DESCRIPTION
In order to reduce the time spend in building navit for sailfish I disabled as discussed in  #910 the compilation steps for the i586 platform. 