### PR TITLE
Fix:ci:use F-Droid server version compatible with OS image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
             test -d build || mkdir build
             test -d fdroidserver || mkdir fdroidserver
             git ls-remote https://gitlab.com/fdroid/fdroidserver.git master
-            curl --silent https://gitlab.com/fdroid/fdroidserver/-/archive/master/fdroidserver-master.tar.gz | tar -xz --directory=fdroidserver --strip-components=1
+            curl --silent https://gitlab.com/fdroid/fdroidserver/-/archive/7accb96b/fdroidserver-7accb96b.tar.gz | tar -xz --directory=fdroidserver --strip-components=1
             export PATH="`pwd`/fdroidserver:$PATH"
             export PYTHONPATH="$CI_PROJECT_DIR/fdroidserver:$CI_PROJECT_DIR/fdroidserver/examples"
             export PYTHONUNBUFFERED=true


### PR DESCRIPTION
See #1203. This reverts to an earlier version of F-Droid server, compatible with the Debian version on the CI image.