### PR TITLE
Fix linux_development.rst

### DIFF
--- a/docs/development/linux_development.rst
+++ b/docs/development/linux_development.rst
@@ -92,7 +92,7 @@ For Raspberry Pi OS:
 
     sudo apt-get install cmake zlib1g-dev libpng-dev libgtk2.0-dev librsvg2-bin \
                          g++ gpsd gpsd-clients libgps-dev libdbus-glib-1-dev freeglut3-dev libxft-dev \
-                         libglib2.0-dev libfreeimage-dev gettext protobuf-c-compiler  libprotobuf-c-dev
+                         libglib2.0-dev libfreeimage-dev gettext protobuf-c-compiler libprotobuf-c-dev libspeechd-dev
 
 
 Fedora dependencies


### PR DESCRIPTION
Added missing dependency libspeechd-dev for Raspberry Pi OS.
