### PR TITLE
Fail sanity check on errors

### DIFF
--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -86,8 +86,10 @@ for f in $(git diff --name-only refs/remotes/origin/trunk | sort -u); do
             rc=$?
             if [[ $rc -ne 0 ]]; then
                 echo "[ERROR] Your ${f} file doesn't validate against the navit/navit.dtd using xmllint" >&2
+                exit 3
             fi
         fi
     fi
 done
 git diff
+exit $return_code


### PR DESCRIPTION
if the sanity check fails, it is helpful if the pipeline execution task
is also marked with a red icon. This returns a non-null exit code in
case the sanity check fails to communicate this failure as part of the
CI run
