### PR TITLE
Sanity_Check: reduce log output, increase clarity

### DIFF
--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -91,5 +91,5 @@ for f in $(git diff --name-only refs/remotes/origin/trunk | sort -u); do
         fi
     fi
 done
-git diff
+git diff --stat
 exit $return_code


### PR DESCRIPTION
this removes duplicate data from the log output of the sanity check and attempts to be more helpful in analyzing issues by providing a short list of failed files at the end of the log