### PR TITLE
Make sure park, meadow, scrub, and wood render in correct order

### DIFF
--- a/navit/navit_layout_car_dark_shipped.xml
+++ b/navit/navit_layout_car_dark_shipped.xml
@@ -181,6 +181,10 @@
 			<polygon color="#06190f"/>
 			<text text_size="5"/>
 		</itemgra>
+		<itemgra item_types="poly_park" order="0-">
+			<polygon color="#031909"/>
+			<text color="#55c4bd" background_color="#000000" text_size="5"/>
+		</itemgra>
 		<itemgra item_types="poly_heath" order="10-">
 			<polygon color="#061c11"/>
 			<text text_size="5"/>
@@ -241,10 +245,6 @@
 			<polygon color="#030f07"/>
 			<text text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_wood" order="0-">
-			<polygon color="#041a06"/>
-			<text color="#55c4bd" background_color="#000000" text_size="5"/>
-		</itemgra>
 		<itemgra item_types="poly_greenhouse" order="10-">
 			<polygon color="#071d16"/>
 			<text text_size="5"/>
@@ -273,8 +273,8 @@
 			<polygon color="#041a06"/>
 			<text color="#55c4bd" background_color="#000000" text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_park" order="0-">
-			<polygon color="#031909"/>
+		<itemgra item_types="poly_wood" order="0-">
+			<polygon color="#041a06"/>
 			<text color="#55c4bd" background_color="#000000" text_size="5"/>
 		</itemgra>
 		<itemgra item_types="poly_sport" order="10-">

--- a/navit/navit_layout_car_shipped.xml
+++ b/navit/navit_layout_car_shipped.xml
@@ -158,6 +158,10 @@
 			<polygon color="#ddcc88"/>
 			<text text_size="5"/>
 		</itemgra>
+		<itemgra item_types="poly_park" order="0-">
+			<polygon color="#77cc55"/>
+			<text text_size="5"/>
+		</itemgra>
 		<itemgra item_types="poly_heath" order="10-">
 			<polygon color="#d6d99f"/>
 			<text text_size="5"/>
@@ -218,10 +222,6 @@
 			<polygon color="#797548"/>
 			<text text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_wood" order="0-">
-			<polygon color="#8ec78d" src="wood.png" w="100" h="100"/>
-			<text text_size="5"/>
-		</itemgra>
 		<itemgra item_types="poly_greenhouse" order="10-">
 			<polygon color="#f9e8cb"/>
 			<text text_size="5"/>
@@ -255,8 +255,8 @@
 			<polygon color="#c8d7ab" src="scrub.png" w="50" h="50"/>
 			<text text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_park" order="0-">
-			<polygon color="#77cc55"/>
+		<itemgra item_types="poly_wood" order="0-">
+			<polygon color="#8ec78d" src="wood.png" w="100" h="100"/>
 			<text text_size="5"/>
 		</itemgra>
 		<itemgra item_types="poly_sport" order="10-">


### PR DESCRIPTION
Improve rendering order involving park, meadow, scrub, and wood polygons.
Please see before and after below:

Before:
![1a](https://user-images.githubusercontent.com/23396293/84478255-4836ae80-ac91-11ea-8883-a0db6cb0cd04.jpg)
After:
![1b](https://user-images.githubusercontent.com/23396293/84478262-4b319f00-ac91-11ea-844e-026261f2184b.jpg)

Before:
![2a](https://user-images.githubusercontent.com/23396293/84478264-4cfb6280-ac91-11ea-9168-992780f2181a.jpg)
After:
![2b](https://user-images.githubusercontent.com/23396293/84478270-508ee980-ac91-11ea-9845-0cb485af9aad.jpg)

Before:
![3a](https://user-images.githubusercontent.com/23396293/84478276-54227080-ac91-11ea-8104-6d21e724877d.jpg)
After:
![3b](https://user-images.githubusercontent.com/23396293/84478283-55ec3400-ac91-11ea-9282-dbeb0419be18.jpg)

Before:
![4a](https://user-images.githubusercontent.com/23396293/84478288-57b5f780-ac91-11ea-82e4-e7768e56fe1b.jpg)
After:
![4b](https://user-images.githubusercontent.com/23396293/84478303-5be21500-ac91-11ea-8b7f-fae1fb3e02e7.jpg)
