### PR TITLE
cleanup:search:Remove duplicate code for search_fix_spaces

### DIFF
--- a/navit/android.c
+++ b/navit/android.c
@@ -682,7 +682,8 @@ static void android_search_idle(struct android_search_priv *search_priv) {
 
 static void start_search(struct android_search_priv *search_priv, const char *search_string) {
     dbg(lvl_debug,"enter %s", search_string);
-    char *str=search_fix_spaces(search_string);
+    char tmp_search_string = *search_string; // This is allows us to avoid warnings about discarding const qualifier
+    char *str=search_fix_spaces(&tmp_search_string);
     search_priv->phrases = g_strsplit(str, " ", 0);
     //ret=search_address_town(ret, sl, phrases, NULL, partial, jni);
 

--- a/navit/android.c
+++ b/navit/android.c
@@ -680,35 +680,6 @@ static void android_search_idle(struct android_search_priv *search_priv) {
     dbg(lvl_info, "leave");
 }
 
-static char *search_fix_spaces(const char *str) {
-    int i;
-    int len=strlen(str);
-    char c,*s,*d,*ret=g_strdup(str);
-
-    for (i = 0 ; i < len ; i++) {
-        if (ret[i] == ',' || ret[i] == '/')
-            ret[i]=' ';
-    }
-    s=ret;
-    d=ret;
-    len=0;
-    do {
-        c=*s++;
-        if (c != ' ' || len != 0) {
-            *d++=c;
-            len++;
-        }
-        while (c == ' ' && *s == ' ')
-            s++;
-        if (c == ' ' && *s == '\0') {
-            d--;
-            len--;
-        }
-    } while (c);
-
-    return ret;
-}
-
 static void start_search(struct android_search_priv *search_priv, const char *search_string) {
     dbg(lvl_debug,"enter %s", search_string);
     char *str=search_fix_spaces(search_string);

--- a/navit/android.c
+++ b/navit/android.c
@@ -682,8 +682,7 @@ static void android_search_idle(struct android_search_priv *search_priv) {
 
 static void start_search(struct android_search_priv *search_priv, const char *search_string) {
     dbg(lvl_debug,"enter %s", search_string);
-    char tmp_search_string = *search_string; // This is allows us to avoid warnings about discarding const qualifier
-    char *str=search_fix_spaces(&tmp_search_string);
+    char *str=search_fix_spaces(search_string);
     search_priv->phrases = g_strsplit(str, " ", 0);
     //ret=search_address_town(ret, sl, phrases, NULL, partial, jni);
 

--- a/navit/search.c
+++ b/navit/search.c
@@ -135,7 +135,7 @@ int search_list_level(enum attr_type attr_type) {
     }
 }
 
-char *search_fix_spaces(char *str) {
+char *search_fix_spaces(const char *str) {
     int i;
     int len=strlen(str);
     char c,*s,*d,*ret=g_strdup(str);

--- a/navit/search.c
+++ b/navit/search.c
@@ -136,7 +136,9 @@ int search_list_level(enum attr_type attr_type) {
 }
 
 /**
- * @brief replaces ',' and '/' by spaces and removes spaces from both end of the string
+ * @brief Replaces ',' and '/' by ' ', deduplicates spaces within the string
+ *        and strips spaces from both ends of the string
+ *
  * @param pointer to the string to cleanup
  * @return pointer to the cleaned up string
  */

--- a/navit/search.c
+++ b/navit/search.c
@@ -135,7 +135,7 @@ int search_list_level(enum attr_type attr_type) {
     }
 }
 
-static char *search_fix_spaces(char *str) {
+char *search_fix_spaces(char *str) {
     int i;
     int len=strlen(str);
     char c,*s,*d,*ret=g_strdup(str);

--- a/navit/search.c
+++ b/navit/search.c
@@ -135,6 +135,11 @@ int search_list_level(enum attr_type attr_type) {
     }
 }
 
+/**
+ * @brief replaces ',' and '/' by spaces and removes spaces from both end of the string
+ * @param pointer to the string to cleanup
+ * @return pointer to the cleaned up string
+ */
 char *search_fix_spaces(const char *str) {
     int i;
     int len=strlen(str);

--- a/navit/search.c
+++ b/navit/search.c
@@ -167,6 +167,9 @@ char *search_fix_spaces(const char *str) {
             len--;
         }
     } while (c);
+    // Make sure the string is terminated at current position even if nothing has been added to it.
+    // This case happen when you use a string containing only chars that will be discarded.
+    *d='\0';
     return ret;
 }
 

--- a/navit/search.c
+++ b/navit/search.c
@@ -141,7 +141,7 @@ static char *search_fix_spaces(char *str) {
     char c,*s,*d,*ret=g_strdup(str);
 
     for (i = 0 ; i < len ; i++) {
-        if (ret[i] == ',' || ret[i] == ',' || ret[i] == '/')
+        if (ret[i] == ',' || ret[i] == '/')
             ret[i]=' ';
     }
     s=ret;

--- a/navit/search.h
+++ b/navit/search.h
@@ -87,6 +87,7 @@ char *search_list_get_unique(struct search_list *this_, char *unique);
 struct search_list_result *search_list_get_result(struct search_list *this_);
 void search_list_destroy(struct search_list *this_);
 void search_init(void);
+static char *search_fix_spaces(char *str);
 /* end of prototypes */
 #ifdef __cplusplus
 }

--- a/navit/search.h
+++ b/navit/search.h
@@ -87,7 +87,7 @@ char *search_list_get_unique(struct search_list *this_, char *unique);
 struct search_list_result *search_list_get_result(struct search_list *this_);
 void search_list_destroy(struct search_list *this_);
 void search_init(void);
-static char *search_fix_spaces(char *str);
+char *search_fix_spaces(char *str);
 /* end of prototypes */
 #ifdef __cplusplus
 }

--- a/navit/search.h
+++ b/navit/search.h
@@ -87,7 +87,7 @@ char *search_list_get_unique(struct search_list *this_, char *unique);
 struct search_list_result *search_list_get_result(struct search_list *this_);
 void search_list_destroy(struct search_list *this_);
 void search_init(void);
-char *search_fix_spaces(char *str);
+char *search_fix_spaces(const char *str);
 /* end of prototypes */
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Closes: #898 

The only differences I can see between the function in search.c and the one in android.c are:
* the signature takes a `const char *` in android.c instead of a `char *` which shouldn't be a problem
* the 1st if of the for loop has a duplicate `ret[i] == ',' ||` condition which is cleaned up with the PR

Note that this would add a compilation warning saying:
```
warning: passing argument 1 of ‘search_fix_spaces’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
```
But as we need the const context for the android part to call `ReleaseStringUTFChars` I'm not sure if there's a better way to do that.