### PR TITLE
fix:graphics/qt5:Add missing include

### DIFF
--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -45,6 +45,7 @@ extern "C" {
 #include <QFont>
 #include <QGuiApplication>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPixmap>
 #include <QScreen>
 #include <QSvgRenderer>


### PR DESCRIPTION
When running `make` or more specifically `make graphics_qt5`, compilation fails with this error:
```
/home/bbq/gits/navit-gps/navit/navit/graphics/qt5/graphics_qt5.cpp: In function ‘void draw_polygon_with_holes(graphics_priv*, graphics_gc_priv*, point*, int, int, int*, point**)’:
/home/bbq/gits/navit-gps/navit/navit/graphics/qt5/graphics_qt5.cpp:439:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  439 |     QPainterPath path;
      |                  ^~~~
/home/bbq/gits/navit-gps/navit/navit/graphics/qt5/graphics_qt5.cpp:440:18: error: aggregate ‘QPainterPath inner’ has incomplete type and cannot be defined
  440 |     QPainterPath inner;
      |                  ^~~~~
```

Adding the `#include` fixes that error.

(I don't actually run the qt5 GUI; on my distro's package qt5 is also explicitly disabled. But the documentation has `cmake ... ; make` as the development workflow)