### PR TITLE
fix:build:core:Fix two issues where the wrong enum type is used

### DIFF
--- a/navit/command.c
+++ b/navit/command.c
@@ -158,7 +158,7 @@ static void result_free(struct result *res) {
         attr_free_content(&res->attr);
         res->allocated=0;
     } else {
-        res->attr.type=type_none;
+        res->attr.type=attr_none;
         res->attr.u.data=NULL;
     }
 }

--- a/navit/map/binfile/binfile.c
+++ b/navit/map/binfile/binfile.c
@@ -565,7 +565,7 @@ static int binfile_attr_get(void *priv_data, enum attr_type attr_type, struct at
                     size_rem-=subsize+1;
                     i++;
                 }
-                mr->attrs[i].type=type_none;
+                mr->attrs[i].type=attr_none;
                 mr->attrs[i].u.data=NULL;
                 attr->u.attrs=mr->attrs;
             } else {


### PR DESCRIPTION
Fix two issues where the wrong enum type is used, but both have the same value of 0
