### PR TITLE
Refactor:fdroid:Remove build.xml generation

### DIFF
--- a/.fdroid.yml
+++ b/.fdroid.yml
@@ -37,7 +37,6 @@ Builds:
     rm:
       - navit/support/espeak/espeak-data/*
     prebuild:
-      - echo '<project name="Navit"><target name="clean"/></project>' > build.xml
       # ndk is needed because of CI limitations and can be removed once the CI image comes with NDK 20
       - $$SDK$$/tools/bin/sdkmanager "cmake;3.6.4111459" "ndk;20.0.5594570" > /dev/null
       - sed -i -e '/gradlew/d' scripts/build_android.sh


### PR DESCRIPTION
Replicating a change requested by the F-Droid team, to keep our in-repo recipe in sync with the one on fdroiddata (as far as possible). Turns out build.xml is no longer needed, seems to be an ant leftover.