### PR TITLE
Add:gui/internal: Allowing comma-separated geo coordinates

### DIFF
--- a/navit/gui/internal/gui_internal.c
+++ b/navit/gui/internal/gui_internal.c
@@ -2402,10 +2402,19 @@ static void gui_internal_cmd_enter_coord_do(struct gui_priv *this, struct widget
     /* possible entry can be identical to coord_format output but only space between lat and lng is allowed */
     widgettext=g_ascii_strup(widget->text,-1);
 
-    lat=strtok(widgettext," ");
-    lng=strtok(NULL,"");
+    lat = NULL;
+    lng=strchr(widgettext, ' ');
+    if (lng == NULL) { /* If no space is found in string, try comma-separated coordinates */
+        lng=strchr(widgettext, ',');
+    }
+    if (lng) {
+        lat = widgettext;
+        *lng = '\0';
+        lng++;
+    }
 
     if(!lat || !lng) {
+        dbg(lvl_warning,"Could not parse coord \"%s\", ignoring", widget->text);
         g_free(widgettext);
         return;
     }

--- a/navit/gui/internal/gui_internal_command.c
+++ b/navit/gui/internal/gui_internal_command.c
@@ -176,6 +176,8 @@ static int gui_internal_cmd_enter_coord(struct gui_priv *this, char *function, s
     gui_internal_widget_append(wr,row);
     row=gui_internal_text_new(this, "52°31'19N 19°24'46E", gravity_top_center|flags_fill|orientation_vertical);
     gui_internal_widget_append(wr,row);
+    row=gui_internal_text_new(this, "52.5219,19.4127", gravity_top_center|flags_fill|orientation_vertical);
+    gui_internal_widget_append(wr,row);
 
     if (this->keyboard)
         gui_internal_widget_append(w, gui_internal_keyboard(this, VKBD_DEGREE));


### PR DESCRIPTION
This PR extends the geo coordinates format accepted by the internal GUI.
A new valid format is accepted like 52.5219,19.4127 (decimal latitude and longitude separated by a comma character, without any space).
![image](https://user-images.githubusercontent.com/383502/208945631-401caaf9-afbe-4a2b-820f-f7ffc7bccbc8.png)

This allows inputting locations like they are displayed within Google maps:
![image](https://user-images.githubusercontent.com/383502/208946329-b7ab58c9-0ce8-4944-b397-4be17a58a29e.png)
