### PR TITLE
fix:ci: update sailfish os SDK version to 3.4.0.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,10 +65,10 @@ jobs:
       - run: if scripts/check_need_build.sh; then circleci step halt; fi
       - run:
           name: make build dir
-          command:  mkdir ../rpmbuild
+          command:  mkdir ../rpmbuild && chmod 777 ../rpmbuild
       - run:
           name: run build
-          command: ls -lah ../rpmbuild && docker run -e VERSION_ID=3.1.0.12 -v `pwd`/../rpmbuild:/home/nemo/rpmbuild:rw -v `pwd`:/home/nemo/navit hoehnp/sailfishos-platform-sdk:3.1.0.12 /bin/bash -x /home/nemo/navit/contrib/sailfish/build_sailfish_ci.sh
+          command: ls -lah ../rpmbuild && docker run -e VERSION_ID=3.4.0.24 -v `pwd`/../rpmbuild:/home/nemo/rpmbuild:rw -v `pwd`:/home/nemo/navit coderus/sailfishos-platform-sdk:3.4.0.24 /bin/bash -x /home/nemo/navit/contrib/sailfish/build_sailfish_ci.sh
       - store_artifacts:
           name: Store rpm
           path: ../rpmbuild/RPMS/

--- a/contrib/sailfish/build_sailfish_ci.sh
+++ b/contrib/sailfish/build_sailfish_ci.sh
@@ -19,4 +19,7 @@ sb2 -t SailfishOS-${VERSION_ID}-armv7hl -m sdk-build rpmbuild --define "_topdir 
 #intel devices
 #sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-install -R zypper --non-interactive in $(grep "^BuildRequires: " navit-sailfish.spec | sed -e "s/BuildRequires: //")
 #sb2 -t SailfishOS-${VERSION_ID}-i486 -m sdk-build rpmbuild --define "_topdir /home/nemo/rpmbuild" --define "navit_source ${SCRIPTPATH}/../.." -bb navit-sailfish.spec
+#64 bit devices
+sb2 -t SailfishOS-${VERSION_ID}-aarch64 -m sdk-install -R zypper --non-interactive in $(grep "^BuildRequires: " navit-sailfish.spec | sed -e "s/BuildRequires: //")
+sb2 -t SailfishOS-${VERSION_ID}-aarch64 -m sdk-build rpmbuild --define "_topdir /home/nemo/rpmbuild" --define "navit_source ${SCRIPTPATH}/../.." -bb navit-sailfish.spec
 


### PR DESCRIPTION
Sailfish SDK 3.4.0.24 is the newest version known to run on
Jolla1 devices therefore this version is chosen. As it allows
to build aarch64 binaries as well building those is enabled
on ci. SDK images are fetched from coderus, thanks for providing.

Images are known to be good on Jolla1(3.4.0.24) and Xperia XA2
(4.4.0.64, latest as of writing). Aarch64 rpm is completely untested.
