### PR TITLE
fix:build:android: Don't sign apk if no valid keyring is available

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,15 +31,14 @@ platform :android do
   end
   lane :playstore do
     sh("cd ..;bash scripts/build_android.sh")
-    
     gradle(
       task: 'assemble',
       build_type: 'Release'
     )
     isOnMasterBranch = currentBranch() == "master"
     if isOnMasterBranch
-      upload_to_play_store( track: 'beta', 
-      						json_key: 'key.json', 
+      upload_to_play_store( track: 'beta',
+      						json_key: 'key.json',
       						apk: 'navit/android/build/outputs/apk/release/android-release.apk',
       						package_name: 'org.navitproject.navit'
       					  )

--- a/navit/android/build.gradle
+++ b/navit/android/build.gradle
@@ -34,7 +34,9 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+            if(file(System.getenv("KEYSTORE")  ?: "/store").exists()){
+                signingConfig signingConfigs.release
+            }
         }
     }
     lintOptions {

--- a/scripts/setup_publish_keys.sh
+++ b/scripts/setup_publish_keys.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-if [ -n $GOOGLE_KEY ]; then
+if [[ -n $GOOGLE_KEY ]]; then
   echo $GOOGLE_KEY | base64 -d > key.json
 fi
-if [ -n $KEY ]; then
+if [[ -n $KEY ]]; then
   wget "https://github.com/navit-gps/infrastructure-blackbox/raw/master/keyrings/keystore.gpg"
   openssl aes-256-cbc -d -in keystore.gpg -md md5 -k $KEY > ~/.keystore
   keytool -importkeystore -srcstorepass "$STORE_PASS" -deststorepass "$STORE_PASS" -srckeystore ~/.keystore -destkeystore ~/.keystore -deststoretype pkcs12


### PR DESCRIPTION
This happens usually if building with CI on fork repository
may fix #994 