### PR TITLE
maptool: consider one-way property of circular junctions

### DIFF
--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1091,7 +1091,7 @@ void osm_add_tag(char *k, char *v) {
             level=5;
     }
     if (! g_strcmp0(k,"junction")) {
-        if (! g_strcmp0(v,"roundabout"))
+        if ( (! g_strcmp0(v,"roundabout") ) || (! g_strcmp0(v,"circular") ) )
             flags[0] |= AF_ONEWAY | AF_ROUNDABOUT | AF_ROUNDABOUT_VALID;
     }
     if (! g_strcmp0(k,"maxspeed")) {


### PR DESCRIPTION
this fixes #1331

This helped to not send me head-on into the wrong direction of a roundabout.
before:
<img width="888" height="705" alt="before" src="https://github.com/user-attachments/assets/2e4210dc-3cd6-4d10-befb-c6a4ea8d7a77" />

after:
<img width="913" height="407" alt="with_patch" src="https://github.com/user-attachments/assets/bb25238a-af1b-4eba-bcd9-c76374525f21" />
