### PR TITLE
fix:ci:Fix checkstyle changes since 8.24

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -31,6 +31,12 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <property name="severity" value="error"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -44,11 +50,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-            <property name="severity" value="error"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -259,7 +259,6 @@
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>

--- a/docs/development/programming_guidelines.rst
+++ b/docs/development/programming_guidelines.rst
@@ -206,4 +206,8 @@ For the Java code we follow the Google coding conventions from Google Java Style
 This style is enforced by using Checkstyle. Its definition file can be found at the root of the repository:
 `checkstyle.xml <https://github.com/navit-gps/navit/blob/trunk/checkstyle.xml>`_
 
+.. note::
+
+  Checkstyle 8.25 minimum is required if you want to run checkstyle without using gradle.
+
 Please add yourself to the list of authors, if you make a significant change.

--- a/navit/android/build.gradle
+++ b/navit/android/build.gradle
@@ -68,7 +68,7 @@ android {
         }
 
         checkstyle {
-            toolVersion = '8.10'
+            toolVersion = '8.26'
         }
     }
     applicationVariants.all { variant ->


### PR DESCRIPTION
In [8.24](https://checkstyle.org/releasenotes.html#Release_8.24), the following change happened:
```
Change LineLength Check parent from TreeWalker to Checker. Author: rnveach, Roman Ivanov #2116
```

In [8.25](https://checkstyle.org/releasenotes.html#Release_8.25), the following change happened:
```
JavadocMethodCheck: remove deprecated properties ignoreMethodNamesRegex, minLineCount, allowMissingJavadoc, allowMissingPropertyJavadoc. Author: rnveach #7096
```

This PR is fixing this.
Fixes #945