### PR TITLE
Feat:ci_sanity_check: check xml for validity towards dtd always

### DIFF
--- a/scripts/ci_sanity_checks.sh
+++ b/scripts/ci_sanity_checks.sh
@@ -84,17 +84,15 @@ for f in $(git --no-pager diff --name-only refs/remotes/origin/trunk | sort -u);
             clang-format -i "${f}"
         fi
 
-        if [[ "${f: -11}" == "shipped.xml" ]]; then
-            echo "[INFO] Checking for compliance with the DTD using xmllint on ${f}..."
-            xmllint --noout --dtdvalid navit/navit.dtd "$f"
-            rc=$?
-            if [[ $rc -ne 0 ]]; then
-                echo "[ERROR] Your ${f} file doesn't validate against the navit/navit.dtd using xmllint" >&2
-                exit 3
-            fi
-        fi
-    fi
+       fi
 done
+
+
+echo "[INFO] Checking for compliance with the DTD using xmllint on ${f}..."
+if ! find . -type f -name "*shipped.xml" -print0 | xargs -0L1 xmllint --noout --dtdvalid navit/navit.dtd; then
+		echo "[ERROR] one of the \*shipped.xml-files doesn't validate against the navit/navit.dtd using xmllint" >&2
+		return_code=3
+fi
 
 check_diff
 exit $return_code


### PR DESCRIPTION
This applies the xml sanity check to all all xml files indifferent if they changed as previously, changes in the DTD would not cause the sanity check to be run. As such this avoids incomplete dtd changes

