### PR TITLE
Fix:maptool:Duplicate multipolygons if required

### DIFF
--- a/navit/maptool/maptool.c
+++ b/navit/maptool/maptool.c
@@ -879,6 +879,7 @@ static void maptool_assemble_map(struct maptool_params *p, char *suffix, char **
         zip_write_index(zip_info);
         zip_write_directory(zip_info);
         zip_close(zip_info);
+        zip_destroy(zip_info);
         if (!p->keep_tmpfiles) {
             remove_countryfiles();
             tempfile_unlink("index","");


### PR DESCRIPTION
In order to support (multi)polygons that are tagged with more than one
set of tags resulting it to require two navit items to be represented on
map, affected elements are duplicated and added with every item type
decoded. This is already done for ways and points. This fix makes
maptool do this for multipolygons as well.

+ fixes some valgrind findings