### PR TITLE
Fix:build/android:do not double-define getcwd on recent NDK versions

### DIFF
--- a/navit/support/gettext_intl/dcigettext.c
+++ b/navit/support/gettext_intl/dcigettext.c
@@ -156,7 +156,7 @@ char *getwd ();
 # else
 #  if VMS
 #   define getcwd(buf, max) (getcwd) (buf, max, 0)
-#  else
+#  elif !(defined(__clang__) && defined(__BIONIC_FORTIFY))
 char *getcwd ();
 #  endif
 # endif


### PR DESCRIPTION
Fixes #1043

Holding this back while jkoan is still investigating the build issues on F-Droid.

I have successfully built this locally on NDK 21, then after downgrading to NDK 18 (which had not experienced the issue this commit intends to fix).

@jandegr I can’t officially add you as a reviewer here, but your input would be appreciated (e.g. if I’ve overlooked something).