### PR TITLE
Add:CI:Add job for F-Droid build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,40 @@ jobs:
           name: Update Navit-Download-Center
           command: |
             bash scripts/update_download_center.sh
+  build_fdroid:
+    docker:
+      - image: registry.gitlab.com/fdroid/ci-images-client:latest
+    steps:
+      - checkout
+      - run:
+          name: Build with F-Droid
+          command: |
+            test -d build || mkdir build
+            test -d fdroidserver || mkdir fdroidserver
+            git ls-remote https://gitlab.com/fdroid/fdroidserver.git master
+            curl --silent https://gitlab.com/fdroid/fdroidserver/repository/master/archive.tar.gz | tar -xz --directory=fdroidserver --strip-components=1
+            export PATH="`pwd`/fdroidserver:$PATH"
+            export PYTHONPATH="$CI_PROJECT_DIR/fdroidserver:$CI_PROJECT_DIR/fdroidserver/examples"
+            export PYTHONUNBUFFERED=true
+            bash fdroidserver/buildserver/setup-env-vars $ANDROID_HOME
+            adduser --disabled-password --gecos "" vagrant
+            ln -s $CI_PROJECT_DIR/fdroidserver /home/vagrant/fdroidserver
+            mkdir -p /vagrant/cache
+            wget -q https://services.gradle.org/distributions/gradle-5.6.2-bin.zip --output-document=/vagrant/cache/gradle-5.6.2-bin.zip
+            bash fdroidserver/buildserver/provision-gradle
+            bash fdroidserver/buildserver/provision-apt-get-install http://deb.debian.org/debian
+            source /etc/profile.d/bsenv.sh
+            apt-get dist-upgrade
+            apt-get install -t stretch-backports fdroidserver python3-asn1crypto python3-ruamel.yaml yamllint
+            apt-get purge fdroidserver
+            export GRADLE_USER_HOME=$PWD/.gradle
+            set -x
+            apt-get install sudo
+            fdroid build --verbose --on-server --no-tarball
+      - store_artifacts:
+           name: Store APK
+           path: unsigned
+           destination: apk
   build_win32:
     docker:
       - image: ubuntu:14.04
@@ -264,6 +298,9 @@ workflows:
           requires:
             - sanity_check
       - build_android:
+          requires:
+            - sanity_check
+      - build_fdroid:
           requires:
             - sanity_check
       - build_sailfish:

--- a/.fdroid.yml
+++ b/.fdroid.yml
@@ -1,0 +1,54 @@
+Categories:
+  - Navigation
+License: GPL-2.0-only
+WebSite: https://www.navit-project.org/
+SourceCode: https://github.com/navit-gps/navit
+IssueTracker: http://trac.navit-project.org
+Translation: https://translations.launchpad.net/navit/trunk/+pots/navit
+Changelog: https://github.com/navit-gps/navit/blob/HEAD/CHANGELOG.md#changelog
+
+AutoName: Navit
+Description: |-
+    Its modular design is capable of using vector maps of various formats for
+    routing and rendering of the displayed map. It’s even possible to use multiple
+    maps at a time. While Navit supports all major platforms, there is a fork
+    specializing on an easy-to-use, Android-only solution:
+    https://f-droid.org/packages/com.zoffcc.applications.zanavi.
+
+    The routing engine not only calculates an optimal route to your destination, but
+    also generates directions and even speaks to you.
+
+    Navit currently speaks 27 languages. You can help translating via the web-based
+    <a href="http://translations.launchpad.net/navit/trunk/+pots/navit">translation page</a>.
+
+RepoType: git
+Repo: https://github.com/navit-gps/navit
+
+Builds:
+  - versionName: generated_at_build_time
+    versionCode: 42
+    # since we generate version codes on the fly, we never know them at commit time
+    # therefore we use dummy values and skip the version check
+    novcheck: yes
+    commit: HEAD
+    gradle:
+      - yes
+    output: build/outputs/apk/release/navit-release.apk
+    rm:
+      - navit/support/espeak/espeak-data/*
+    prebuild:
+      - echo '<project name="Navit"><target name="clean"/></project>' > build.xml
+      # ndk is needed because of CI limitations and can be removed once the CI image comes with NDK 20
+      - $$SDK$$/tools/bin/sdkmanager "cmake;3.6.4111459" "ndk;20.0.5594570" > /dev/null
+      - sed -i -e '/gradlew/d' scripts/build_android.sh
+    build: scripts/build_android.sh
+    # disable for now because of CI limitations
+    #ndk: r20b
+
+MaintainerNotes: |-
+    Found JAR file at navit/android/libs/TTS_library_stub.jar, removed as of v0.5.3-442-g96d9c41.
+    NDK r12b is the minimum required as of v0.5.3, later versions may work but are untested.
+
+AutoUpdateMode: Version %v
+UpdateCheckMode: HTTP
+UpdateCheckData: https://download.navit-project.org/api/version.json|"version_code":.*"(.*)"|.|"version_name":.*\"(.*)\",


### PR DESCRIPTION
This adds a new CircleCI job which will build Navit in an F-Droid build environment.

The environment is identical to what F-Droid currently uses for CI. Some changes to the build recipe were necessary (see comments) as the CI image does not fully correspond to the live build server. Therefore, passing CI is no guarantee that this version will build on F-Droid (and vice versa), but it is as close as reasonably possible right now.

On the long run, we could consider dropping the Android build job and instead just signing the output of this job with our key and uploading it to Google Play. However, that is beyond the scope of the present PR.