### PR TITLE
Fix:maptool: circular junctions allow oneway to be specified

### DIFF
--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -1082,7 +1082,11 @@ void osm_add_tag(char *k, char *v) {
         if (!g_strcmp0(v,"1")) {
             flags[0] |= AF_ONEWAY | AF_ROUNDABOUT_VALID;
         }
-        if (! g_strcmp0(v,"-1")) {
+        else if (! g_strcmp0(v,"0")) {
+            flags[0] &= ~AF_ONEWAY;
+            flags[0] &= ~AF_ONEWAYREV;
+        }
+        else if (! g_strcmp0(v,"-1")) {
             flags[0] |= AF_ONEWAYREV | AF_ROUNDABOUT_VALID;
         }
         if (!in_way)


### PR DESCRIPTION
this follows up on 191529acab24e0cea8f70351cb1ec7e0398fb0cc that implemented circular junctions to default to one-way streets. While already an improvement, it is not entirely accurate as in fact there are circular junctions that are specified as one-way, there are bidirectional circular junctions and there are circular junctions that lack the oneway tag entirely.

This implements circular junctions to default to oneway=yes, and considers a oneway-tag, should it be set.

This fixes #1331 for real, this time.

routing for circular junctions with oneway=yes:
<img width="1008" height="639" alt="circular_oneway=yes" src="https://github.com/user-attachments/assets/026cab27-5ec4-420f-91f8-805bdc7bc805" />

routing for circular junctions with oneway=no:
<img width="1079" height="774" alt="circular_oneway=no" src="https://github.com/user-attachments/assets/c0c75e9c-92d3-4673-94e0-d33595c6598b" />

routing for circular junctions without oneway tag:
<img width="1107" height="603" alt="circular_no_oneway" src="https://github.com/user-attachments/assets/6c05ee65-f877-4b49-90c3-37e107d18565" />
