### PR TITLE
Chore:command: Warning on String Truncation resolved

### DIFF
--- a/navit/command.c
+++ b/navit/command.c
@@ -1472,7 +1472,7 @@ void command_evaluate(struct attr *attr, const char *expr) {
     }
     if (ctx.error && ctx.error != eof_reached) {
         char expr[32];
-        strncpy(expr, ctx.expr, 32);
+        strncpy(expr, ctx.expr, 31);
         expr[31]='\0';
         err = command_error_to_text(ctx.error);
         dbg(lvl_error, "error %s starting at %s", err, expr);


### PR DESCRIPTION
This shortens the amount of data to be considered by strncpy, avoiding the warning. There is no functional change, as the next line would have terminated eventually overflowing strings even before this - silencing the warning is still a good idea as it reduces false positives
