### PR TITLE
add:maptool:add waterway=weir as poly_dam to map

### DIFF
--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -787,6 +787,7 @@ static char *attrmap= {
     "w	waterway=riverbank	poly_water\n"
     "w	waterway=stream		water_stream\n"
     "w	waterway=dam		poly_dam\n"
+    "w	waterway=weir		poly_dam\n"
     "w	barrier=ditch	ditch\n"
     "w	barrier=hedge	hedge\n"
     "w	barrier=fence	fence\n"


### PR DESCRIPTION
As a lot of big water dams are mapped as waterway=weir, add this tag to Navit as well.
