### PR TITLE
Fix:vehicle/android:Never use fused provider for precise location

### DIFF
--- a/navit/android/src/org/navitproject/navit/NavitVehicle.java
+++ b/navit/android/src/org/navitproject/navit/NavitVehicle.java
@@ -34,6 +34,7 @@ import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
+import java.util.HashSet;
 import java.util.List;
 
 
@@ -163,10 +164,78 @@ public class NavitVehicle {
 
         Log.d("NavitVehicle", "Providers " + sLocationManager.getAllProviders());
 
-        String mPreciseProvider = sLocationManager.getBestProvider(highCriteria, false);
+        HashSet<String> preciseProviders;
+        try {
+            preciseProviders = new HashSet<String>(sLocationManager.getProviders(highCriteria, false));
+        } catch (NullPointerException e) {
+            preciseProviders = new HashSet<String>();
+        }
+        HashSet<String> fastProviders;
+        try {
+            fastProviders = new HashSet<String>(sLocationManager.getProviders(lowCriteria, false));
+        } catch (NullPointerException e) {
+            fastProviders = new HashSet<String>();
+        }
+        /*
+         * Never use the passive and fused providers for the precise providers.
+         * These merge data from multiple sources, which can lead to your location skipping back and
+         * forth between two places. While that may be acceptable for the fast provider (just to get a
+         * first location), it may render navigation unusable if such a provider were to be used as the
+         * precise provider.
+         */
+        preciseProviders.remove(LocationManager.PASSIVE_PROVIDER);
+        preciseProviders.remove("fused");
+
+        /*
+         * Some magic to pick the precise provider:
+         * If Android’s best chosen provider is on our list, use that.
+         * Otherwise, if the list has only one candidate, use that.
+         * Otherwise, prefer GPS for the precise provider, if available.
+         * Otherwise, just pick a random provider from the list.
+         */
+        Log.d("NavitVehicle", "Precise Provider candidates " + preciseProviders);
+        String mPreciseProvider = null;
+        if (preciseProviders.contains(sLocationManager.getBestProvider(highCriteria, false)))
+            mPreciseProvider = sLocationManager.getBestProvider(highCriteria, false);
+        else if (preciseProviders.size() == 1)
+            for (String provider : preciseProviders)
+                mPreciseProvider = provider;
+        else if (preciseProviders.contains(LocationManager.GPS_PROVIDER))
+            mPreciseProvider = LocationManager.GPS_PROVIDER;
+        else
+            /*
+             * Multiple providers, but no GPS, nor any fused/passive providers, and we can’t use the
+             * best provider suggested by the OS.
+             * If we ever get here, we’re on a very exotic device.
+             * This may need some more tweaks – right now, we just pick one at random.
+             */
+            for (String provider : preciseProviders) {
+                mPreciseProvider = provider;
+                break;
+            }
         Log.d("NavitVehicle", "Precise Provider " + mPreciseProvider);
-        mFastProvider = sLocationManager.getBestProvider(lowCriteria, false);
+
+        /*
+         * Similar magic to pick the fast provider:
+         * Eliminate the precise provider from our list so we get to use two providers.
+         * If Android’s best chosen provider is on our list, use that.
+         * Otherwise, if the list has only one candidate, use that.
+         * Otherwise, just pick a random provider from the list.
+         */
+        fastProviders.remove(mPreciseProvider);
+        Log.d("NavitVehicle", "Fast Provider candidates " + fastProviders);
+        if (fastProviders.contains(sLocationManager.getBestProvider(lowCriteria, false)))
+            mFastProvider = sLocationManager.getBestProvider(lowCriteria, false);
+        else if (fastProviders.size() == 1)
+            for (String provider: fastProviders)
+                mFastProvider = provider;
+        else
+            for (String provider: fastProviders) {
+                mFastProvider = provider;
+                break;
+            }
         Log.d("NavitVehicle", "Fast Provider " + mFastProvider);
+
         mVehiclePcbid = pcbid;
         mVehicleScbid = scbid;
         mVehicleFcbid = fcbid;


### PR DESCRIPTION
Android’s fused location provider aggregates locations from multiple providers, typically network and gps.

The AOSP version seems to indiscriminately pipe through any location updates it gets from the backend providers, with no verification or filtering.

When your references are a precise GPS signal and a network location based on a cell tower, with several hundred meters of error, this may cause your position to jump wildly between two places and navigation will become unusable. Such behavior would be OK for the ”fast” provider (which establishes your initial position and gets disabled as soon as the first location from the precise provider is received), but not for the precise provider (which would normally be used for navigation).

Unfortunately, Android seems to prefer the fused location provider over any others when selecting the best location provider based on criteria, and there don’t seem to be any criteria that would effectively deselect the fused provider. That makes Navit basically useless on my new phone.

This PR modifies the way Navit selects its location providers:

* The fused provider (also the passive one, which acts in a similar manner) is never used as the precise provider.
* If Android suggests a provider other than these, based on criteria, we will stick with Android’s suggestion.
* Otherwise, we examine the list of all eligible providers (based on criteria, but eliminating fused and passive):
  * If there is only one provider, we use that.
  * If there are multiple providers and one of them is GPS, we use GPS.
  * Otherwise, we pick a provider at random (should only happen on some very exotic devices – we’re talking about a device which has no GPS, but two high-precision location sources to choose from).
* The fast provider must differ from the precise provider (selecting the second-best fast provider is better than selecting the precise provider twice)
* If Android suggests one that matches our requirements, we use that. (This would likely be the fused provider, if available, or the network provider otherwise.)
* Otherwise, we examine the list of eligible providers (based on criteria, but eliminating the precise provider):
  * If there is only one provider, we use that.
  * Otherwise, we pick a provider at random.

Tests indicate that this will fix the problem. On my new device, Navit now again uses GPS for precise location and fused for fast location.