### PR TITLE
Fix:DTD: polygon: missing attributes src, w, h added

### DIFF
--- a/navit/navit.dtd
+++ b/navit/navit.dtd
@@ -136,6 +136,9 @@
 <!ELEMENT polygon (coord*)>
 <!ATTLIST polygon color CDATA #REQUIRED>
 <!ATTLIST polygon oneway CDATA #IMPLIED>
+<!ATTLIST polygon src CDATA #IMPLIED>
+<!ATTLIST polygon w CDATA #IMPLIED>
+<!ATTLIST polygon h CDATA #IMPLIED>
 <!ELEMENT polyline (coord*)>
 <!ATTLIST polyline color CDATA #REQUIRED>
 <!ATTLIST polyline width CDATA #IMPLIED>


### PR DESCRIPTION
This adds the declaration of optional and already-used (since 17f516a150) attributes to the polygon element. The check only recently started to fail by returning exit codes since a35eebc10cdfedd20b34df4cd6df39ab2fa75255
