### PR TITLE
Fix:ci:Relax checkstyle rules for Java code, see #1041

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -59,9 +59,6 @@
             <property name="tokens"
              value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
-        <module name="NeedBraces">
-            <property name="severity" value="error"/>
-        </module>
         <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
@@ -141,7 +138,7 @@
             <property name="severity" value="error"/>
         </module>
         <module name="MemberName">
-            <property name="format" value="^m[A-Z][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Member name ''{0}'' must match pattern ''{1}''."/>
             <property name="severity" value="error"/>
@@ -211,7 +208,6 @@
             <property name="allowedAbbreviationLength" value="3"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
-        <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>


### PR DESCRIPTION
This relaxes some checkstyle rules to be in line with what we require for C code (see #1041):

* MemberName: No longer enforce member names à la `mFoobar` (which is reminiscent of a now-discouraged practice in C and which we don’t enforce or even use there); now the only requirement is that member names must start with a lowercase letter (as identifiers starting with an uppercase letter are for class names) and contain nothing other than letters and numbers. Hence any of `mFoobar`, `foobar` or `fooBar` is now accepted. `Foobar` or `foo_bar` would get flagged as before.
* NeedBraces: We don’t require braces around single-statement blocks in C (and usually omit them there), so the same now applies to Java code.
* VariableDeclarationUsageDistance: No longer enforced—in C we require variable declaration at the very top due to compiler limitation, so it would be consistent to do the same in Java, though not a requirement. If someone really wants to put effort into this, they can design a rule that says “either declare variables at the top, or no more than 3 lines from first usage”, though I am not sure this can be done in checkstyle.