### PR TITLE
add:ci: enable the pedestrian plugin by default on linux and android

### DIFF
--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -28,7 +28,13 @@ export GRADLE_OPTS='-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryEr
 echo Run CMake
 test -z "$PKG_CONFIG_LIBDIR" && export PKG_CONFIG_LIBDIR=""     # Force cmake below to run ignore build host libraries when using pkgconfig.
 # Note: If you want to compile against specific target libraries that are searched using pkgconfig, please run this script with variable PKG_CONFIG_LIBDIR set to the appropriate path
-cmake ./ -Dvehicle/gpsd_dbus:BOOL=FALSE -Dsvg2png_scaling:STRING=-1,24,32,48,64,96,128,192,256 -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128,192,256 -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96 -DXSL_PROCESSING=y -DXSLTS=android -DANDROID=y || exit 1
+cmake ./ \
+    -Dvehicle/gpsd_dbus:BOOL=FALSE \
+    -Dsvg2png_scaling:STRING=-1,24,32,48,64,96,128,192,256 \
+    -Dsvg2png_scaling_nav:STRING=-1,24,32,48,64,96,128,192,256 \
+    -Dsvg2png_scaling_flag:STRING=-1,24,32,64,96 \
+    -Dplugin/pedestrian=TRUE \
+    -DXSL_PROCESSING=y -DXSLTS=android -DANDROID=y || exit 1
 
 echo Process icons
 pushd navit/icons

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -4,14 +4,17 @@ set -e
 COVERITY_VERSION="2017.07"
 BUILD_PATH="linux"
 
-cmake_opts="-Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=n -Dgraphics/gtk_drawing_area:BOOL=TRUE"
-
 [ -d $BUILD_PATH ] || mkdir -p $BUILD_PATH
 pushd $BUILD_PATH
 
 # Build everything
-    echo "Building..."
-cmake ${cmake_opts} ../
+echo "Building..."
+cmake \
+    -Dgraphics/qt_qpainter:BOOL=FALSE -Dgui/qml:BOOL=FALSE \
+    -DSVG2PNG:BOOL=FALSE -DSAMPLE_MAP=n \
+    -Dgraphics/gtk_drawing_area:BOOL=TRUE \
+    -Dplugin/pedestrian=TRUE \
+    ../
 make -j $(nproc --all)
 make package
 

--- a/scripts/build_win32.sh
+++ b/scripts/build_win32.sh
@@ -7,6 +7,7 @@ mkdir win32
 pushd win32
 
 cmake -DTARGET_ARCH=i686-w64-mingw32 -DCMAKE_SYSTEM_NAME=Windows \
+  -Dplugin/pedestrian=TRUE \
   -Dbinding/python:BOOL=FALSE -DSAMPLE_MAP=n -DBUILD_MAPTOOL=n \
   -DXSLTS=windows -DCMAKE_TOOLCHAIN_FILE=../Toolchain/mingw.cmake ..
 

--- a/scripts/build_wince.sh
+++ b/scripts/build_wince.sh
@@ -5,6 +5,7 @@ mkdir -p wince
 pushd wince
 #
 cmake \
+  -Dplugin/pedestrian=TRUE \
   -DTARGET_ARCH=arm-mingw32ce -DCMAKE_SYSTEM_NAME=WindowsCETest \
   -DCMAKE_TOOLCHAIN_FILE=../Toolchain/mingw.cmake \
   -DXSLTS=windows,wince -DCACHE_SIZE=10485760 -Dsvg2png_scaling:STRING=16,32 \


### PR DESCRIPTION
Hi guys,

I think it would make sense to have the pedestrian module enabled by default.
At least that's how it's configured on Debian.
Wondering if we should have it built by default so that when we distribute the new release it's there.

What do you think?
Are there other plugins you think would be worth enabling by default?

Thanks,
Joseph