### PR TITLE
chore:linux: CircleCI icon logic removed

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -15,7 +15,3 @@ cmake ${cmake_opts} ../
 make -j $(nproc --all)
 make package
 
-if [[ "$CIRCLE_ARTIFACTS" != "" ]]; then
-	echo "Copying icons to artifacts..."
-	cp -r navit/icons $CIRCLE_ARTIFACTS
-fi


### PR DESCRIPTION
CircleCI is not being used any longer for linux builds. This removes dead code.
