### PR TITLE
fix:vehicle:gpsd:Add Support for Gpsd 3.21

### DIFF
--- a/navit/vehicle/gpsd/vehicle_gpsd.c
+++ b/navit/vehicle/gpsd/vehicle_gpsd.c
@@ -17,7 +17,6 @@
  * Boston, MA  02110-1301, USA.
  */
 
-#include <config.h>
 #include <gps.h>
 #include <string.h>
 #include <glib.h>
@@ -166,7 +165,12 @@ vehicle_gpsd_callback(struct gps_data_t *data, const char *buf, size_t len,
         data->set &= ~SATELLITE_SET;
     }
     if (data->set & STATUS_SET) {
+#if GPSD_API_MAJOR_VERSION >= 10
+        priv->status = data->fix.status;
+#else
         priv->status = data->status;
+#endif // GPSD_API_MAJOR_VERSION >= 9
+
         data->set &= ~STATUS_SET;
     }
     if (data->set & MODE_SET) {


### PR DESCRIPTION
This PR fixes the Build against Gpsd 3.21 which had introduced another api change. 
Today its the status which went from `gps_data_t->status` to `gps_data_t->fix.status` 

Changelog for this is here: https://gitlab.com/gpsd/gpsd/-/blob/00c66ad6f44f6283cdddc5f48f334216daf78f12/gps.h#L82