### PR TITLE
Fix:graphics_qt5: allow building without qml again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,9 +386,11 @@ if (Qt5Widgets_FOUND OR Qt5Quick_FOUND)
 		set_with_reason(USE_QML "Qt5Quick found" TRUE)
 		if(USE_QML)
 			set(Qt5_ADDITIONAL_LIBRARIES ${Qt5_ADDITIONAL_LIBRARIES} ${Qt5Quick_LIBRARIES})
+			set_with_reason(gui/qt5_qml "Qt5 found" TRUE
+				${Qt5Quick_LIBRARIES})
+		else()
+			set_with_reason(gui/qt5_qml "feature USE_QML disabled for graphics/qt5" FALSE)
 		endif()
-		set_with_reason(gui/qt5_qml "Qt5 found" TRUE
-			${Qt5Quick_LIBRARIES})
 
 	endif()
 	set_with_reason(graphics/qt5 "Qt5 found" TRUE

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -753,10 +753,12 @@ static void* get_data(struct graphics_priv* this_priv, char const* type) {
         resize_callback(this_priv, this_priv->pixmap->width(), this_priv->pixmap->height());
         return win;
     }
+#if USE_QML
     if (strcmp(type, "engine") == 0) {
         dbg(lvl_debug, "Hand over QQmlApplicationEngine");
         return (this_priv->engine);
     }
+#endif
     return NULL;
 }
 


### PR DESCRIPTION
As building qithout QML is rarely done, a ifdefing mistake was made in graphics qt5. This change requests fixes this.
Additionally gui_qt5_qml is disabled when QML support is disabled on graphics_qt5 as this is mandatory.
