### PR TITLE
Make file picker compatible with Android 11

### DIFF
--- a/navit/android/src/org/navitproject/navit/Navit.java
+++ b/navit/android/src/org/navitproject/navit/Navit.java
@@ -733,7 +733,7 @@ public class Navit extends Activity {
                 if (resultCode == RESULT_OK) {
                     String newDir = data.getStringExtra(FileBrowserActivity.returnDirectoryParameter);
                     Log.d(TAG, "selected path= " + newDir);
-                    if (!newDir.contains("/navit")) {
+                    if (!(newDir.contains("/navit") || newDir.contains("/org.navitproject.navit"))) {
                         newDir = newDir + "/navit/";
                     } else {
                         newDir = newDir + "/";
@@ -779,7 +779,8 @@ public class Navit extends Activity {
     private void setMapLocation() {
         Intent fileExploreIntent = new Intent(this,FileBrowserActivity.class);
         fileExploreIntent
-            .putExtra(FileBrowserActivity.startDirectoryParameter, "/mnt")
+            .putExtra(FileBrowserActivity.startDirectoryParameter,
+                    getApplicationContext().getExternalFilesDir(null).toString())
             .setAction(FileBrowserActivity.INTENT_ACTION_SELECT_DIR);
         startActivityForResult(fileExploreIntent,NavitSelectStorage_id);
     }

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -78,6 +78,6 @@ echo Build
 ./gradlew assembleDebug || exit 128
 
 echo Build finished.
-echo APK should be in "navit/android/build/outputs/apk" and can be installed with
+echo APK should be in "build/outputs/apk" and can be installed with
 echo ./gradlew installDebug
 


### PR DESCRIPTION
As mentioned in #1117:

* Default location for file picker is Navit’s private shared storage dir (`/sdcard/Android/data/org.navitproject.navit/files`), which is not affected by restrictions introduced with Android 11
* When the selected path contains Navit’s package ID, it is applied as-is (rather than appending `/navit`) – this is the same behavior as for paths including `/navit`, the assumption being that we are already in a Navit-specific part of the filesystem