### PR TITLE
Fix:build:Reduce source tree pollution by Android build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ android {
     }
     externalNativeBuild {
         cmake {
+            buildStagingDirectory "./android-builddir"
             path 'CMakeLists.txt'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,8 @@ android {
             java.srcDirs = ["navit/android/src"]
             resources.srcDirs = ["navit/android/src"]
             renderscript.srcDirs = ["navit/android/src"]
-            res.srcDirs = ["navit/android/res"]
-            assets.srcDirs = ["navit/android/assets"]
+            res.srcDirs = ["navit/android/res", "android-builddir/android/res"]
+            assets.srcDirs = ["navit/android/assets", "android-builddir/android/assets"]
             }
     }
     externalNativeBuild {

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -38,10 +38,10 @@ cmake ../ -Dvehicle/gpsd_dbus:BOOL=FALSE -Dsvg2png_scaling:STRING=-1,24,32,48,64
 echo Process icons
 pushd navit/icons
 make || exit 32
-rm -rf ../../../navit/android/res/drawable-nodpi
-mkdir ../../../navit/android/res/drawable-nodpi
-cp ./*.png ../../../navit/android/res/drawable-nodpi
-pushd ../../../navit/android/res/drawable-nodpi
+rm -rf ../../android/res/drawable-nodpi
+mkdir -p ../../android/res/drawable-nodpi
+cp ./*.png ../../android/res/drawable-nodpi
+pushd ../../android/res/drawable-nodpi
 rename -f 'y/A-Z/a-z/' ./*.png
 popd
 popd
@@ -49,10 +49,10 @@ popd
 echo Process translations
 pushd po
 make || exit 64
-rm -rf ../../navit/android/res/raw
-mkdir ../../navit/android/res/raw
-cp ./*.mo ../../navit/android/res/raw
-pushd ../../navit/android/res/raw
+rm -rf ../android/res/raw
+mkdir -p ../android/res/raw
+cp ./*.mo ../android/res/raw
+pushd ../android/res/raw
 rename -f 'y/A-Z/a-z/' ./*.mo
 popd
 popd
@@ -61,11 +61,9 @@ popd
 
 echo Process xml config files
 make navit_config_xml || exit 96
-pushd ../navit
 rm -rf ./android/assets
 mkdir -p ./android/assets
-cp -R ../$BUILD_PATH/navit/config ./android/assets/
-popd
+cp -R ./navit/config ./android/assets/
 
 #run gradle from root dir, not $BUILD_PATH
 popd


### PR DESCRIPTION
As described in #762, this now moves all CMake output from the Android build to a subdir named `android-builddir`.

<del>For now, generated XML, PNG and translation files still get copied into the source tree. However, each gets written to an otherwise unused subdir (no mixing of code and generated files within the same dir), making cleanup much easier than before.</del>

With this change, the Android build leaves five elements in the source tree:
* `android-builddir/` (the build dir)
* `cmake_plugin_settings.txt`
* <del>`navit/android/assets/` (XML config files, entire dir)</del>
* <del>`navit/android/res/drawable-nodpi/` (PNG bitmaps, entire dir)</del>
* <del>`navit/android/res/raw/`(translations, entire dir)</del>

@jkoan For now, this does not change anything about the use of `build_android.sh` or the double CMake. See if you can use this for your Android build efforts—if you have already solved the Android source tree pollution issue otherwise, feel free to close this.