### PR TITLE
fix:ci:fix sailfish artifacts uploading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
       - store_artifacts:
           name: Store rpm
           path: ../rpmbuild/RPMS/
+          destination: rpmbuild
   build_android:
     working_directory: ~/code
     docker:


### PR DESCRIPTION
For whatever reasons the sailfish rpms are not visible in circleci
any more when they used to be. Maybe because of indirect path usage on
uploading them. This fixes that.