### PR TITLE
feat:maptool: write temporary files into instance-specific directory

### DIFF
--- a/navit/maptool/maptool.c
+++ b/navit/maptool/maptool.c
@@ -80,6 +80,9 @@ static long start_brk;
 #endif
 static struct timespec start_ts;
 
+static char coord_tmp_path[PATH_MAX];
+
+
 /*
   Asynchronous signal safe lltoa function (note: no trailing \0 char!)
 */
@@ -558,7 +561,7 @@ static void exit_with_error(char* error_message) {
 }
 
 static void osm_read_input_data(struct maptool_params *p, char *suffix) {
-    unlink("coords.tmp");
+    unlink(coord_tmp_path);
     if (p->process_ways)
         p->osm.ways=tempfile(suffix,"ways",1);
     if (p->process_nodes) {
@@ -635,11 +638,11 @@ static void osm_count_references(struct maptool_params *p, char *suffix, int cle
         fprintf(stderr, "slice %d of %d\n",slices-i-1,slices-1);
         if (!first) {
             FILE *ways=tempfile(suffix,"ways",0);
-            load_buffer("coords.tmp",&node_buffer, i*slice_size, slice_size);
+            load_buffer(coord_tmp_path,&node_buffer, i*slice_size, slice_size);
             if (clear)
                 clear_node_item_buffer();
             ref_ways(ways);
-            save_buffer("coords.tmp",&node_buffer, i*slice_size);
+            save_buffer(coord_tmp_path,&node_buffer, i*slice_size);
             fclose(ways);
         }
         FILE *poly2poi=tempfile(suffix,first?"poly2poi":"poly2poi_resolved",0);
@@ -675,7 +678,7 @@ static void osm_resolve_coords_and_split_at_intersections(struct maptool_params 
         graph=tempfile(suffix,"graph",1);
         coastline=tempfile(suffix,"coastline",1);
         if (i)
-            load_buffer("coords.tmp",&node_buffer, i*slice_size, slice_size);
+            load_buffer(coord_tmp_path,&node_buffer, i*slice_size, slice_size);
         map_resolve_coords_and_split_at_intersections(ways,ways_split,ways_split_index,graph,coastline,final);
         fclose(ways_split);
         if (ways_split_index)
@@ -718,13 +721,15 @@ static void osm_process_coastlines(struct maptool_params *p, char *suffix) {
     }
 }
 
+
+
 static void osm_process_turn_restrictions(struct maptool_params *p, char *suffix) {
     FILE *ways_split, *ways_split_index, *relations, *coords;
     p->osm.turn_restrictions=tempfile(suffix,"turn_restrictions",0);
     if (!p->osm.turn_restrictions)
         return;
     relations=tempfile(suffix,"relations",1);
-    coords=fopen("coords.tmp","rb");
+    coords=fopen(coord_tmp_path,"rb");
     ways_split=tempfile(suffix,"ways_split",0);
     ways_split_index=tempfile(suffix,"ways_split_index",0);
     process_turn_restrictions(p->osm.turn_restrictions,coords,ways_split,ways_split_index,relations);
@@ -744,7 +749,7 @@ static void osm_process_multipolygons(struct maptool_params *p, char *suffix) {
         return;
     relations=tempfile(suffix,"multipolygons_out", 1);
     /* no coords in multipolygons. */
-    //coords=fopen("coords.tmp", "rb");
+    //coords=fopen(coord_tmp_path, "rb");
     ways_split=tempfile(suffix,"ways_split",0);
     ways_split_index=tempfile(suffix,"ways_split_index",0);
     process_multipolygons(p->osm.multipolygons,/*coords*/NULL,ways_split,ways_split_index,relations);
@@ -868,7 +873,7 @@ static void maptool_assemble_map(struct maptool_params *p, char *suffix, char **
         tempfile_unlink(suffix,"way2poi_result");
         tempfile_unlink(suffix,"coastline_result");
         tempfile_unlink(suffix,"towns_poly");
-        unlink("coords.tmp");
+        unlink(coord_tmp_path);
     }
     if (last) {
         zipnum=zip_get_zipnum(zip_info);
@@ -890,9 +895,9 @@ static void maptool_assemble_map(struct maptool_params *p, char *suffix, char **
 
 static void maptool_load_node_table(struct maptool_params *p, int last) {
     if (!p->node_table_loaded) {
-        slices=(sizeof_buffer("coords.tmp")+(long long)slice_size-(long long)1)/(long long)slice_size;
+        slices=(sizeof_buffer(coord_tmp_path)+(long long)slice_size-(long long)1)/(long long)slice_size;
         assert(slices>0);
-        load_buffer("coords.tmp",&node_buffer,last?(slices-1)*slice_size:0, slice_size);
+        load_buffer(coord_tmp_path,&node_buffer,last?(slices-1)*slice_size:0, slice_size);
         p->node_table_loaded=1;
     }
 }
@@ -928,6 +933,7 @@ int main(int argc, char **argv) {
 #ifndef HAVE_GLIB
     _g_slice_thread_init_nomessage();
 #endif
+    snprintf(coord_tmp_path, FILENAME_MAX, "%s/coords.tmp", tempfile_obtain_prefix());
     linguistics_init();
 
     memset(&p, 0, sizeof(p));
@@ -1130,5 +1136,6 @@ int main(int argc, char **argv) {
     start_phase(&p,"done");
     if(p.timestamp != NULL)
         g_free(p.timestamp);
+    tempfile_cleanup();
     return 0;
 }

--- a/navit/maptool/maptool.h
+++ b/navit/maptool/maptool.h
@@ -383,6 +383,8 @@ char *tempfile_name(char *suffix, char *name);
 FILE *tempfile(char *suffix, char *name, int mode);
 void tempfile_unlink(char *suffix, char *name);
 void tempfile_rename(char *suffix, char *from, char *to);
+char *tempfile_obtain_prefix(void);
+void tempfile_cleanup(void);
 
 /* tile.c */
 extern GHashTable *tile_hash,*tile_hash2;

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -41,6 +41,7 @@
 #define M_PI_4     0.785398163397448309616
 #endif
 
+
 static int in_way, in_node, in_relation;
 osmid nodeid,wayid;
 
@@ -1392,7 +1393,9 @@ static void node_buffer_to_hash(void) {
 
 void flush_nodes(int final) {
     fprintf(stderr,"flush_nodes %d\n",final);
-    save_buffer("coords.tmp",&node_buffer,slices*slice_size);
+    char coords_tmp_path[PATH_MAX];
+    snprintf(coords_tmp_path, PATH_MAX, "%s/coords.tmp", tempfile_obtain_prefix());
+    save_buffer(coords_tmp_path,&node_buffer,slices*slice_size);
     if (!final) {
         node_buffer.size=0;
     }
@@ -2283,7 +2286,7 @@ void osm_process_towns(FILE *in, FILE *boundaries, FILE *ways, char *suffix) {
             int i;
 
             if (!tc->country->file) {
-                char *name=g_strdup_printf("country_%d.unsorted.tmp", tc->country->countryid);
+                char *name=g_strdup_printf("%s/country_%d.unsorted.tmp", tempfile_obtain_prefix(), tc->country->countryid);
                 tc->country->file=fopen(name,"wb");
                 g_free(name);
             }
@@ -2369,8 +2372,8 @@ void sort_countries(int keep_tmpfiles) {
             fclose(co->file);
             co->file=NULL;
         }
-        name_in=g_strdup_printf("country_%d.unsorted.tmp", co->countryid);
-        name_out=g_strdup_printf("country_%d.tmp", co->countryid);
+        name_in=g_strdup_printf("%s/country_%d.unsorted.tmp", tempfile_obtain_prefix(), co->countryid);
+        name_out=g_strdup_printf("%s/country_%d.tmp", tempfile_obtain_prefix(), co->countryid);
         co->r=world_bbox;
         item_bin_sort_file(name_in, name_out, &co->r, &co->size);
         if (!keep_tmpfiles)
@@ -4091,7 +4094,7 @@ static void index_country_add(struct zip_info *info, int country_id, char*first_
 void write_countrydir(struct zip_info *zip_info, int max_index_size) {
     int i;
     int max=11;
-    char filename[32];
+    char filename[64];
     struct country_table *co;
     for (i = 0 ; i < sizeof(country_table)/sizeof(struct country_table) ; i++) {
         co=&country_table[i];
@@ -4114,7 +4117,7 @@ void write_countrydir(struct zip_info *zip_info, int max_index_size) {
 
             tile(&co->r, "", tileco, max, overlap, NULL);
 
-            snprintf(filename,sizeof(filename),"country_%d.tmp", co->countryid);
+            snprintf(filename,sizeof(filename),"%s/country_%d.tmp", tempfile_obtain_prefix(), co->countryid);
             in=fopen(filename,"rb");
 
             snprintf(countrypart,sizeof(countrypart),"country_%d_p",co->countryid);
@@ -4187,14 +4190,14 @@ void write_countrydir(struct zip_info *zip_info, int max_index_size) {
 }
 
 void load_countries(void) {
-    char filename[32];
+    char filename[64];
     FILE *f;
     int i;
     struct country_table *co;
 
     for (i = 0 ; i < sizeof(country_table)/sizeof(struct country_table) ; i++) {
         co=&country_table[i];
-        sprintf(filename,"country_%d.tmp", co->countryid);
+        sprintf(filename,"%s/country_%d.tmp", tempfile_obtain_prefix(), co->countryid);
         f=fopen(filename,"rb");
         if (f) {
             int i,first=1;
@@ -4220,18 +4223,18 @@ void load_countries(void) {
 
 void remove_countryfiles(void) {
     int i,j;
-    char filename[32];
+    char filename[64];
     struct country_table *co;
 
     for (i = 0 ; i < sizeof(country_table)/sizeof(struct country_table) ; i++) {
         co=&country_table[i];
         if (co->size) {
-            sprintf(filename,"country_%d.tmp", co->countryid);
+            sprintf(filename,"%s/country_%d.tmp", tempfile_obtain_prefix(), co->countryid);
             unlink(filename);
         }
         for(j=0; j<=co->nparts; j++) {
             char partsuffix[32];
-            sprintf(filename,"country_%d_p", co->countryid);
+            sprintf(filename,"%s/country_%d_p", tempfile_obtain_prefix(), co->countryid);
             sprintf(partsuffix,"%d",j);
             tempfile_unlink(partsuffix,filename);
         }

--- a/navit/maptool/tempfile.c
+++ b/navit/maptool/tempfile.c
@@ -20,11 +20,32 @@
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
+#include <sys/stat.h>
 #include "maptool.h"
 #include "debug.h"
 
+char *tempfile_obtain_prefix() {
+    static char *tmpfile_prefix = NULL;
+
+    if (!tmpfile_prefix) {
+#define tmpfile_prefix_size 64
+        tmpfile_prefix=calloc(tmpfile_prefix_size, 1);
+
+        snprintf(tmpfile_prefix, tmpfile_prefix_size, "maptool_%d.tmp", getpid());
+        if (mkdir(tmpfile_prefix, 0755)) {
+            perror("Error creating directory");
+            exit(1);
+        }
+    }
+    return tmpfile_prefix;
+}
+
+void tempfile_cleanup() {
+    rmdir(tempfile_obtain_prefix());
+}
+
 char *tempfile_name(char *suffix, char *name) {
-    return g_strdup_printf("%s_%s.tmp",name, suffix);
+    return g_strdup_printf("%s/%s_%s.tmp", tempfile_obtain_prefix(), name, suffix);
 }
 FILE *tempfile(char *suffix, char *name, int mode) {
     char *buffer=tempfile_name(suffix, name);
@@ -46,14 +67,14 @@ FILE *tempfile(char *suffix, char *name, int mode) {
 
 void tempfile_unlink(char *suffix, char *name) {
     char buffer[4096];
-    sprintf(buffer,"%s_%s.tmp",name, suffix);
+    sprintf(buffer,"%s/%s_%s.tmp",tempfile_obtain_prefix(), name, suffix);
     unlink(buffer);
 }
 
 void tempfile_rename(char *suffix, char *from, char *to) {
     char buffer_from[4096],buffer_to[4096];
-    sprintf(buffer_from,"%s_%s.tmp",from,suffix);
-    sprintf(buffer_to,"%s_%s.tmp",to,suffix);
+    sprintf(buffer_from,"%s/%s_%s.tmp",tempfile_obtain_prefix(),from,suffix);
+    sprintf(buffer_to,"%s/%s_%s.tmp",tempfile_obtain_prefix(),to,suffix);
     dbg_assert(rename(buffer_from, buffer_to) == 0);
 
 }


### PR DESCRIPTION
This isolates the temporary files of different maptool instances. Once isolated, this allows running multiple instances of maptool inside the same directory at the same time. 

This fixes #1328