### PR TITLE
fix:sailfish: enable sandboxing for sailfish OS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,6 @@ jobs:
       - checkout
       - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
-          name: install docker
-          command: circleci-install docker
-      - run:
           name: make build dir
           command:  mkdir ../rpmbuild
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ set(TEXTURE_DIR share/navit/textures CACHE PATH "Navit texture path")
 add_definitions ("-DTEXTURE_DIR=\"${TEXTURE_DIR}\"")
 set(MAN_DIR share/man/man1 CACHE PATH "Navit man path")
 add_definitions ("-DMAN_DIR=\"${MAN_DIR}\"")
+set(HOMECONFIG_DIR .navit CACHE PATH "Navit config path in home dir")
+add_definitions ("-DHOMECONFIG_DIR=\"${HOMECONFIG_DIR}\"")
 # LIB_DIR
 IF(UNIX AND NOT ANDROID AND NOT APPLE)
 	IF (NOT LIBDIR)

--- a/contrib/sailfish/navit-sailfish.spec
+++ b/contrib/sailfish/navit-sailfish.spec
@@ -83,6 +83,7 @@ cmake  -DCMAKE_INSTALL_PREFIX:PATH=/usr \
        -DLOCALE_DIR:PATH=share/harbour-navit/locale \
        -DIMAGE_DIR:PATH=share/harbour-navit/icons \
        -DTEXTURE_DIR:PATH=share/harbour-navit/textures \
+       -DHOMECONFIG_DIR:PATH=.config/org.navitproject/navit \
        -DLIB_DIR:PATH=share/harbour-navit/lib \
        -DBUILD_MAPTOOL:BOOL=FALSE \
        -Dfont/freetype:BOOL=FALSE \
@@ -138,6 +139,11 @@ fi
 
 
 %changelog
+*Thu May 19 2022 metalstrolch 0.5.6-0
+- Enable sailjail
+- local config dir in $HOME changed to ~/.config/org.naviproject/navit
+- default map location now /home/nemo/Documents/map.navit.bin due to sailjail
+
 *Mon Oct 01 2018 metalstrolch 0.5.3-1
 - fix rpm updating from 0.5.1 by adding %pre section
 

--- a/contrib/sailfish/navit-sailfish.spec
+++ b/contrib/sailfish/navit-sailfish.spec
@@ -10,7 +10,7 @@ Name: harbour-navit
 Summary: Open Source car navigation system
 #Version: %{navit_version}_%{git_version}
 Version: 0.5.6
-Release: 1
+Release: 2
 License: GPL
 Group: Applications/Productivity
 URL: http://navit-project.org/
@@ -139,7 +139,7 @@ fi
 
 
 %changelog
-*Thu May 19 2022 metalstrolch 0.5.6-0
+*Thu May 19 2022 metalstrolch 0.5.6-2
 - Enable sailjail
 - local config dir in $HOME changed to ~/.config/org.naviproject/navit
 - default map location now /home/nemo/Documents/map.navit.bin due to sailjail

--- a/navit/graphics/qt5/graphics_qt5.cpp
+++ b/navit/graphics/qt5/graphics_qt5.cpp
@@ -1018,6 +1018,8 @@ static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics
 #else
     navit_app = new QGuiApplication(graphics_priv->argc, graphics_priv->argv);
 #endif
+    navit_app->setOrganizationName(QStringLiteral("org.navitproject"));
+    navit_app->setApplicationName(QStringLiteral("navit"));
 
 #if HAVE_FREETYPE
     graphics_priv->font_freetype_new = font_freetype_new;
@@ -1044,7 +1046,7 @@ static struct graphics_priv* graphics_qt5_new(struct navit* nav, struct graphics
     graphics_priv->GPriv = NULL;
     if (use_qml) {
         /* register our QtQuick widget to allow it's usage within QML */
-        qmlRegisterType<QNavitQuick>("com.navit.graphics_qt5", 1, 0, "QNavitQuick");
+        qmlRegisterType<QNavitQuick>("org.navitproject.graphics_qt5", 1, 0, "QNavitQuick");
         /* get our qml application from embedded resources. May be replaced by the
              * QtQuick gui component if enabled */
         graphics_priv->engine = new QQmlApplicationEngine();

--- a/navit/graphics/qt5/graphics_qt5.qml
+++ b/navit/graphics/qt5/graphics_qt5.qml
@@ -1,4 +1,4 @@
-import com.navit.graphics_qt5 1.0
+import org.navitproject.graphics_qt5 1.0
 import QtQuick 2.2
 import QtQuick.Window 2.0
 

--- a/navit/graphics/qt5/loader.qml
+++ b/navit/graphics/qt5/loader.qml
@@ -1,4 +1,4 @@
-import com.navit.graphics_qt5 1.0
+import org.navitproject.graphics_qt5 1.0
 import QtQuick 2.2
 import QtQuick.Window 2.0
 

--- a/navit/gui/qt5_qml/skins/modern/bookmark.qml
+++ b/navit/gui/qt5_qml/skins/modern/bookmark.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.0
-import com.navit.graphics_qt5 1.0
+import org.navitproject.graphics_qt5 1.0
 
 
 Item {

--- a/navit/gui/qt5_qml/skins/modern/main.qml
+++ b/navit/gui/qt5_qml/skins/modern/main.qml
@@ -1,4 +1,4 @@
-import com.navit.graphics_qt5 1.0
+import org.navitproject.graphics_qt5 1.0
 import QtQuick 2.2
 
 Rectangle {

--- a/navit/gui/qt5_qml/skins/modern/poi.qml
+++ b/navit/gui/qt5_qml/skins/modern/poi.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.0
-import com.navit.graphics_qt5 1.0
+import org.navitproject.graphics_qt5 1.0
 
 
 Item {

--- a/navit/icons/desktop_icons/navit.desktop.in
+++ b/navit/icons/desktop_icons/navit.desktop.in
@@ -16,3 +16,8 @@ Categories=GTK;Utility;Geography;
 GenericName=Navit
 GenericName[de]=Navit
 X-Nemo-Application-Type=no-invoker
+#sailfish jail. Doesn't hurt others hopefully
+[X-Sailjail]
+Permissions=Documents;Location;RemovableMedia
+OrganizationName=org.navitproject
+ApplicationName=navit

--- a/navit/main.c
+++ b/navit/main.c
@@ -93,7 +93,7 @@ static char *environment_vars[][6]= {
     {"NAVIT_LIBDIR",      ":",          ":/"LIB_DIR,     ":\\lib",      ":/lib",        ":\\lib"},
     {"NAVIT_SHAREDIR",    ":",          ":/"SHARE_DIR,   ":",           ":/share",      ":"},
     {"NAVIT_LOCALEDIR",   ":/../locale",":/"LOCALE_DIR,  ":\\locale",   ":/locale",     ":\\locale"},
-    {"NAVIT_USER_DATADIR",":",          "~/.navit",      ":\\data",     ":/home",       "~\\navit"},
+    {"NAVIT_USER_DATADIR",":",          "~/"HOMECONFIG_DIR,      ":\\data",     ":/home",       "~\\navit"},
     {"NAVIT_LOGFILE",     NULL,         NULL,            ":\\navit.log",NULL,           ":\\navit.log"},
     {"NAVIT_LIBPREFIX",   "*/.libs/",   NULL,            NULL,          NULL,           NULL},
     {NULL,                NULL,         NULL,            NULL,          NULL,           NULL},

--- a/navit/navit.c
+++ b/navit/navit.c
@@ -377,7 +377,7 @@ char* navit_get_user_data_directory(int create) {
     dir = getenv("NAVIT_USER_DATADIR");
     if (create && !file_exists(dir)) {
         dbg(lvl_debug,"creating dir %s", dir);
-        if (file_mkdir(dir,0)) {
+        if (file_mkdir(dir,1)) {
             dbg(lvl_error,"failed creating dir %s", dir);
             return NULL;
         }

--- a/navit/xslt/sailfish_mapset.xslt
+++ b/navit/xslt/sailfish_mapset.xslt
@@ -17,9 +17,9 @@
          <xsl:text>&#x0A; 			</xsl:text>
 			<map type="binfile" enabled="yes" active="no" data="/usr/share/harbour-navit/maps/osm_bbox_11.3,47.9,11.7,48.2.bin"/>
          <xsl:text>&#x0A; 			</xsl:text>
-			<map type="binfile" enabled="yes" data="~/Maps/map.navit.bin"/>
+			<map type="binfile" enabled="yes" data="~/Documents/map.navit.bin"/>
          <xsl:text>&#x0A; 			</xsl:text>
-			<map type="binfile" enabled="yes" active="no" name="map.navit.heightlines.bin" data="~/Maps/map.navit.heightlines.bin"/>
+			<map type="binfile" enabled="yes" active="no" name="map.navit.heightlines.bin" data="~/Documents/map.navit.heightlines.bin"/>
          <xsl:text>&#x0A; 		</xsl:text>
 		</mapset>
       <xsl:text>&#x0A; 		</xsl:text>


### PR DESCRIPTION
This pull request adds proper sandboxing support for recent Sailfish OS releases featuring sandboxing. In order to do this some changes need to be done:
- use proper object path for Qt5 components (org.navitproject.navit)
- allow the ~/.navit location to be changed on build time. HOMECONFIG_DIR variable added to build. Sailfish requires ~/.config/org.navitproject/navit 
- create user config path with sub directories if not existing.
- add Sailfish sandbox config to .desktop file
- Change sailfish default config to have maps in ~/Documents instead of ~/Maps as the latter won't exist in sandbox.