### PR TITLE
Clarify error message and print it only on actual error

### DIFF
--- a/navit/map/textfile/textfile.c
+++ b/navit/map/textfile/textfile.c
@@ -17,55 +17,55 @@
  * Boston, MA  02110-1301, USA.
  */
 
-#include <glib.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <math.h>
+#include "attr.h"
 #include "config.h"
 #include "debug.h"
-#include "plugin.h"
-#include "projection.h"
+#include "file.h"
 #include "item.h"
 #include "map.h"
 #include "maptype.h"
-#include "attr.h"
+#include "plugin.h"
+#include "projection.h"
 #include "transform.h"
-#include "file.h"
+#include <errno.h>
+#include <glib.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "textfile.h"
 
 static int map_id;
 
-static void remove_comment_line(char* line) {
-    if (line[0]==TEXTFILE_COMMENT_CHAR) {
-        line='\0';
+static void remove_comment_line(char *line) {
+    if (line[0] == TEXTFILE_COMMENT_CHAR) {
+        line = '\0';
     }
 }
 
 static void get_line(struct map_rect_priv *mr) {
-    if(mr->f) {
+    if (mr->f) {
         if (!mr->m->is_pipe)
-            mr->pos=ftell(mr->f);
+            mr->pos = ftell(mr->f);
         else
-            mr->pos+=mr->lastlen;
-        if(fgets(mr->line, TEXTFILE_LINE_SIZE, mr->f) == NULL) {
+            mr->pos += mr->lastlen;
+        if (fgets(mr->line, TEXTFILE_LINE_SIZE, mr->f) == NULL) {
             if (!feof(mr->f))
                 dbg(lvl_error, "Unable to get line (%s) in file %s", strerror(errno), mr->m->filename);
-            mr->line[0]=0;
+            mr->line[0] = 0;
         }
-        dbg(lvl_debug,"read textfile line: %s", mr->line);
+        dbg(lvl_debug, "read textfile line: %s", mr->line);
         remove_comment_line(mr->line);
-        mr->lastlen=strlen(mr->line)+1;
-        if (strlen(mr->line) >= TEXTFILE_LINE_SIZE-1)
+        mr->lastlen = strlen(mr->line) + 1;
+        if (strlen(mr->line) >= TEXTFILE_LINE_SIZE - 1)
             dbg(lvl_error, "line too long: %s", mr->line);
     }
 }
 
 static void map_destroy_textfile(struct map_priv *m) {
     g_free(m->filename);
-    if(m->charset) {
+    if (m->charset) {
         g_free(m->charset);
     }
     g_free(m);
@@ -77,30 +77,30 @@ static void textfile_coord_rewind(void *priv_data) {
 static int parse_line(struct map_rect_priv *mr, int attr) {
     int pos;
 
-    pos=coord_parse(mr->line, projection_mg, &mr->c);
+    pos = coord_parse(mr->line, projection_mg, &mr->c);
     if (pos < strlen(mr->line) && attr) {
-        strcpy(mr->attrs, mr->line+pos);
+        strcpy(mr->attrs, mr->line + pos);
     }
     return pos;
 }
 
 static int textfile_coord_get(void *priv_data, struct coord *c, int count) {
-    struct map_rect_priv *mr=priv_data;
-    int ret=0;
-    dbg(lvl_warning,"enter, count: %d",count);
+    struct map_rect_priv *mr = priv_data;
+    int ret = 0;
+    dbg(lvl_warning, "enter, count: %d", count);
     while (count--) {
         if (mr->f && !feof(mr->f) && (!mr->item.id_hi || !mr->eoc) && parse_line(mr, mr->item.id_hi)) {
             if (c) {
-                *c=mr->c;
-                dbg(lvl_debug,"c=0x%x,0x%x", c->x, c->y);
+                *c = mr->c;
+                dbg(lvl_debug, "c=0x%x,0x%x", c->x, c->y);
                 c++;
             }
             ret++;
             get_line(mr);
             if (mr->item.id_hi)
-                mr->eoc=1;
+                mr->eoc = 1;
         } else {
-            mr->more=0;
+            mr->more = 0;
             break;
         }
     }
@@ -108,46 +108,46 @@ static int textfile_coord_get(void *priv_data, struct coord *c, int count) {
 }
 
 static void textfile_attr_rewind(void *priv_data) {
-    struct map_rect_priv *mr=priv_data;
-    mr->attr_pos=0;
-    mr->attr_last=attr_none;
+    struct map_rect_priv *mr = priv_data;
+    mr->attr_pos = 0;
+    mr->attr_last = attr_none;
 }
 
 static void textfile_encode_attr(char *attr_val, enum attr_type attr_type, struct attr *attr) {
     if (attr_type >= attr_type_int_begin && attr_type <= attr_type_int_end)
-        attr->u.num=atoi(attr_val);
+        attr->u.num = atoi(attr_val);
     else
-        attr->u.str=attr_val;
+        attr->u.str = attr_val;
 }
 
 static int textfile_attr_get(void *priv_data, enum attr_type attr_type, struct attr *attr) {
-    struct map_rect_priv *mr=priv_data;
-    char *str=NULL;
-    dbg(lvl_debug,"mr=%p attrs='%s' ", mr, mr->attrs);
+    struct map_rect_priv *mr = priv_data;
+    char *str = NULL;
+    dbg(lvl_debug, "mr=%p attrs='%s' ", mr, mr->attrs);
     if (attr_type != mr->attr_last) {
-        dbg(lvl_debug,"reset attr_pos");
-        mr->attr_pos=0;
-        mr->attr_last=attr_type;
+        dbg(lvl_debug, "reset attr_pos");
+        mr->attr_pos = 0;
+        mr->attr_last = attr_type;
     }
     if (attr_type == attr_any) {
-        dbg(lvl_debug,"attr_any");
-        if (attr_from_line(mr->attrs,NULL,&mr->attr_pos,mr->attr, mr->attr_name)) {
-            attr_type=attr_from_name(mr->attr_name);
-            dbg(lvl_debug,"found attr '%s' 0x%x", mr->attr_name, attr_type);
-            attr->type=attr_type;
+        dbg(lvl_debug, "attr_any");
+        if (attr_from_line(mr->attrs, NULL, &mr->attr_pos, mr->attr, mr->attr_name)) {
+            attr_type = attr_from_name(mr->attr_name);
+            dbg(lvl_debug, "found attr '%s' 0x%x", mr->attr_name, attr_type);
+            attr->type = attr_type;
             textfile_encode_attr(mr->attr, attr_type, attr);
             return 1;
         }
     } else {
-        str=attr_to_name(attr_type);
-        dbg(lvl_debug,"attr='%s' ",str);
-        if (attr_from_line(mr->attrs,str,&mr->attr_pos,mr->attr, NULL)) {
+        str = attr_to_name(attr_type);
+        dbg(lvl_debug, "attr='%s' ", str);
+        if (attr_from_line(mr->attrs, str, &mr->attr_pos, mr->attr, NULL)) {
             textfile_encode_attr(mr->attr, attr_type, attr);
-            dbg(lvl_debug,"found");
+            dbg(lvl_debug, "found");
             return 1;
         }
     }
-    dbg(lvl_debug,"not found");
+    dbg(lvl_debug, "not found");
     return 0;
 }
 
@@ -161,47 +161,47 @@ static struct item_methods methods_textfile = {
 static struct map_rect_priv *map_rect_new_textfile(struct map_priv *map, struct map_selection *sel) {
     struct map_rect_priv *mr;
 
-    dbg(lvl_debug,"enter");
-    mr=g_new0(struct map_rect_priv, 1);
-    mr->m=map;
-    mr->sel=sel;
+    dbg(lvl_debug, "enter");
+    mr = g_new0(struct map_rect_priv, 1);
+    mr->m = map;
+    mr->sel = sel;
     if (map->flags & 1)
-        mr->item.id_hi=1;
+        mr->item.id_hi = 1;
     else
-        mr->item.id_hi=0;
-    mr->item.id_lo=0;
-    mr->item.meth=&methods_textfile;
-    mr->item.priv_data=mr;
+        mr->item.id_hi = 0;
+    mr->item.id_lo = 0;
+    mr->item.meth = &methods_textfile;
+    mr->item.priv_data = mr;
     if (map->is_pipe) {
 #ifdef HAVE_POPEN
-        char *oargs,*args=g_strdup(map->filename),*sep=" ";
+        char *oargs, *args = g_strdup(map->filename), *sep = " ";
         enum layer_type lay;
         g_free(mr->args);
         while (sel) {
-            oargs=args;
-            args=g_strdup_printf("%s 0x%x 0x%x 0x%x 0x%x", oargs, sel->u.c_rect.lu.x, sel->u.c_rect.lu.y, sel->u.c_rect.rl.x,
-                                 sel->u.c_rect.rl.y);
+            oargs = args;
+            args = g_strdup_printf("%s 0x%x 0x%x 0x%x 0x%x", oargs, sel->u.c_rect.lu.x, sel->u.c_rect.lu.y,
+                                   sel->u.c_rect.rl.x, sel->u.c_rect.rl.y);
             g_free(oargs);
-            for (lay=layer_town ; lay < layer_end ; lay++) {
-                oargs=args;
-                args=g_strdup_printf("%s%s%d", oargs, sep, sel->order);
+            for (lay = layer_town; lay < layer_end; lay++) {
+                oargs = args;
+                args = g_strdup_printf("%s%s%d", oargs, sep, sel->order);
                 g_free(oargs);
-                sep=",";
+                sep = ",";
             }
-            sel=sel->next;
+            sel = sel->next;
         }
-        dbg(lvl_debug,"popen args %s", args);
-        mr->args=args;
-        mr->f=popen(mr->args, "r");
-        mr->pos=0;
-        mr->lastlen=0;
+        dbg(lvl_debug, "popen args %s", args);
+        mr->args = args;
+        mr->f = popen(mr->args, "r");
+        mr->pos = 0;
+        mr->lastlen = 0;
 #else
-        dbg(lvl_error,"unable to work with pipes %s",map->filename);
+        dbg(lvl_error, "unable to work with pipes %s", map->filename);
 #endif
     } else {
-        mr->f=fopen(map->filename, "r");
+        mr->f = fopen(map->filename, "r");
     }
-    if(!mr->f) {
+    if (!mr->f) {
         if (!(errno == ENOENT && map->no_warning_if_map_file_missing)) {
             dbg(lvl_error, "error opening textfile %s: %s", map->filename, strerror(errno));
         }
@@ -209,7 +209,6 @@ static struct map_rect_priv *map_rect_new_textfile(struct map_priv *map, struct 
     get_line(mr);
     return mr;
 }
-
 
 static void map_rect_destroy_textfile(struct map_rect_priv *mr) {
     if (mr->f) {
@@ -225,8 +224,8 @@ static void map_rect_destroy_textfile(struct map_rect_priv *mr) {
 }
 
 static struct item *map_rect_get_item_textfile(struct map_rect_priv *mr) {
-    char *p,type[TEXTFILE_LINE_SIZE];
-    dbg(lvl_debug,"map_rect_get_item_textfile id_hi=%d line=%s", mr->item.id_hi, mr->line);
+    char *p, type[TEXTFILE_LINE_SIZE];
+    dbg(lvl_debug, "map_rect_get_item_textfile id_hi=%d line=%s", mr->item.id_hi, mr->line);
     if (!mr->f) {
         return NULL;
     }
@@ -234,24 +233,24 @@ static struct item *map_rect_get_item_textfile(struct map_rect_priv *mr) {
         struct coord c;
         textfile_coord_get(mr, &c, 1);
     }
-    for(;;) {
+    for (;;) {
         if (feof(mr->f)) {
-            dbg(lvl_debug,"map_rect_get_item_textfile: eof %d",mr->item.id_hi);
+            dbg(lvl_debug, "map_rect_get_item_textfile: eof %d", mr->item.id_hi);
             if (mr->m->flags & 1) {
                 if (!mr->item.id_hi)
                     return NULL;
-                mr->item.id_hi=0;
+                mr->item.id_hi = 0;
             } else {
                 if (mr->item.id_hi)
                     return NULL;
-                mr->item.id_hi=1;
+                mr->item.id_hi = 1;
             }
             if (mr->m->is_pipe) {
 #ifdef HAVE_POPEN
                 pclose(mr->f);
-                mr->f=popen(mr->args, "r");
-                mr->pos=0;
-                mr->lastlen=0;
+                mr->f = popen(mr->args, "r");
+                mr->pos = 0;
+                mr->lastlen = 0;
 #endif
             } else {
                 fseek(mr->f, 0, SEEK_SET);
@@ -259,45 +258,45 @@ static struct item *map_rect_get_item_textfile(struct map_rect_priv *mr) {
             }
             get_line(mr);
         }
-        if ((p=strchr(mr->line,'\n')))
-            *p='\0';
+        if ((p = strchr(mr->line, '\n')))
+            *p = '\0';
         if (mr->item.id_hi) {
-            mr->attrs[0]='\0';
+            mr->attrs[0] = '\0';
             if (!parse_line(mr, 1)) {
                 get_line(mr);
                 continue;
             }
-            dbg(lvl_debug,"map_rect_get_item_textfile: point found");
-            mr->eoc=0;
-            mr->item.id_lo=mr->pos;
+            dbg(lvl_debug, "map_rect_get_item_textfile: point found");
+            mr->eoc = 0;
+            mr->item.id_lo = mr->pos;
         } else {
             if (parse_line(mr, 1)) {
                 get_line(mr);
                 continue;
             }
-            dbg(lvl_debug,"map_rect_get_item_textfile: line found");
-            if (! mr->line[0]) {
+            dbg(lvl_debug, "map_rect_get_item_textfile: line found");
+            if (!mr->line[0]) {
                 get_line(mr);
                 continue;
             }
-            mr->item.id_lo=mr->pos;
+            mr->item.id_lo = mr->pos;
             strcpy(mr->attrs, mr->line);
             get_line(mr);
-            dbg(lvl_debug,"mr=%p attrs=%s", mr, mr->attrs);
+            dbg(lvl_debug, "mr=%p attrs=%s", mr, mr->attrs);
         }
-        dbg(lvl_debug,"get_attrs %s", mr->attrs);
-        if (attr_from_line(mr->attrs,"type",NULL,type,NULL)) {
-            dbg(lvl_debug,"type='%s'", type);
-            mr->item.type=item_from_name(type);
+        dbg(lvl_debug, "get_attrs %s", mr->attrs);
+        if (attr_from_line(mr->attrs, "type", NULL, type, NULL)) {
+            dbg(lvl_debug, "type='%s'", type);
+            mr->item.type = item_from_name(type);
             if (mr->item.type == type_none)
                 dbg(lvl_error, "Warning: type '%s' unknown", type);
         } else {
             get_line(mr);
             continue;
         }
-        mr->attr_last=attr_none;
-        mr->more=1;
-        dbg(lvl_debug,"return attr='%s'", mr->attrs);
+        mr->attr_last = attr_none;
+        mr->more = 1;
+        dbg(lvl_debug, "return attr='%s'", mr->attrs);
         return &mr->item;
     }
 }
@@ -306,14 +305,14 @@ static struct item *map_rect_get_item_byid_textfile(struct map_rect_priv *mr, in
     if (mr->m->is_pipe) {
 #ifndef _MSC_VER
         pclose(mr->f);
-        mr->f=popen(mr->args, "r");
-        mr->pos=0;
-        mr->lastlen=0;
+        mr->f = popen(mr->args, "r");
+        mr->pos = 0;
+        mr->lastlen = 0;
 #endif /* _MSC_VER */
     } else
         fseek(mr->f, id_lo, SEEK_SET);
     get_line(mr);
-    mr->item.id_hi=id_hi;
+    mr->item.id_hi = id_hi;
     return map_rect_get_item_textfile(mr);
 }
 
@@ -329,38 +328,38 @@ static struct map_methods map_methods_textfile = {
 
 static struct map_priv *map_new_textfile(struct map_methods *meth, struct attr **attrs, struct callback_list *cbl) {
     struct map_priv *m;
-    struct attr *data=attr_search(attrs, attr_data);
-    struct attr *charset=attr_search(attrs, attr_charset);
-    struct attr *flags=attr_search(attrs, attr_flags);
-    struct attr *no_warn=attr_search(attrs, attr_no_warning_if_map_file_missing);
+    struct attr *data = attr_search(attrs, attr_data);
+    struct attr *charset = attr_search(attrs, attr_charset);
+    struct attr *flags = attr_search(attrs, attr_flags);
+    struct attr *no_warn = attr_search(attrs, attr_no_warning_if_map_file_missing);
     struct file_wordexp *wexp;
-    int len,is_pipe=0;
+    int len, is_pipe = 0;
     char *wdata;
     char **wexp_data;
-    if (! data)
+    if (!data)
         return NULL;
-    dbg(lvl_debug,"map_new_textfile %s", data->u.str);
-    wdata=g_strdup(data->u.str);
-    len=strlen(wdata);
-    if (len && wdata[len-1] == '|') {
-        wdata[len-1]='\0';
-        is_pipe=1;
+    dbg(lvl_debug, "map_new_textfile %s", data->u.str);
+    wdata = g_strdup(data->u.str);
+    len = strlen(wdata);
+    if (len && wdata[len - 1] == '|') {
+        wdata[len - 1] = '\0';
+        is_pipe = 1;
     }
-    wexp=file_wordexp_new(wdata);
-    wexp_data=file_wordexp_get_array(wexp);
-    *meth=map_methods_textfile;
+    wexp = file_wordexp_new(wdata);
+    wexp_data = file_wordexp_get_array(wexp);
+    *meth = map_methods_textfile;
 
-    m=g_new0(struct map_priv, 1);
-    m->id=++map_id;
-    m->filename=g_strdup(wexp_data[0]);
-    m->is_pipe=is_pipe;
-    m->no_warning_if_map_file_missing=(no_warn!=NULL) && (no_warn->u.num);
+    m = g_new0(struct map_priv, 1);
+    m->id = ++map_id;
+    m->filename = g_strdup(wexp_data[0]);
+    m->is_pipe = is_pipe;
+    m->no_warning_if_map_file_missing = (no_warn != NULL) && (no_warn->u.num);
     if (flags)
-        m->flags=flags->u.num;
-    dbg(lvl_debug,"map_new_textfile %s %s", m->filename, wdata);
+        m->flags = flags->u.num;
+    dbg(lvl_debug, "map_new_textfile %s %s", m->filename, wdata);
     if (charset) {
-        m->charset=g_strdup(charset->u.str);
-        meth->charset=m->charset;
+        m->charset = g_strdup(charset->u.str);
+        meth->charset = m->charset;
     }
     file_wordexp_destroy(wexp);
     g_free(wdata);
@@ -368,7 +367,6 @@ static struct map_priv *map_new_textfile(struct map_methods *meth, struct attr *
 }
 
 void plugin_init(void) {
-    dbg(lvl_debug,"textfile: plugin_init");
+    dbg(lvl_debug, "textfile: plugin_init");
     plugin_register_category_map("textfile", map_new_textfile);
 }
-


### PR DESCRIPTION
this clarifies an error message as found in #1395 and adjusts the whitespace in map/textfile.c
 
This is, again, based on #1378 to obtain the include fixes that were done in that branch.