### PR TITLE
Update:CI: Use debian:latest in the CI to get more up-to-date tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 defaults: &defaults
   docker:
-    - image: ubuntu:18.04
+    - image: debian:latest
 jobs:
   sanity_check:
     docker:


### PR DESCRIPTION
This is just changing the default image to pull more up-to-date dependencies like gcc.