### PR TITLE
Make sure industry, sport, meadow, scrub, and cemetery render in correct order

### DIFF
--- a/navit/navit_layout_car_dark_shipped.xml
+++ b/navit/navit_layout_car_dark_shipped.xml
@@ -268,6 +268,9 @@
 			<polyline color="#051912"/>
 			<text color="#55c4bd" background_color="#000000" text_size="5"/>
 		</itemgra>
+		<itemgra item_types="poly_cemetery" order="8-">
+			<polygon color="#061b16"/>
+		</itemgra>
 		<itemgra item_types="poly_meadow" order="0-">
 			<polygon color="#051d11"/>
 		</itemgra>
@@ -434,9 +437,6 @@
 		</itemgra>
 		<itemgra item_types="poly_terminal" order="7-">
 			<polygon color="#282424"/>
-		</itemgra>
-		<itemgra item_types="poly_cemetery" order="8-">
-			<polygon color="#061b16"/>
 		</itemgra>
 		<itemgra item_types="poly_car_parking" order="8-">
 			<polygon color="#071b0d"/>

--- a/navit/navit_layout_car_dark_shipped.xml
+++ b/navit/navit_layout_car_dark_shipped.xml
@@ -82,6 +82,9 @@
 		<itemgra item_types="poly_town" order="0-">
 			<polygon color="#071912"/>
 		</itemgra>
+		<itemgra item_types="poly_industry,poly_place" order="0-">
+			<polygon color="#061b18"/>
+		</itemgra>
 		<itemgra item_types="poly_naval_base" order="10-">
 			<polygon color="#03140f"/>
 			<text text_size="5"/>
@@ -225,6 +228,9 @@
 			<polygon color="#05190d"/>
 			<text text_size="5"/>
 		</itemgra>
+		<itemgra item_types="poly_sport" order="10-">
+			<polygon color="#051c0d"/>
+		</itemgra>
 		<itemgra item_types="poly_fishing" order="10-">
 			<polygon color="#030700"/>
 			<text text_size="5"/>
@@ -277,9 +283,6 @@
 			<polygon color="#041a06"/>
 			<text color="#55c4bd" background_color="#000000" text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_sport" order="10-">
-			<polygon color="#051c0d"/>
-		</itemgra>
 		<itemgra item_types="poly_beach" order="0-">
 			<polygon color="#071d0d"/>
 			<text color="#55c4bd" background_color="#000000" text_size="5"/>
@@ -329,9 +332,6 @@
 		<itemgra item_types="poly_sports_pitch" order="10-">
 			<polygon color="#041d0f"/>
 			<polyline color="#021709"/>
-		</itemgra>
-		<itemgra item_types="poly_industry,poly_place" order="0-">
-			<polygon color="#061b18"/>
 		</itemgra>
 		<itemgra item_types="poly_service" order="8-18">
 			<polygon color="#1a1a1a"/>

--- a/navit/navit_layout_car_shipped.xml
+++ b/navit/navit_layout_car_shipped.xml
@@ -245,6 +245,9 @@
 			<polyline color="#bbccaa"/>
 			<text text_size="5"/>
 		</itemgra>
+		<itemgra item_types="poly_cemetery" order="1-">
+			<polygon color="#ccddcc" src="cemetery.png" w="32" h="32"/>
+		</itemgra>
 		<itemgra item_types="poly_meadow" order="0-">
 			<polygon color="#bbee99"/>
 			<polyline color="#79c691"/>
@@ -433,9 +436,6 @@
 		</itemgra>
 		<itemgra item_types="poly_terminal" order="7-">
 			<polygon color="#e3c6a6"/>
-		</itemgra>
-		<itemgra item_types="poly_cemetery" order="1-">
-			<polygon color="#ccddcc" src="cemetery.png" w="32" h="32"/>
 		</itemgra>
 		<itemgra item_types="poly_car_parking" order="1-">
 			<polygon color="#eedd77"/>

--- a/navit/navit_layout_car_shipped.xml
+++ b/navit/navit_layout_car_shipped.xml
@@ -78,6 +78,9 @@
 			<polygon color="#ffccaa"/>
 			<polyline color="#ebb481"/>
 		</itemgra>
+		<itemgra item_types="poly_industry,poly_place" order="0-">
+			<polygon color="#dddddd"/>
+		</itemgra>
 		<itemgra item_types="poly_naval_base" order="10-">
 			<polygon color="#6a9993"/>
 			<text text_size="5"/>
@@ -202,6 +205,9 @@
 			<polygon color="#b4c479"/>
 			<text text_size="5"/>
 		</itemgra>
+		<itemgra item_types="poly_sport" order="10-">
+			<polygon color="#a5dc72"/>
+		</itemgra>
 		<itemgra item_types="poly_fishing" order="10-">
 			<polygon color="#713907"/>
 			<text text_size="5"/>
@@ -259,9 +265,6 @@
 			<polygon color="#8ec78d" src="wood.png" w="100" h="100"/>
 			<text text_size="5"/>
 		</itemgra>
-		<itemgra item_types="poly_sport" order="10-">
-			<polygon color="#a5dc72"/>
-		</itemgra>
 		<itemgra item_types="poly_beach" order="0-">
 			<polygon color="#eeee77"/>
 			<text text_size="5"/>
@@ -318,9 +321,6 @@
 		<itemgra item_types="poly_sports_pitch" order="10-">
 			<polygon color="#88ee88"/>
 			<polyline color="#55bb55"/>
-		</itemgra>
-		<itemgra item_types="poly_industry,poly_place" order="0-">
-			<polygon color="#dddddd"/>
 		</itemgra>
 		<itemgra item_types="poly_service" order="8-18">
 			<polygon color="#fefefe"/>


### PR DESCRIPTION
Improve rendering order involving industry, sport, meadow, scrub, and cemetery polygons.
Please see before and after below:

Before:
![Screenshot_20200615-070835_Navit](https://user-images.githubusercontent.com/23396293/84621524-10bb4280-aedb-11ea-9e9e-9771ca7469ca.jpg)
After:
![Screenshot_20200615-070854_Navit](https://user-images.githubusercontent.com/23396293/84621541-1c0e6e00-aedb-11ea-8bf1-4095c8104687.jpg)

Before:
![Screenshot_20200615-071003_Navit](https://user-images.githubusercontent.com/23396293/84621544-1e70c800-aedb-11ea-9d3f-a131e91b6f2f.jpg)
After:
![Screenshot_20200615-071030_Navit](https://user-images.githubusercontent.com/23396293/84621549-203a8b80-aedb-11ea-955b-e0e4fab2c977.jpg)

Before:
![Screenshot_20200615-071224_Navit](https://user-images.githubusercontent.com/23396293/84621554-229ce580-aedb-11ea-9e21-de32716db52b.jpg)
After:
![Screenshot_20200615-071252_Navit](https://user-images.githubusercontent.com/23396293/84621557-2597d600-aedb-11ea-8635-93df22a163bd.jpg)

Before:
![Screenshot_20200615-071936_Navit](https://user-images.githubusercontent.com/23396293/84621560-27fa3000-aedb-11ea-87a6-c92e6ae3f281.jpg)
After:
![Screenshot_20200615-071955_Navit](https://user-images.githubusercontent.com/23396293/84621563-2af52080-aedb-11ea-8a4d-76872f92b852.jpg)

Before:
![Screenshot_20200615-073226_Navit](https://user-images.githubusercontent.com/23396293/84621566-2df01100-aedb-11ea-94af-eb2f5f7775ae.jpg)
After:
![Screenshot_20200615-073251_Navit](https://user-images.githubusercontent.com/23396293/84621572-2f213e00-aedb-11ea-81a5-f9b7d2c7eed9.jpg)