### PR TITLE
Fixed(ci):Fix merge in main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
   merge_trunk_in_master:
     runs-on: ubuntu-latest
     needs: [build_android, build_fdroid, build_wince, build_tomtom_minimal, build_linux, build_tomtom_plugin, build_win32]
-    if: github.ref == 'trunk'
+    if: github.ref == 'refs/heads/trunk'
     steps:
       - uses: actions/checkout@v6
       - name: Merge to master branch
@@ -282,5 +282,4 @@ jobs:
         with:
           type: now
           target_branch: 'master'
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{ github.token }}


### PR DESCRIPTION
This fixes two issues. 
1) The credentials to the merge Workflow need to be passed as github_token parameter, not as a Enviroment variable
2) The if always evaluates to false (see log)

```
2026-02-26T21:16:44.9060000Z Evaluating merge_trunk_in_master.if
2026-02-26T21:16:44.9060000Z Evaluating: (success() && ((github.ref == 'trunk')))
2026-02-26T21:16:44.9060000Z Expanded: (true && ('refs/heads/trunk' == 'trunk'))
2026-02-26T21:16:44.9060000Z Result: false
```
