### PR TITLE
FIX:maptool: remove assertion from item_bin_copy_attr

### DIFF
--- a/navit/maptool/itembin.c
+++ b/navit/maptool/itembin.c
@@ -85,13 +85,10 @@ void item_bin_copy_coord(struct item_bin *ib, struct item_bin *from, int dir) {
     for (i = 1 ; i <= count ; i++)
         item_bin_add_coord(ib, &c[count-i], 1);
 }
-
 void item_bin_copy_attr(struct item_bin *ib, struct item_bin *from, enum attr_type attr) {
     struct attr_bin *ab=item_bin_get_attr_bin(from, attr, NULL);
     if (ab)
         item_bin_add_attr_data(ib, ab->type, (void *)(ab+1), (ab->len-1)*4);
-    assert(attr == attr_osm_wayid);
-    assert(item_bin_get_wayid(ib) == item_bin_get_wayid(from));
 }
 
 void item_bin_add_coord_rect(struct item_bin *ib, struct rect *r) {


### PR DESCRIPTION
The removed assertion disallowed the use of item_bin_copy_attr for
anything else than attr_osm_wayid when debug build was enabled. This
used to work prior the introduction of multipolygon support. There
item_bin_copy_attr is used to copy all kinds of attrs not knowing about
the assert.
So remove the assert as it seems to have been never correct.

Fixes #1147 