### PR TITLE
fix:maptool: filter out unknown multipolygons before processing

### DIFF
--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1656,6 +1656,12 @@ country_from_iso2(char *iso) {
     return country_from_countryid(country_id_from_iso2(iso));
 }
 
+static inline int filter_unknown(struct item_bin * ib) {
+    if(ignore_unknown && (ib->type==type_point_unkn || ib->type==type_street_unkn || ib->type==type_none))
+        return 1;
+    return 0;
+}
+
 static inline void osm_end_relation_multipolygon (struct maptool_osm * osm) {
     if((!g_strcmp0(relation_type, "multipolygon")) && (!boundary)) {
         int count;
@@ -1675,6 +1681,11 @@ static inline void osm_end_relation_multipolygon (struct maptool_osm * osm) {
             //fprintf(stderr, "relation id "OSMID_FMT": got %d types\n", osmid_attr_value, count);
             item_bin_add_attr_string(tmp_item_bin, attr_label, attr_strings[attr_string_label]);
             for(a=0; a < count ; a++) {
+                /*Don't write out multipolygons that will result in unknown types if -n is given.
+                 *So we don't process useless multipolygons. May save a lot of time.
+                 */
+                if(filter_unknown(tmp_item_bin))
+                    continue;
                 /* no need to clone the item in memory. We just write it out multiple times */
                 if(a==1) {
                     /*add duplicate tag if 2nd type. The tag stays for all subsequent writes */


### PR DESCRIPTION
This commit causes maptool to filter out multipolygon relations
whose tags result in unknown binfile type before processing them 
if -n is given on command line. May save a lot of processing time.