### PR TITLE
maptool: Enable Town Search when processing map regions by hard-coding the country

### DIFF
--- a/navit/maptool/boundaries.c
+++ b/navit/maptool/boundaries.c
@@ -85,13 +85,6 @@ static GList *process_boundaries_setup(FILE *boundaries, struct relations *relat
                 if (!g_strcmp0(int_name, "France"))
                     iso = "FR";
             }
-            if (!boundary->country) {
-                char *ags = osm_tag_value(ib, "de:amtlicher_gemeindeschluessel");
-                char *rs  = osm_tag_value(ib, "de:regionalschluessel");
-                if (ags || rs) {
-                    boundary->country = country_from_iso2("DE");
-                }
-            }
             if (iso) {
                 struct country_table *country = country_from_iso2(iso);
                 if (!country)
@@ -106,6 +99,14 @@ static GList *process_boundaries_setup(FILE *boundaries, struct relations *relat
                 osm_warning("relation", item_bin_get_relationid(ib), 0,
                             "Country Boundary doesn't contain an ISO3166-1 tag\n");
         }
+        if (!boundary->country) {
+            char *ags = osm_tag_value(ib, "de:amtlicher_gemeindeschluessel");
+            char *rs  = osm_tag_value(ib, "de:regionalschluessel");
+            if (ags || rs) {
+                boundary->country = country_from_iso2("DE");
+            }
+        }
+
         while ((member = item_bin_get_attr(ib, attr_osm_member, member))) {
             long long osm_id;
             int read = 0;

--- a/navit/maptool/boundaries.c
+++ b/navit/maptool/boundaries.c
@@ -60,6 +60,18 @@ static void process_boundaries_member(void *func_priv, void *relation_priv, stru
         b->segments = g_list_prepend(b->segments, item_bin_to_poly_segment(member, role));
 }
 
+/* Propagate country from parent to children that don't have one set */
+static void boundary_propagate_country(GList *boundaries, struct country_table *parent_country) {
+    while (boundaries) {
+        struct boundary *b = boundaries->data;
+        if (!b->country && parent_country) {
+            b->country = parent_country;
+        }
+        boundary_propagate_country(b->children, b->country);
+        boundaries = g_list_next(boundaries);
+    }
+}
+
 static GList *process_boundaries_setup(FILE *boundaries, struct relations *relations) {
     struct item_bin *ib;
     GList *boundaries_list = NULL;
@@ -311,7 +323,9 @@ GList *process_boundaries(FILE *boundaries, FILE *ways) {
     boundaries_list = process_boundaries_setup(boundaries, relations);
     relations_process(relations, NULL, ways);
     relations_destroy(relations);
-    return process_boundaries_finish(boundaries_list);
+    boundaries_list = process_boundaries_finish(boundaries_list);
+    boundary_propagate_country(boundaries_list, NULL);
+    return boundaries_list;
 }
 
 void free_boundaries(GList *bl) {

--- a/navit/maptool/boundaries.c
+++ b/navit/maptool/boundaries.c
@@ -64,10 +64,13 @@ static void process_boundaries_member(void *func_priv, void *relation_priv, stru
 static void boundary_propagate_country(GList *boundaries, struct country_table *parent_country) {
     while (boundaries) {
         struct boundary *b = boundaries->data;
-        if (!b->country && parent_country) {
+        /* Don't assign country to postal_code boundaries - they are not administrative
+         * units and must not appear as country matches for town assignment */
+        char *boundary_type = osm_tag_value(b->ib, "boundary");
+        int is_postal = !g_strcmp0(boundary_type, "postal_code");
+        if (!b->country && parent_country && !is_postal)
             b->country = parent_country;
-        }
-        boundary_propagate_country(b->children, b->country);
+        boundary_propagate_country(b->children, is_postal ? NULL : b->country);
         boundaries = g_list_next(boundaries);
     }
 }
@@ -110,6 +113,11 @@ static GList *process_boundaries_setup(FILE *boundaries, struct relations *relat
             } else
                 osm_warning("relation", item_bin_get_relationid(ib), 0,
                             "Country Boundary doesn't contain an ISO3166-1 tag\n");
+        }
+        if (!boundary->country) {
+            char *iso2 = osm_tag_value(ib, "ISO3166-2");
+            if (iso2 && !strncmp(iso2, "DE-", 3))
+                boundary->country = country_from_iso2("DE");
         }
         if (!boundary->country) {
             char *ags = osm_tag_value(ib, "de:amtlicher_gemeindeschluessel");

--- a/navit/maptool/boundaries.c
+++ b/navit/maptool/boundaries.c
@@ -85,6 +85,13 @@ static GList *process_boundaries_setup(FILE *boundaries, struct relations *relat
                 if (!g_strcmp0(int_name, "France"))
                     iso = "FR";
             }
+            if (!boundary->country) {
+                char *ags = osm_tag_value(ib, "de:amtlicher_gemeindeschluessel");
+                char *rs  = osm_tag_value(ib, "de:regionalschluessel");
+                if (ags || rs) {
+                    boundary->country = country_from_iso2("DE");
+                }
+            }
             if (iso) {
                 struct country_table *country = country_from_iso2(iso);
                 if (!country)

--- a/navit/maptool/maptool.c
+++ b/navit/maptool/maptool.c
@@ -53,6 +53,7 @@ GHashTable *dedupe_ways_hash;
 int phase;
 int slices;
 int unknown_country;
+char *hardcoded_country;
 char ch_suffix[] = "r"; /* Used to make compiler happy due to Bug 35903 in gcc */
 /** Textual description of available experimental features, or NULL (=none available). */
 char *experimental_feature_description = "Move coastline data to order 6 tiles. Makes map look more smooth, but may "
@@ -305,6 +306,7 @@ static void usage(void) {
                "files\n");
     fprintf(f, "-W (--ways-only)                  : process only ways\n");
     fprintf(f, "-U (--unknown-country)            : add objects with unknown country to index\n");
+    fprintf(f, "-C <ISO-Code>                     : Assign country <ISO-code> to towns in unknown countries\n");
     fprintf(f, "-x (--index-size)                 : set maximum country index size in bytes\n");
     fprintf(f, "-z (--compression-level) <level>  : set the compression level\n");
     fprintf(f, "Internal options (undocumented):\n");
@@ -394,7 +396,7 @@ static int parse_option(struct maptool_params *p, char **argv, int argc, int *op
 #ifdef HAVE_POSTGRESQL
                     "d:"
 #endif
-                    "e:hi:knm:p:r:s:t:T:wu:z:Ux:",
+                    "e:hi:knm:C:p:r:s:t:T:wu:z:Ux:",
                     long_options, option_index);
     if (c == -1)
         return 1;
@@ -438,6 +440,9 @@ static int parse_option(struct maptool_params *p, char **argv, int argc, int *op
         break;
     case 'U':
         unknown_country = 1;
+        break;
+    case 'C':
+        hardcoded_country = g_strdup(optarg);
         break;
     case 'a':
         attr_debug_level = atoi(optarg);

--- a/navit/maptool/maptool.h
+++ b/navit/maptool/maptool.h
@@ -252,6 +252,7 @@ extern int processed_nodes, processed_nodes_out, processed_ways, processed_relat
 extern int bytes_read;
 extern int overlap;
 extern int unknown_country;
+extern char *hardcoded_country;
 extern int experimental;
 void sig_alrm(int sig);
 void sig_alrm_end(void);

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -2045,8 +2045,13 @@ static struct town_country *town_country_list_insert_if_new(GList **town_country
 
 static GList *osm_process_town_unknown_country(void) {
     static struct country_table *unknown;
-    if (!unknown)
-        unknown = country_from_countryid(999);
+    int country = 999;
+
+    if (!unknown) {
+        if (!!hardcoded_country)
+            country = country_id_from_iso2(hardcoded_country);
+        unknown = country_from_countryid(country);
+    }
 
     return g_list_prepend(NULL, town_country_new(unknown));
 }

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1312,7 +1312,8 @@ void osm_add_tag(char *k, char *v) {
         level = 5;
     }
     if ((!g_strcmp0(k, "de:amtlicher_gemeindeschluessel")) || (!g_strcmp0(k, "de:regionalschluessel"))) {
-        g_strlcpy(is_in_buffer, "Germany", sizeof(is_in_buffer));
+        if (!is_in_buffer[0])
+            g_strlcpy(is_in_buffer, "Deutschland", sizeof(is_in_buffer));
         level = 5;
     }
     if (!g_strcmp0(k, "place_county")) {

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1312,7 +1312,7 @@ void osm_add_tag(char *k, char *v) {
         level = 5;
     }
     if ((!g_strcmp0(k, "de:amtlicher_gemeindeschluessel")) || (!g_strcmp0(k, "de:regionalschluessel"))) {
-        g_strlcpy(is_in_buffer, "Deutschland", sizeof(is_in_buffer));
+        g_strlcpy(is_in_buffer, "Germany", sizeof(is_in_buffer));
         level = 5;
     }
     if (!g_strcmp0(k, "place_county")) {
@@ -1794,7 +1794,7 @@ static void relation_add_tag(char *k, char *v) {
             boundary = 1;
         }
     } else if (!g_strcmp0(k, "de:amtlicher_gemeindeschluessel") || !g_strcmp0(k, "de:regionalschluessel")) {
-        g_strlcpy(iso_code, "DE", 3);
+        g_strlcpy(iso_code, "DE", sizeof(iso_code));
     } else if (!g_strcmp0(k, "ISO3166-1") || !g_strcmp0(k, "ISO3166-1:alpha2")) {
         g_strlcpy(iso_code, v, sizeof(iso_code));
     } else if (!g_strcmp0(k, "name")) {

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1311,6 +1311,10 @@ void osm_add_tag(char *k, char *v) {
         g_strlcpy(is_in_buffer, v, sizeof(is_in_buffer));
         level = 5;
     }
+    if ((!g_strcmp0(k, "de:amtlicher_gemeindeschluessel")) || (!g_strcmp0(k, "de:regionalschluessel"))) {
+        g_strlcpy(is_in_buffer, "Deutschland", sizeof(is_in_buffer));
+        level = 5;
+    }
     if (!g_strcmp0(k, "place_county")) {
         /**
          * Ireland uses the place_county OSM tag to describe what county a town is in.
@@ -1789,6 +1793,8 @@ static void relation_add_tag(char *k, char *v) {
         if (!g_strcmp0(v, "administrative") || !g_strcmp0(v, "postal_code")) {
             boundary = 1;
         }
+    } else if (!g_strcmp0(k, "de:amtlicher_gemeindeschluessel") || !g_strcmp0(k, "de:regionalschluessel")) {
+        g_strlcpy(iso_code, "DE", 3);
     } else if (!g_strcmp0(k, "ISO3166-1") || !g_strcmp0(k, "ISO3166-1:alpha2")) {
         g_strlcpy(iso_code, v, sizeof(iso_code));
     } else if (!g_strcmp0(k, "name")) {
@@ -2217,6 +2223,8 @@ static GList *osm_process_town_by_boundary(GList *bl, struct item_bin *town, str
                 osm_process_town_by_boundary_update_attrs(town, tc, matches);
         }
     }
+
+    // could we check for countries here and see if a town is geographically inside it?
 
     g_list_free(matches);
 

--- a/navit/support/glib/fake.c
+++ b/navit/support/glib/fake.c
@@ -18,11 +18,11 @@
 #include <stdio.h>              /* fputs/fprintf */
 
 char* g_convert (const char  *in,
-	int        len,            
+	int        len,
 	const char  *to_codeset,
 	const char  *from_codeset,
-	int        *bytes_read,     
-	int        *bytes_written,  
+	int        *bytes_read,
+	int        *bytes_written,
 	void      **error)
 {
 	return g_strdup(in);
@@ -77,7 +77,7 @@ GPrivate* g_private_new(GDestroyNotify notify){
 
 #ifndef HAVE_API_WIN32_BASE
 void* g_private_get(GPrivate *priv) {
-    pthread_once(&priv->once, (void (*)(void))_g_private_init); 
+    pthread_once(&priv->once, (void (*)(void))_g_private_init);
     return pthread_getspecific(priv->key);
 }
 
@@ -133,7 +133,7 @@ g_get_current_time (GTimeVal *result)
 }
 
 // FIXME: should use real utf8-aware function
-gchar * g_utf8_casefold(const gchar *s, gssize len) 
+gchar * g_utf8_casefold(const gchar *s, gssize len)
 {
   return g_ascii_strdown(s,len);
 }


### PR DESCRIPTION
When processing a part of a larger map, for example a region in Germany, town search will not work because the towns are not inside a larger country polygon as that is missing from the map data. This introduces a new command line switch -C that may be used together with -U. When -C is passed, each town in an unknown country will be placed in the country <ISO-code>.

This fixes #1323