### PR TITLE
cleanup:ci:Simplify the listing of files for sanity check

### DIFF
--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -24,12 +24,7 @@ check_diff(){
 }
 
 # List the files that are different from the trunk
-from=$(git rev-parse refs/remotes/origin/trunk)
-to=$(git rev-parse HEAD)
-interval=${from}..${to}
-[[ "${from}" == "${to}" ]] && interval=${to}
-
-for f in $(git diff --name-only ${interval} | sort -u); do
+for f in $(git diff --name-only refs/remotes/origin/trunk | sort -u); do
     if [[ "${f}" =~ navit/support/ ]] || [[ "${f}" =~ navit/fib-1\.1/ ]] || [[ "${f}" =~ navit/traffic/permanentrestrictions/ ]] ; then
         echo "[DEBUG] Skipping file ${f} ..."
         continue


### PR DESCRIPTION
The current way of doing with interval sometimes leads to the last commit from trunk being included in the diff, leading to false positives.
This change simplifies the way we pull the files, and should make it more reliable.
