### PR TITLE
fix(core): Size of center_timeout aligned with u.num to be long

### DIFF
--- a/navit/navit.c
+++ b/navit/navit.c
@@ -139,7 +139,7 @@ struct navit {
     struct map *former_destination;
     struct point pressed, last, current;
     int button_pressed, moved, popped, zoomed;
-    int center_timeout;
+    long center_timeout;
     int autozoom_secs;
     int autozoom_min;
     int autozoom_max;


### PR DESCRIPTION
In #1474 it was reported that reducing the timeout parameter makes auto zoom behave differently. This aligns the size of the underlying datastructures to help


