### PR TITLE
fix:plugins: too few arguments to functions navit_attr_iter_new and config_attr_iter_new

### DIFF
--- a/navit/plugin/pedestrian/pedestrian.c
+++ b/navit/plugin/pedestrian/pedestrian.c
@@ -1338,7 +1338,7 @@ static void pedestrian_navit_init(struct navit *nav) {
 #endif
     transform_set_scale(trans, 16);
     navit_get_attr(nav, attr_layout, &initial_layout, NULL);
-    iter = navit_attr_iter_new();
+    iter = navit_attr_iter_new(NULL);
     while (navit_get_attr(nav, attr_layout, &attr, iter)) {
         if (!strcmp(attr.u.layout->name, "Route")) {
             dbg(lvl_debug, "found %s", attr_to_name(attr.type));

--- a/navit/plugin/pedestrian/pedestrian.c
+++ b/navit/plugin/pedestrian/pedestrian.c
@@ -1397,7 +1397,7 @@ void plugin_init(void) {
     callback.type = attr_callback;
     callback.u.callback = callback_new_attr_0(callback_cast(pedestrian_navit), attr_navit);
     config_add_attr(config, &callback);
-    iter = config_attr_iter_new();
+    iter = config_attr_iter_new(NULL);
     while (config_get_attr(config, attr_navit, &navit, iter)) {
         pedestrian_navit_init(navit.u.navit);
     }


### PR DESCRIPTION
In Debian, the build fails with the 2 following errors:
```
/<<PKGBUILDDIR>>/navit/plugin/pedestrian/pedestrian.c: In function ‘pedestrian_navit_init’:
/<<PKGBUILDDIR>>/navit/plugin/pedestrian/pedestrian.c:1341:12: error: too few arguments to function ‘navit_attr_iter_new’
 1341 |     iter = navit_attr_iter_new();
      |            ^~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/navit/plugin/pedestrian/pedestrian.c:1400:12: error: too few arguments to function ‘config_attr_iter_new’
 1400 |     iter = config_attr_iter_new();
      |            ^~~~~~~~~~~~~~~~~~~~
```

This PR should fix that.

Note that the following flags are set during the build. Maybe we should consider having those inside our standard build system to avoid surprises (broken in several lines for readability):
```
-fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wall -Wundef -Wcast-align
  -Wpointer-arith -Wno-unused-parameter -Wno-sign-compare
  -Wno-missing-field-initializers
  -Wextra  -Wmissing-prototypes  -Wstrict-prototypes  -Wformat-security
  -g -O2 -Wformat -Werror=format-security -Wdate-time  -fPIC
```
What do you think?