### PR TITLE
Update macos_development.rst

### DIFF
--- a/docs/development/macos_development.rst
+++ b/docs/development/macos_development.rst
@@ -4,6 +4,10 @@ MacOS Development
 
 Here are some notes about running navit under Apple Mac OSX.
 
+================================================================================================================================
+WARNING: These instructions are currently unmaintained. Please feel free to submit a PR if you manage to build navit on Mac OSX.
+================================================================================================================================
+
 What you will need
 ==================
 


### PR DESCRIPTION
As discussed in #1088, it seems that building on Mac OSX is not functional right now. Therefore, I would suggest to include this warning. If someone is willing to resolve #767  I would suggest to remove the warning again. Any thoughts?
