### PR TITLE
Unique icon for POI dialog

### DIFF
--- a/navit/gui/gtk/gui_gtk_action.c
+++ b/navit/gui/gtk/gui_gtk_action.c
@@ -212,7 +212,7 @@ static GtkActionEntry entries[] = {
     { "InfoAction", NULL, _n("_Info"), NULL, NULL, G_CALLBACK(info_action) },
 #endif /*GTK_STOCK_INFO*/
     { "DestinationAction", "flag_icon", _n("Set _destination"), "<control>D", _n("Opens address search dialog"), G_CALLBACK(destination_action) },
-    { "POIAction", "flag_icon", _n("_POI search"), "<control>P", _n("Opens POI search dialog"), G_CALLBACK(poi_search_action) },
+    { "POIAction", GTK_STOCK_INFO, _n("_POI search"), "<control>P", _n("Opens POI search dialog"), G_CALLBACK(poi_search_action) },
     { "RouteClearAction", NULL, _n("_Stop Navigation"), "<control>S", NULL, G_CALLBACK(route_clear_action) },
     { "Test", NULL, _n("Test"), NULL, NULL, G_CALLBACK(destination_action) },
     { "QuitAction", GTK_STOCK_QUIT, _n("_Quit"), "<control>Q",_n("Quit the application"), G_CALLBACK (quit_action) }
@@ -328,7 +328,6 @@ static const char * flag_xpm[] = {
     "+                     ",
     "+                     "
 };
-
 
 
 static struct {


### PR DESCRIPTION
GTK gui uses the same icon for destination and poi dialog. 
Use GTK_STOCK_INFO icon for poi dialog.
![poiicon](https://user-images.githubusercontent.com/5459286/133917082-7d959d70-b231-4436-a5dd-e5c5aafb406a.png)

