### PR TITLE
Fix:build:do not request CXX if explicitly disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,11 @@ cmake_minimum_required(VERSION 3.2)
 set(MACOSX_BUNDLE_GUI_IDENTIFIER "org.navitproject.navit")
 set(MACOSX_BUNDLE_BUNDLE_NAME "Navit")
 message(STATUS "Building with CMake V${CMAKE_VERSION}")
-project(navit C CXX)
+if (DISABLE_CXX)
+	project(navit C)
+else(DISABLE_CXX)
+	project(navit C CXX)
+endif(DISABLE_CXX)
 
 # Workaround for CMake issue 8345 / 9220, see http://trac.navit-project.org/ticket/1041
 if(DEFINED CMAKE_CXX_COMPILER AND CMAKE_CXX_COMPILER MATCHES "^$")


### PR DESCRIPTION
This fixes issues with builds failing because of CMake not finding a suitable C++ compiler although CXX was explicitly disabled.

Sample output from an Android build, which this PR fixes:

```
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is unknown
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at CMakeLists.txt:10 (project):
  No CMAKE_CXX_COMPILER could be found.
  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
-- Configuring incomplete, errors occurred!
```