### PR TITLE
Enhancement:layout_car:Add stripes to danger_area

### DIFF
--- a/navit/navit_layout_car_shipped.xml
+++ b/navit/navit_layout_car_shipped.xml
@@ -186,10 +186,6 @@
 			<polygon color="#998877"/>
 			<text text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_danger_area" order="10-">
-			<polygon color="#f2ba1b"/>
-			<text text_size="5"/>
-		</itemgra>
 		<itemgra item_types="poly_common" order="10-">
 			<polygon color="#7bab36"/>
 			<text text_size="5"/>
@@ -515,6 +511,11 @@
 		<itemgra item_types="poly_airfield" order="10-">
 			<polygon color="#ecd3cf66"/>
 			<text text_size="5"/>
+		</itemgra>
+		<itemgra item_types="poly_danger_area" order="8-">
+				<polygon color="#f2ba1b33" src="diagonal-stripes.png" w="16" h="16"/>
+				<polyline color="#ff0000b5"/>
+				<text text_size="5"/>
 		</itemgra>
 	</layer>
 	<layer name="heightlines">

--- a/navit/textures/diagonal-stripes.svg
+++ b/navit/textures/diagonal-stripes.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="diagonal-stripes.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="7.0056832"
+     inkscape:cy="7.0756723"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1889"
+     inkscape:window-height="1025"
+     inkscape:window-x="31"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,93.566687)">
+    <path
+       style="fill:none;stroke:#ff0000;stroke-width:1.0015748;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.70980394;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 0,-81.566687 12,-12"
+       id="path817"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ff0000;stroke-width:1.0015748;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:0.70980394;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 12,-77.566687 4,-4"
+       id="path821"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>


### PR DESCRIPTION
This pull request adds a red stripe texture that is used for poly_danger_area on car layout.
Additionally to that, a lightly transparent red border is added to it.

To see the diagonal stripes one needs to use either gtk_drawing_area or qt5 graphics as only those currently support textured polygons.
