### PR TITLE
Fix:plugin/j1850: Replace graphic_fg_white with graphic_fg.

### DIFF
--- a/navit/plugin/j1850/j1850.c
+++ b/navit/plugin/j1850/j1850.c
@@ -316,7 +316,7 @@ static void osd_j1850_init(struct j1850 *this, struct navit *nav) {
     graphics_gc_set_linewidth(this->white, this->width);
 
 
-    graphics_gc_set_linewidth(this->osd_item.graphic_fg_white, this->width);
+    graphics_gc_set_linewidth(this->osd_item.graphic_fg, this->width);
 
     event_add_timeout(500, 1, callback_new_1(callback_cast(osd_j1850_draw), this));
 


### PR DESCRIPTION
Looks like this was missed in:
46f67d8937cfef6158eeee6e5ed039d29fc1b8f7

Fixes:
```
j1850.c:319:46: error: ‘struct osd_item’ has no member named ‘graphic_fg_white’
```