### PR TITLE
Fix:build:Fix F-Droid build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
 jobs:
   sanity_check:
     docker:
-      - image: navit/sanity_check:latest
+      - image: circleci/android:api-29-ndk
     steps:
       - checkout
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,12 @@ INCLUDE (CheckLibraryExists)
 INCLUDE (CheckFunctionExists)
 INCLUDE (CheckSymbolExists)
 
+if(ANDROID)
+	set(ENV{PKG_CONFIG_DIR} "")
+	set(ENV{PKG_CONFIG_LIBDIR} "${CMAKE_SYSROOT}/usr/lib/pkgconfig:${CMAKE_SYSROOT}/usr/share/pkgconfig")
+	set(ENV{PKG_CONFIG_SYSROOT_DIR} ${CMAKE_SYSROOT})
+endif(ANDROID)
+
 ################################
 #  pkg-config based detection  #
 ################################

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                arguments '-DDISABLE_CXX=y', '-DUSE_PLUGINS=n', '-DBUILD_MAPTOOL=n', '-DXSL_PROCESSING=n', '-DSAMPLE_MAP=n'
+                arguments '-DDISABLE_CXX=y', '-DUSE_PLUGINS=n', '-DBUILD_MAPTOOL=n', '-DXSL_PROCESSING=n', '-DSAMPLE_MAP=n', '-DCMAKE_SYSROOT='+android.ndkDirectory+'/sysroot'
             }
         }
     }


### PR DESCRIPTION
As discussed with @jkoan on IRC, this fixes the build issues we had on F-Droid (see #1085).

The issues were caused by the toolchain trying to build against host libraries, which doesn’t work when cross-compiling, as is the case for Android. Oddly, this only happened on some build environments, not on others; we never quite figured out why. On those that worked, our bundled support libraries were used. These are essentially stripped-down versions of upstream libraries which aren’t getting a lot of maintenance—a kludge we’d rather avoid having to use and are hoping to get rid of one day.

This fix ensures the correct directories are passed to CMake and pkg-config. A test run of the F-Droid build (on the F-Droid CI setup) has passed.

The changes require NDK when running `sanity_check`, therefore I had to change the CI config to use the Android image for that step. As a side effect, the `navit/sanity_check` image might no longer be needed (at least the CI config does not use it any more).