### PR TITLE
fix(gui_internal): pass HAVE_SYSTEM as preprocessor flag to support c…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,7 @@ endif(HAVE_LIBSPEECHD)
 
 if (HAVE_SYSTEM)
 	set_with_reason(speech/cmdline "system() call is available" TRUE)
+	add_compile_definitions(HAVE_SYSTEM)
 endif(HAVE_SYSTEM)
 
 if (HAVE_CREATEPROCESS)

--- a/docs/user/configuration/Gui_internal.rst
+++ b/docs/user/configuration/Gui_internal.rst
@@ -32,6 +32,16 @@ with
 
 inside the <gui .../> tag.
 
+The internal gui has a feature to call a browser on OSM nodes. To use it,
+place a shellscript called navit-browser.sh into your PATH.
+
+The shellscript should contain a call to the browser that is meant to be
+executed, similar to this
+
+.. code-block: bash
+   #!/bin/bash
+   xdg-open $@
+
 Menu
 ----
 


### PR DESCRIPTION
…alling browser

this defines HAVE_SYSTEM as preprocessor directive if the corresponding cmake variable is set