### PR TITLE
Fix:core: cancel drawing on resize request

### DIFF
--- a/navit/graphics/qt5/QNavitQuick.cpp
+++ b/navit/graphics/qt5/QNavitQuick.cpp
@@ -181,12 +181,7 @@ void QNavitQuick::geometryChanged(const QRectF& newGeometry, const QRectF& oldGe
     if (graphics_priv->pixmap == NULL) {
         graphics_priv->pixmap = new QPixmap(width(), height());
     }
-    painter = new QPainter(graphics_priv->pixmap);
-    if (painter != NULL) {
-        QBrush brush;
-        painter->fillRect(0, 0, width(), height(), brush);
-        delete painter;
-    }
+    graphics_priv->pixmap->fill(Qt::transparent);
     dbg(lvl_debug, "size %fx%f", width(), height());
     dbg(lvl_debug, "pixmap %p %dx%d", graphics_priv->pixmap, graphics_priv->pixmap->width(),
         graphics_priv->pixmap->height());

--- a/navit/graphics/qt5/QNavitWidget.cpp
+++ b/navit/graphics/qt5/QNavitWidget.cpp
@@ -105,12 +105,7 @@ void QNavitWidget::resizeEvent(QResizeEvent* event) {
     if (graphics_priv->pixmap == NULL) {
         graphics_priv->pixmap = new QPixmap(size());
     }
-    painter = new QPainter(graphics_priv->pixmap);
-    if (painter != NULL) {
-        QBrush brush;
-        painter->fillRect(0, 0, width(), height(), brush);
-        delete painter;
-    }
+    graphics_priv->pixmap->fill(Qt::transparent);
     dbg(lvl_debug, "size %dx%d", width(), height());
     dbg(lvl_debug, "pixmap %p %dx%d", graphics_priv->pixmap, graphics_priv->pixmap->width(),
         graphics_priv->pixmap->height());

--- a/navit/navit.c
+++ b/navit/navit.c
@@ -490,8 +490,12 @@ void navit_handle_resize(struct navit *this_, int w, int h) {
     graphics_set_rect(this_->gra, &sel.u.p_rect);
     if (callback)
         callback_list_call_attr_1(this_->attr_cbl, attr_graphics_ready, this_);
-    if (this_->ready == 3)
+    if (this_->ready == 3) {
+        /* About to resize. Cancel drawing whatever it is */
+        graphics_draw_cancel(this_->gra, this_->displaylist);
+        /* draw again even if we did not cancel anything */
         navit_draw_async(this_, 1);
+    }
 }
 
 static void navit_resize(void *data, int w, int h) {


### PR DESCRIPTION
This commit causes navit to cancel async drawing in case of resize
request. Drawing is started again after that. this should effectively
cause a redraw on subsequent calls to resize. Some graphics like qt5
call resize for both dimension changes if the widget gets resized.