### PR TITLE
Enable static code analysis during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,13 @@ IF(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+	find_program(iwyu_path NAMES include-what-you-use iwyu)
+	if (iwyu_path)
+		set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${iwyu_path} )
+	endif()
+endif()
+
 # binary name
 set(NAVIT_BINARY navit CACHE STRING "Navit binary name")
 # install path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,7 +873,6 @@ CHECK_FUNCTION_EXISTS (_atoi64 HAVE__ATOI64)
 
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
 			   "${CMAKE_CURRENT_BINARY_DIR}/config.h" )
-
 # Compile with -Wall -Wextra. We need all the help we can get from the compiler :-).
 # Disabled warnings:
 # -Wno-missing-field-initializers: Used a lot, does not seem problematic.
@@ -881,19 +880,22 @@ CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
 #                        functions implementing the interface of a plugin.
 # -Wno-sign-compare: We currently just use int almost everywhere.
 #                    Unclear if it's really worth correcting.
-add_compiler_flag_if_available("-Wall")
-add_compiler_flag_if_available("-Wno-unused-parameter")
-add_compiler_flag_if_available("-Wno-sign-compare")
-add_compiler_flag_if_available("-Wno-missing-field-initializers")
-add_compiler_flag_if_available("-Wundef")
-add_compiler_flag_if_available("-Wcast-align")
-add_compiler_flag_if_available("-Wpointer-arith")
-add_compiler_flag_if_available("-Wextra")
-add_compiler_flag_if_available("-Wdate-time")
-add_compiler_flag_if_available("-Wmissing-prototypes")
-add_compiler_flag_if_available("-Wstrict-prototypes")
-add_compiler_flag_if_available("-Wformat-security")
+# -Wpedantic:        There is a large amount of matches and it seems unclear
+#                    whether fixing these is worth it before C23
+add_debug_compiler_flag_if_available("-Wall")
+add_debug_compiler_flag_if_available("-Wno-unused-parameter")
+add_debug_compiler_flag_if_available("-Wno-sign-compare")
+add_debug_compiler_flag_if_available("-Wno-missing-field-initializers")
+add_debug_compiler_flag_if_available("-Wundef")
+add_debug_compiler_flag_if_available("-Wcast-align")
+add_debug_compiler_flag_if_available("-Wpointer-arith")
+add_debug_compiler_flag_if_available("-Wextra")
+add_debug_compiler_flag_if_available("-Wdate-time")
+add_debug_compiler_flag_if_available("-Wmissing-prototypes")
+add_debug_compiler_flag_if_available("-Wstrict-prototypes")
+add_debug_compiler_flag_if_available("-Wformat-security")
 add_compiler_flag_if_available("-Werror=format-security")
+add_debug_compiler_flag_if_available("-fanalyzer")
 
 if (ASAN)
 	message(STATUS "Activating AddressSanitizer. To prevent libasan breaking the build, export ASAN_OPTIONS=detect_leaks=0")

--- a/cmake/navit_macros.cmake
+++ b/cmake/navit_macros.cmake
@@ -91,6 +91,15 @@ endmacro(message_error)
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+
+macro(add_debug_compiler_flag_if_available FLAG)
+   set(VAR_FLAG_AVAILABLE_C "FLAG_AVAILABLE_C_${FLAG}")
+   check_c_compiler_flag(${FLAG} ${VAR_FLAG_AVAILABLE_C})
+   if (${${VAR_FLAG_AVAILABLE_C}})
+	   add_compile_options("$<$<CONFIG:DEBUG>:${FLAG}>")
+   endif()
+endmacro(add_debug_compiler_flag_if_available)
+
 macro(add_compiler_flag_if_available FLAG)
    set(VAR_FLAG_AVAILABLE_C "FLAG_AVAILABLE_C_${FLAG}")
    check_c_compiler_flag(${FLAG} ${VAR_FLAG_AVAILABLE_C})


### PR DESCRIPTION
this enables one of the options named in #1424 as part of the regular build.

I am not sure we want this turned on always, Let me read your thoughts please.