### PR TITLE
update:ci:Trying out using github action for checkstyle

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,0 +1,12 @@
+name: Go
+on: [push]
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@latest
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '1.12'
+      - run: ./gradlew checkstyleMain


### PR DESCRIPTION
Trying out related to #725 
For whatever reason the actions are not active on this repo and I can't figure out how to activate them.
The idea would be to have the checkstyle and sanity check out of circleci to avoid wasting CircleCI time and avoid scaring too much contributors.
We'll see. I'll keep the PR open for a bit to see if I can find out how to do a proof of concept on that.