### PR TITLE
fix:build:android: Fix VersionCode after 31.12.2020

### DIFF
--- a/gradle/scripts/git-scm-version.gradle
+++ b/gradle/scripts/git-scm-version.gradle
@@ -15,7 +15,7 @@ import java.time.format.DateTimeFormatter
 ext {
     git = Grgit.open(currentDir: projectDir)
     gitVersionName = git.describe(match: ["v[0-9.rc]*"])
-    gitVersionCode = Integer.parseInt(DateTimeFormatter.ofPattern("yyMMddHHmm").format(git.head().dateTime))
+    gitVersionCode = Integer.parseInt(DateTimeFormatter.ofPattern("yyyyMMddHH").format(git.head().dateTime))
 }
 
 task printVersion() {

--- a/gradle/scripts/git-scm-version.gradle
+++ b/gradle/scripts/git-scm-version.gradle
@@ -15,7 +15,11 @@ import java.time.format.DateTimeFormatter
 ext {
     git = Grgit.open(currentDir: projectDir)
     gitVersionName = git.describe(match: ["v[0-9.rc]*"])
-    gitVersionCode = Integer.parseInt(DateTimeFormatter.ofPattern("yyyyMMddHH").format(git.head().dateTime))
+    hh = Integer.parseInt(DateTimeFormatter.ofPattern("HH").format(git.head().dateTime))
+    mm = Integer.parseInt(DateTimeFormatter.ofPattern("mm").format(git.head().dateTime))
+    hhmm = Math.round((hh*4)+(mm/15)).toString()
+    yyyyMMdd = DateTimeFormatter.ofPattern("yyyyMMdd").format(git.head().dateTime)
+    gitVersionCode = Integer.parseInt(yyyyMMdd + hhmm)
 }
 
 task printVersion() {


### PR DESCRIPTION
Currently the VersionCode has the Format yyMMddHHmm
which breaked at 01.01.2021 because the maximum allowed Version by
Google Play is 2100000000 because of the limitation of older Android
Devices.
Out currently highest VersionCode is 2012201504 and we need to keep it
continuous, so the new Format would be yyyyMMddHH.
Of cause this has the limitation that we can "only" create one
Versioncode per Hour.
But this is the the best @hoehnp and I came up yesterday.
As a result a PR will follow which will remove the android build from
the master build and instead will add it to a scheduled build (nightly
build)