### PR TITLE
Android: Activate downloaded maps automatically

### DIFF
--- a/navit/xslt/map_sdcard_navitmap_bin.xslt
+++ b/navit/xslt/map_sdcard_navitmap_bin.xslt
@@ -2,5 +2,7 @@
 <xsl:transform version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xi="http://www.w3.org/2001/XInclude">
 	<xsl:template match="/config/navit/mapset/xi:include">
 		<maps type="binfile" data="$NAVIT_USER_DATADIR/*.bin" />
+		<xsl:text>&#x0A;                        </xsl:text>
+		<maps type="binfile" data="/sdcard/Download/*.bin" />
 	</xsl:template>
 </xsl:transform>

--- a/navit/xslt/map_sdcard_navitmap_bin.xslt
+++ b/navit/xslt/map_sdcard_navitmap_bin.xslt
@@ -3,6 +3,6 @@
 	<xsl:template match="/config/navit/mapset/xi:include">
 		<maps type="binfile" data="$NAVIT_USER_DATADIR/*.bin" />
 		<xsl:text>&#x0A;                        </xsl:text>
-		<maps type="binfile" data="/sdcard/Download/*.bin" />
+		<maps type="binfile" data="/sdcard/Download/osm_bbox_*.bin" />
 	</xsl:template>
 </xsl:transform>


### PR DESCRIPTION
Activate downloaded maps automatically on Android by including the `/sdcard/Download` directory.
This is done so that maps downloaded in the browser, f.ex. using the Planet Extractor, which go to `/sdcard/Download` by default, are activated automatically without having to change the map location in de UI. This way, maps can be downloaded in the app using the UI, and maps can also be downloaded through the browser. Both will _just work™_.