### PR TITLE
[WIP] Update:Android:GUI/Internal: Show contextual GUI menu when receiving geo intent

### DIFF
--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -368,7 +368,7 @@ public class Navit extends Activity {
             } else if (naviScheme.equals("geo")
                     && intent.getAction().equals("android.intent.action.VIEW")) {
                 invokeCallbackOnGeo(intent.getData().getSchemeSpecificPart(),
-                        NavitCallbackHandler.MsgType.CLB_SET_DESTINATION, "");
+                        NavitCallbackHandler.MsgType.CLB_COORD_ACTIONS, "");
             }
         }
     }

--- a/navit/android/src/org/navitproject/navit/NavitCallbackHandler.java
+++ b/navit/android/src/org/navitproject/navit/NavitCallbackHandler.java
@@ -42,20 +42,33 @@ class NavitCallbackHandler {
 
 
     enum MsgType {
-        CLB_SET_DESTINATION, CLB_SET_DISPLAY_DESTINATION, CLB_CALL_CMD, CLB_LOAD_MAP, CLB_UNLOAD_MAP,
-        CLB_DELETE_MAP
+        CLB_SET_DESTINATION, /* Set the current navigation destination to geographical coordinates */
+        CLB_SET_DISPLAY_DESTINATION, /* Set current navigation destination to a given position on the current graphical display */
+        CLB_COORD_ACTIONS, /* Open a contextual menu with possible actions related to the provided geographical coordinates */
+        CLB_CALL_CMD, /* Call a custom internal command (like in the GUI scripts) */
+        CLB_LOAD_MAP, /* Load a map */
+        CLB_UNLOAD_MAP, /* Unload a map */
+        CLB_DELETE_MAP /* Unload a map and delete it from the storage */
     }
 
 
     static class CallBackHandler extends Handler {
         public void handleMessage(Message msg) {
             switch (msg_values[msg.what]) {
-                case CLB_SET_DESTINATION:
+                case CLB_SET_DESTINATION: {
                     String lat = Float.toString(msg.getData().getFloat("lat"));
                     String lon = Float.toString(msg.getData().getFloat("lon"));
                     String q = msg.getData().getString(("q"));
                     callbackMessageChannel(3, lat + "#" + lon + "#" + q);
-                    break;
+                }
+                break;
+                case CLB_COORD_ACTIONS: {
+                    String lat = Float.toString(msg.getData().getFloat("lat"));
+                    String lon = Float.toString(msg.getData().getFloat("lon"));
+                    String q = msg.getData().getString(("q"));
+                    callbackMessageChannel(8, lat + "#" + lon + "#" + q);
+                }
+                break;
                 case CLB_SET_DISPLAY_DESTINATION:
                     int x = msg.arg1;
                     int y = msg.arg2;

--- a/navit/gui.c
+++ b/navit/gui.c
@@ -142,6 +142,17 @@ int gui_add_bookmark(struct gui *gui, struct pcoord *c, char *description) {
     return ret;
 }
 
+int gui_show_coord_actions(struct gui *gui, struct pcoord *c, char *description) {
+    int ret;
+    dbg(lvl_info,"enter");
+    if (! gui->meth.show_coord_actions)
+        return 0;
+    ret=gui->meth.show_coord_actions(gui->priv, c, description);
+
+    dbg(lvl_info,"ret=%d", ret);
+    return ret;
+}
+
 int gui_set_graphics(struct gui *this_, struct graphics *gra) {
     if (! this_->meth.set_graphics) {
         dbg(lvl_error, "cannot set graphics, method 'set_graphics' not available");

--- a/navit/gui.h
+++ b/navit/gui.h
@@ -39,6 +39,7 @@ struct gui_methods {
 	int (*run_main_loop)(struct gui_priv *priv);
 	struct datawindow_priv *(*datawindow_new)(struct gui_priv *priv, const char *name, struct callback *click, struct callback *close, struct datawindow_methods *meth);
 	int (*add_bookmark)(struct gui_priv *priv, struct pcoord *c, char *description);
+	int (*show_coord_actions)(struct gui_priv *priv, struct pcoord *c, char *description);
 	void (*disable_suspend)(struct gui_priv *priv);
 	int (*get_attr)(struct gui_priv *priv, enum attr_type type, struct attr *attr);
 	int (*add_attr)(struct gui_priv *priv, struct attr *attr);
@@ -64,6 +65,7 @@ struct menu *gui_menubar_new(struct gui *gui);
 struct menu *gui_popup_new(struct gui *gui);
 struct datawindow *gui_datawindow_new(struct gui *gui, const char *name, struct callback *click, struct callback *close);
 int gui_add_bookmark(struct gui *gui, struct pcoord *c, char *description);
+int gui_show_coord_actions(struct gui *this_,  struct pcoord *c, char *description);
 int gui_set_graphics(struct gui *this_, struct graphics *gra);
 void gui_disable_suspend(struct gui *this_);
 int gui_has_main_loop(struct gui *this_);

--- a/navit/gui/gtk/gui_gtk_window.c
+++ b/navit/gui/gtk/gui_gtk_window.c
@@ -276,12 +276,13 @@ static int gui_gtk_add_bookmark(struct gui_priv *gui, struct pcoord *c, char *de
 }
 
 struct gui_methods gui_gtk_methods = {
-    NULL,
+    NULL, // gui_gtk_menubar_new
     gui_gtk_popup_new,
     gui_gtk_set_graphics,
-    NULL,
+    NULL, // gui_gtk_run_main_loop
     gui_gtk_datawindow_new,
     gui_gtk_add_bookmark,
+    NULL, // gui_gtk_show_coord_actions
 };
 
 static gboolean gui_gtk_delete(GtkWidget *widget, GdkEvent *event, struct navit *nav) {

--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -2893,6 +2893,11 @@ static int gui_internal_set_graphics(struct gui_priv *this, struct graphics *gra
     return 0;
 }
 
+static int gui_internal_show_coord_actions(struct gui_priv *this, struct pcoord *c, char *description) {
+    gui_internal_cmd2_show_geopos_options(this, c, description);
+    return 1;
+}
+
 static void gui_internal_disable_suspend(struct gui_priv *this) {
     if (this->win->disable_suspend)
         this->win->disable_suspend(this->win);
@@ -2904,12 +2909,13 @@ static void gui_internal_disable_suspend(struct gui_priv *this) {
 //# Authors: Martin Schaller (04/2008)
 //##############################################################################################################
 struct gui_methods gui_internal_methods = {
-    NULL,
-    NULL,
+    NULL, // gui_internal_menubar_new
+    NULL, // gui_internal_popup_new
     gui_internal_set_graphics,
-    NULL,
-    NULL,
-    NULL,
+    NULL, // gui_internal_run_main_loop
+    NULL, // gui_internal_datawindow_new
+    NULL, // gui_internal_add_bookmark
+    gui_internal_show_coord_actions,
     gui_internal_disable_suspend,
     gui_internal_get_attr,
     gui_internal_add_attr,

--- a/navit/gui/internal/gui_internal_command.c
+++ b/navit/gui/internal/gui_internal_command.c
@@ -1061,6 +1061,25 @@ error:
     return;
 }
 
+void gui_internal_cmd2_show_geopos_actions(struct gui_priv *this, struct pcoord *c, char *description) {
+    struct widget w;
+    const char *name=NULL;
+
+    dbg(lvl_debug,"enter");
+    //~ if (!in || !in[0])
+        //~ dbg(lvl_error, "No arg");
+    //~ if (in[0] && ATTR_IS_STRING(in[0]->type)) {
+        //~ name=in[1]->u.str;
+        //~ dbg(lvl_error, "1st arg is string \"%s\"", name)
+    //~ }
+
+    w.name = "Location from QR code";
+    w.text = g_strdup("1.583471 15.340001");
+    pcoord_parse(w.text, projection_mg, &(w.c));
+    gui_internal_cmd_position(this, &w, (void*)8);
+    g_free(w.text);
+}
+
 static int gui_internal_cmd_img(struct gui_priv * this, char *function, struct attr **in, struct attr ***out) {
     char *str=g_strdup("<img"),*suffix=NULL,*onclick=g_strdup(""),*html;
 
@@ -1173,6 +1192,8 @@ static int gui_internal_cmd2(struct gui_priv *this, char *function, struct attr 
         gui_internal_cmd2_waypoints(this, function, in, out);
     else if(!strcmp(function, "about"))
         gui_internal_cmd2_about(this, function, in, out);
+    //else if(!strcmp(function, "geopos_actions"))
+    //	gui_internal_cmd2_show_geopos_actions(this, function, in, out);
 
     if(entering)
         graphics_draw_mode(this->gra, draw_mode_end);
@@ -1209,6 +1230,7 @@ static struct command_table commands[] = {
     {"waypoints",command_cast(gui_internal_cmd2)},
     {"write",command_cast(gui_internal_cmd_write)},
     {"about",command_cast(gui_internal_cmd2)},
+    //{"geopos_actions",command_cast(gui_internal_cmd2_show_geopos_actions)},
 #if HAS_IFADDRS
     {"network_info",command_cast(gui_internal_cmd2)},
 #endif

--- a/navit/gui/internal/gui_internal_command.h
+++ b/navit/gui/internal/gui_internal_command.h
@@ -2,7 +2,8 @@
 struct attr;
 struct gui_priv;
 struct pcoord;
-char *gui_internal_coordinates(struct pcoord *pc, char sep);
 int gui_internal_cmd2_quit(struct gui_priv *this, char *function, struct attr **in, struct attr ***out);
 void gui_internal_command_init(struct gui_priv *this, struct attr **attrs);
+//void gui_internal_cmd2_show_geopos_actions(struct gui_priv *this, char *function, struct attr **in, struct attr ***out);
+void gui_internal_cmd2_show_geopos_actions(struct gui_priv *this, struct pcoord *c, char *description);
 /* end of prototypes */

--- a/navit/gui/win32/gui_win32.c
+++ b/navit/gui/win32/gui_win32.c
@@ -562,9 +562,10 @@ struct gui_methods win32_gui_methods = {
     NULL, // win32_gui_menubar_new,
     win32_gui_popup_new,
     win32_gui_set_graphics,
-    NULL,
+    NULL, // win32_gui_run_main_loop
     NULL, // win32_gui_datawindow_new,
     win32_gui_add_bookmark,
+    NULL, // win32_gui_show_coord_actions
 };
 
 


### PR DESCRIPTION
I my previous PR #812, the default action when receiving a geo intent (for example by scanning a geo QR code), is to start navigating to the provided location.
This PR aims to give the user more control over which action is started when navit receives a geo intent.
For this (and only implemented when using the internal GUI), I bring up the contextual submenu for a geo position in the internal GUI, and let the user select what to do with this position (add bookmark, set as waypoint, destination, search for nearby POIs), in the same way as when the geo pos is entered manually in the internal GUI.

This is only for Android, and if this feature is not implemented in the active GUI plugin (only implemented in internal GUI for now), the behaviour will revert back to set destination to the GPS coords.