### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/navit/script/osm/border_follower.pl
+++ b/navit/script/osm/border_follower.pl
@@ -19,7 +19,7 @@ $required_admin_level=$ARGV[2];
 $type=$ARGV[3];
 $alt_type=$ARGV[4];
 $revers=0;
-$api=new Geo::OSM::APIClient(api=>'http://www.openstreetmap.org/api/0.5');
+$api=new Geo::OSM::APIClient(api=>'https://api.openstreetmap.org/api/0.5');
 $wayid=$first_wayid;
 $path="$first_wayid";
 sub error
@@ -33,7 +33,7 @@ sub error
 	$lath=$node->{lat}+0.01;
 	$lonl=$node->{lon}-0.01;
 	$lonh=$node->{lon}+0.01;
-	system("firefox 'http://www.informationfreeway.org/?lat=$lat&lon=$lon&zoom=12&layers=B000F000F' ; wget -O error.osm http://www.openstreetmap.org/api/0.5/map?bbox=$lonl,$latl,$lonh,$lath ; josm error.osm --selection=id:$last");
+	system("firefox 'http://www.informationfreeway.org/?lat=$lat&lon=$lon&zoom=12&layers=B000F000F' ; wget -O error.osm https://api.openstreetmap.org/api/0.5/map?bbox=$lonl,$latl,$lonh,$lath ; josm error.osm --selection=id:$last");
 	exit(1);
 }
 

--- a/navit/script/osm/osmtool.pl
+++ b/navit/script/osm/osmtool.pl
@@ -138,5 +138,5 @@ while (substr($ARGV[0],0,2) eq '--') {
 	$attr{$key}=$value;
 	shift;
 }
-$api=new Geo::OSM::APIClient(api=>'http://www.openstreetmap.org/api/0.6',%attr);
+$api=new Geo::OSM::APIClient(api=>'https://api.openstreetmap.org/api/0.6',%attr);
 command(@ARGV);


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

You will likely need to update code parameter `APIClientV5` and related file/package, and url parameter `0.5` => `0.6`, if in-use.

(Also, sorry for default 'updated file ...' commit message.)

cc: @OLFDB 