### PR TITLE
update:CI: skip the build steps if the change is only for documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Id
           command: cat /etc/*release
@@ -39,6 +40,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Install doxygen and other essentials
           command: apt-get update && apt-get -y install doxygen ca-certificates git rsync
@@ -54,6 +56,7 @@ jobs:
     machine: true
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: install docker
           command: circleci-install docker
@@ -75,6 +78,7 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Id
           command: cat /etc/*release
@@ -131,6 +135,7 @@ jobs:
       - image: ubuntu:14.04
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Prepare the Windows build environment
           command: |
@@ -154,6 +159,7 @@ jobs:
       - image: navit/dockerfiles:wince
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Prepare the WinCE build environment
           command: |
@@ -173,6 +179,7 @@ jobs:
       - image: navit/tomtom-ng
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Setup common requirements
           command: |
@@ -193,6 +200,7 @@ jobs:
       - image: navit/tomtom-ng
     steps:
       - checkout
+      - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Setup common requirements
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          apt-get update && apt-get install -y git
+          apt-get update && apt-get install -y git-core
           if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Prepare the WinCE build environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: if scripts/check_need_build.sh; then circleci step halt; fi
+      - run: |
+          apt-get update && apt-get install -y git
+          if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Id
           command: cat /etc/*release
@@ -135,7 +137,9 @@ jobs:
       - image: ubuntu:14.04
     steps:
       - checkout
-      - run: if scripts/check_need_build.sh; then circleci step halt; fi
+      - run: |
+          apt-get update && apt-get install -y git
+          if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Prepare the Windows build environment
           command: |
@@ -159,7 +163,9 @@ jobs:
       - image: navit/dockerfiles:wince
     steps:
       - checkout
-      - run: if scripts/check_need_build.sh; then circleci step halt; fi
+      - run: |
+          apt-get update && apt-get install -y git
+          if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: Prepare the WinCE build environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ jobs:
       - run:
           name: Run CheckStyle Test
           command: ./gradlew checkstyleMain
+      - store_artifacts:
+          name: Store checkstyle report
+          path: navit/android/checkstyle
+          destination: reports
   build_linux:
     <<: *defaults
     steps:
@@ -119,10 +123,6 @@ jobs:
       - store_artifacts:
           name: Store Lint reports
           path: navit/android/build/reports
-          destination: reports
-      - store_artifacts:
-          name: Store checkstyle report
-          path: /home/circleci/code/navit/android/checkstyle
           destination: reports
       - store_test_results:
           path: test-results

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -18,7 +18,7 @@ if [[ -z "$files" ]]; then
 fi
 
 # This block filters out those don't match the pattern we use to exclude files that should not trigger a build.
-declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$' '.*') # WARNING! '.*' is here only for testing if the circleci command works. It should be removed before merge!
+declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$')
 for f in ${file_list[@]}; do
     for filter in "${filters[@]}" ; do
         if [[ "$f" =~ $filter ]]; then

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -26,7 +26,7 @@ list_files_git_diff(){
 # @return: nothing (the input variable is modified according to the brief description)
 filtered_files_git_diff(){
     local -n _ret=$1
-    declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$')
+    declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$' '.*') # WARNING! '.*' is here only for testing if the circleci command works. It should be removed before merge!
     declare -a file_list=()
     list_files_git_diff file_list
     for f in ${file_list[@]}; do

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -4,43 +4,28 @@
 # The idea is also to build if the exit code is different from 0 as it means we cannot get a filtered list properly.  #
 # ################################################################################################################### #
 
-# @brief: constructs the list of files that differ from the trunk branch.
-#         Note that if you are on the trunk or master branch it will return the files modified by the last commit.
-# @param: a variable you want to use to get the resulting value
-# @return: nothing (the input variable is modified according to the brief description)
-list_files_git_diff(){
-    local -n files=$1
-    files=$(git diff --name-only refs/remotes/origin/trunk)
+# This blockconstructs the list of files that differ from the trunk branch.
+# Note that if you are on the trunk or master branch it will return the files modified by the last commit.
+declare -a file_list=$(git diff --name-only refs/remotes/origin/trunk)
 
-    # If there is no diff that might just mean that you are on the trunk or master branch
-    # so you just want to check the last commit. This way we still have that check more
-    # or less working when pushing directly to trunk or when merging in master.
-    if [[ -z "$files" ]]; then
-        files=$(git diff --name-only HEAD^)
-    fi
-}
+# If there is no diff that might just mean that you are on the trunk or master branch
+# so you just want to check the last commit. This way we still have that check more
+# or less working when pushing directly to trunk or when merging in master.
+if [[ -z "$files" ]]; then
+    file_list=$(git diff --name-only HEAD^)
+fi
 
-# @brief: get the list of files that have differed from trunk (by calling list_files_git_diff for the full list)
-#         and filters out those don't match the pattern we use to exclude files that should not trigger a build.
-# @param: a variable you want to use to get the resulting value
-# @return: nothing (the input variable is modified according to the brief description)
-filtered_files_git_diff(){
-    local -n _ret=$1
-    declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$' '.*') # WARNING! '.*' is here only for testing if the circleci command works. It should be removed before merge!
-    declare -a file_list=()
-    list_files_git_diff file_list
-    for f in ${file_list[@]}; do
-        for filter in "${filters[@]}" ; do
-            if [[ "$f" =~ $filter ]]; then
-                # This removes the element from the element matching the filter
-                file_list=(${file_list[@]/$f})
-                break
-            fi
-        done
+# This block filters out those don't match the pattern we use to exclude files that should not trigger a build.
+declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$' '.*') # WARNING! '.*' is here only for testing if the circleci command works. It should be removed before merge!
+for f in ${file_list[@]}; do
+    for filter in "${filters[@]}" ; do
+        if [[ "$f" =~ $filter ]]; then
+            # This removes the element from the element matching the filter
+            file_list=(${file_list[@]/$f})
+            break
+        fi
     done
-    _ret=$file_list
-}
+done
 
-filtered_files_git_diff filtered_out_modified_files
 # exits with a 0 if the list is empty
-[[ -z "${filtered_out_modified_files}" ]]
+[[ -z "${filte_list}" ]]

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -4,10 +4,12 @@
 # The idea is also to build if the exit code is different from 0 as it means we cannot get a filtered list properly.  #
 # ################################################################################################################### #
 
-# This blockconstructs the list of files that differ from the trunk branch.
+# If we are on a tag, just exit 1 as we want to go on with the build
+git describe --exact-match --tags HEAD 2>&1 2>/dev/null && exit 1 || echo "Not on a tag, checking files diff"
+
+# This block constructs the list of files that differ from the trunk branch.
 # Note that if you are on the trunk or master branch it will return the files modified by the last commit.
 declare -a file_list=$(git diff --name-only refs/remotes/origin/trunk)
-
 # If there is no diff that might just mean that you are on the trunk or master branch
 # so you just want to check the last commit. This way we still have that check more
 # or less working when pushing directly to trunk or when merging in master.

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -26,7 +26,7 @@ list_files_git_diff(){
 # @return: nothing (the input variable is modified according to the brief description)
 filtered_files_git_diff(){
     local -n _ret=$1
-    declare -a filters=('^docs/.*', '.*\.md$', '.*\.rst$')
+    declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$')
     declare -a file_list=()
     list_files_git_diff file_list
     for f in ${file_list[@]}; do

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -18,7 +18,7 @@ if [[ -z "$file_list" ]]; then
 fi
 
 # This block filters out those don't match the pattern we use to exclude files that should not trigger a build.
-declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$' '.*') # WARNING! '.*' is here only for testing if the circleci command works. It should be removed before merge!
+declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$')
 for f in ${file_list[@]}; do
     for filter in "${filters[@]}" ; do
         echo "checking $f with filter $filter"

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+# ################################################################################################################### #
+# This file exits 1 if there are files of interest that should trigger a build and exits normally otherwise.          #
+# The idea is also to build if the exit code is different from 0 as it means we cannot get a filtered list properly.  #
+# ################################################################################################################### #
+
+# @brief: constructs the list of files that differ from the trunk branch.
+#         Note that if you are on the trunk or master branch it will return the files modified by the last commit.
+# @param: a variable you want to use to get the resulting value
+# @return: nothing (the input variable is modified according to the brief description)
+list_files_git_diff(){
+    local -n files=$1
+    files=$(git diff --name-only refs/remotes/origin/trunk)
+
+    # If there is no diff that might just mean that you are on the trunk or master branch
+    # so you just want to check the last commit. This way we still have that check more
+    # or less working when pushing directly to trunk or when merging in master.
+    if [[ -z "$files" ]]; then
+        files=$(git diff --name-only HEAD^)
+    fi
+}
+
+# @brief: get the list of files that have differed from trunk (by calling list_files_git_diff for the full list)
+#         and filters out those don't match the pattern we use to exclude files that should not trigger a build.
+# @param: a variable you want to use to get the resulting value
+# @return: nothing (the input variable is modified according to the brief description)
+filtered_files_git_diff(){
+    local -n _ret=$1
+    declare -a filters=('^docs/.*', '.*\.md$', '.*\.rst$')
+    declare -a file_list=()
+    list_files_git_diff file_list
+    for f in ${file_list[@]}; do
+        for filter in "${filters[@]}" ; do
+            if [[ "$f" =~ $filter ]]; then
+                # This removes the element from the element matching the filter
+                file_list=(${file_list[@]/$f})
+                break
+            fi
+        done
+    done
+    _ret=$file_list
+}
+
+filtered_files_git_diff filtered_out_modified_files
+# exits with a 0 if the list is empty
+[[ -z "${filtered_out_modified_files}" ]]

--- a/scripts/check_need_build.sh
+++ b/scripts/check_need_build.sh
@@ -13,21 +13,23 @@ declare -a file_list=$(git diff --name-only refs/remotes/origin/trunk)
 # If there is no diff that might just mean that you are on the trunk or master branch
 # so you just want to check the last commit. This way we still have that check more
 # or less working when pushing directly to trunk or when merging in master.
-if [[ -z "$files" ]]; then
+if [[ -z "$file_list" ]]; then
     file_list=$(git diff --name-only HEAD^)
 fi
 
 # This block filters out those don't match the pattern we use to exclude files that should not trigger a build.
-declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$')
+declare -a filters=('^docs/.*' '.*\.md$' '.*\.rst$' '.*') # WARNING! '.*' is here only for testing if the circleci command works. It should be removed before merge!
 for f in ${file_list[@]}; do
     for filter in "${filters[@]}" ; do
+        echo "checking $f with filter $filter"
         if [[ "$f" =~ $filter ]]; then
             # This removes the element from the element matching the filter
             file_list=(${file_list[@]/$f})
+            echo "filtering out $f"
             break
         fi
     done
 done
 
 # exits with a 0 if the list is empty
-[[ -z "${filte_list}" ]]
+[[ -z "${file_list}" ]]


### PR DESCRIPTION
Closes #925 

The idea is to skip the build steps if the change is only done on `*.md` or `*.rst` files or is only in the `docs` folder.
Saves CI time and makes the time to have the relevant checks passing shorter. Should help on #910 

Note that the branch should be be up-to-date with trunk to make it work.

Side note: if there is no diff with trunk (aka that's pushed on master or trunk) then we only check for the files in the last commit).
And if we are on a tag, we just exit 1 as we want to build even if the last change is a doc change.