### PR TITLE
Add:docs:sample files list (nl) to use for speech

### DIFF
--- a/docs/speech/nl.sample-files-list.txt
+++ b/docs/speech/nl.sample-files-list.txt
@@ -1,0 +1,169 @@
+# Turn-by-turn texts
+
+"ga"
+"rij"
+"neem"
+"verlaat"
+"oprijden"
+"rijden"
+
+"nu"
+"straks"
+"dan"
+"daarna"
+"volgende"
+
+"links"
+"naar links"
+"rechts"
+"naar rechts"
+"rechtdoor"
+
+"na"
+"naar"
+"richting"
+"andere richtingen"
+"volg de weg gedurende"
+
+"de"
+"het"
+
+"op"
+"af"
+"bij"
+"tot"
+
+"route"
+"routepunt"
+"weg"
+"straat"
+"afslag"
+"oprit"
+"bij knooppunt"
+"rotonde"
+"op de rotonde"
+"de rotonde op"
+
+"kilometer"
+"meter"
+
+"over"
+"dag"
+"dagen"
+"uur"
+"minuten"
+"minuut"
+"afstand"
+
+"invoegen"
+"uitvoegen"
+"aanhouden"
+
+"flauw"
+"scherp"
+
+"indien mogelijk omkeren"
+"geschatte reistijd"
+"geschatte aankomsttijd"
+"bestemming"
+"bereikt"
+"daarna heeft u uw bestemming bereikt"
+"ga terug naar de route"
+"verminder snelheid"
+
+
+# Texts used for roads
+"A"
+"B"
+"C"
+"D"
+"E"
+"I"
+"L"
+"M"
+"N"
+"P"
+"R"
+"S"
+"U"
+"V"
+"X"
+
+"Ring"
+"Noord"
+"Oost"
+"Zuid"
+"West"
+"Centrum"
+
+
+# Numbers
+
+"nulde"
+"eerste"
+"tweede"
+"derde"
+"vierde"
+"vijfde"
+"zesde"
+
+"punt"
+"komma"
+"puntkomma"
+
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+10
+20
+25
+30
+40
+50
+60
+70
+75
+80
+90
+100
+150
+175
+200
+250
+300
+400
+500
+600
+700
+750
+800
+900
+
+
+# Note:
+# '12 kilometer' is spoken as 'one two kilometer' because there is no audio file for '12'.
+# It is clear what is meant but you can create as many audio files with numbers as you like or need.
+
+11 - 19
+21 - 24
+26 - 29
+31 - 39
+41 - 49
+51 - 59
+61 - 69
+71 - 79
+81 - 89
+91 - 99
+
+100 - 199
+200 - 299
+300 - 399
+

--- a/docs/speech/nl.sample-files-list.txt
+++ b/docs/speech/nl.sample-files-list.txt
@@ -1,0 +1,173 @@
+# Turn-by-turn texts
+
+"ga"
+"rij"
+"neem"
+"verlaat"
+"oprijden"
+"rijden"
+
+"nu"
+"straks"
+"dan"
+"daarna"
+"volgende"
+
+"links"
+"naar links"
+"rechts"
+"naar rechts"
+"rechtdoor"
+
+"na"
+"naar"
+"richting"
+"andere richtingen"
+"volg de weg gedurende"
+
+"de"
+"het"
+
+"op"
+"af"
+"in"
+"bij"
+"tot"
+
+"route"
+"routepunt"
+"weg"
+"straat"
+"afslag"
+"oprit"
+"bij knooppunt"
+"rotonde"
+"op de rotonde"
+"de rotonde op"
+
+"kilometer"
+"meter"
+
+"over"
+"dag"
+"dagen"
+"uur"
+"minuten"
+"minuut"
+"afstand"
+
+"invoegen"
+"uitvoegen"
+"aanhouden"
+
+"flauw"
+"scherp"
+
+"indien mogelijk omkeren"
+"favoriet"
+"geschatte reistijd"
+"geschatte aankomsttijd"
+"bestemming"
+"bereikt"
+"daarna heeft u uw bestemming bereikt"
+"ingesteld op"
+"ga terug naar de route"
+"verminder snelheid"
+
+
+# Texts used for roads
+"A"
+"B"
+"C"
+"D"
+"E"
+"I"
+"L"
+"M"
+"N"
+"P"
+"R"
+"S"
+"U"
+"V"
+"X"
+
+"Ring"
+"Noord"
+"Oost"
+"Zuid"
+"West"
+"Centrum"
+
+
+# Numbers
+
+"nulde"
+"eerste"
+"tweede"
+"derde"
+"vierde"
+"vijfde"
+"zesde"
+
+"punt"
+"komma"
+"puntkomma"
+
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+10
+20
+25
+30
+40
+50
+60
+70
+75
+80
+90
+100
+125
+150
+175
+200
+250
+300
+400
+500
+600
+700
+750
+800
+900
+
+
+# Note:
+# '12 kilometer' is spoken as 'one two kilometer' because there is no audio file for '12'.
+# It is clear what is meant but you can create as many audio files with numbers as you like or need.
+
+11 - 19
+21 - 24
+26 - 29
+31 - 39
+41 - 49
+51 - 59
+61 - 69
+71 - 79
+81 - 89
+91 - 99
+
+100 - 199
+200 - 299
+300 - 399
+

--- a/docs/user/configuration/Configuration_Full_list_of_options.rst
+++ b/docs/user/configuration/Configuration_Full_list_of_options.rst
@@ -2427,6 +2427,18 @@ tags.
    |              |       |              | tion <Config |              |
    |              |       |              | uration>`__. |              |
    +--------------+-------+--------------+--------------+--------------+
+   | data-tts     |       |              | Same as      | `            |
+   |              |       |              | 'data'.      |            ` |
+   |              |       |              | When using   |              |
+   |              |       |              | sample files |              |
+   |              |       |              | use this     |              |
+   |              |       |              | option to    |              |
+   |              |       |              | configure    |              |
+   |              |       |              | TTS and use  |              |
+   |              |       |              | 'data' to    |              |
+   |              |       |              | configure    |              |
+   |              |       |              | sample files.|              |
+   +--------------+-------+--------------+--------------+--------------+
    | cps          |       | 0 - ∞        | Speed at     | ``cps="15"`` |
    |              |       |              | which Navit  |              |
    |              |       |              | should speak |              |
@@ -2483,7 +2495,7 @@ tags.
    +--------------+-------+--------------+--------------+--------------+
    | sample_dir   |       |              | For          | ``sampl      |
    |              |       |              | spe          | e_dir="/path |
-   |              |       |              | ech_cmdline, | /to/waves"`` |
+   |              |       |              | ech_cmdline, | /to/files"`` |
    |              |       |              | defines path |              |
    |              |       |              | where        |              |
    |              |       |              | pre-recorded |              |

--- a/docs/user/configuration/Configuration_Full_list_of_options.rst
+++ b/docs/user/configuration/Configuration_Full_list_of_options.rst
@@ -2449,7 +2449,7 @@ tags.
    +--------------+-------+--------------+--------------+--------------+
    | sample_dir   |       |              | For          | ``sampl      |
    |              |       |              | spe          | e_dir="/path |
-   |              |       |              | ech_cmdline, | /to/waves"`` |
+   |              |       |              | ech_cmdline, | /to/files"`` |
    |              |       |              | defines path |              |
    |              |       |              | where        |              |
    |              |       |              | pre-recorded |              |

--- a/docs/user/configuration/advanced/introduction.rst
+++ b/docs/user/configuration/advanced/introduction.rst
@@ -23,7 +23,10 @@ Note that Navit internally handles all text in UTF-8 encoding. If you use a file
 
 ''data'' is the program that can be used to play the sample files. You should specify the program name along with any necessary parameters. The placeholder "%s" will be replaced with the file(s) to be played. All files required for a text will be passed in one go, so the program will need to support playing multiple files. Note that the %s should ''not'' be quoted; the text is not passed through a shell.
 
-Note that if any file that is needed to compose the complete phrase is missing then Navit will be silent. In that case a warning will be printed. Unfortunately, there is no complete list of the samples required. However, all the navigation text is contained in the translation files (.po files), so you can get a rough list.
+Note that if any file that is needed to compose the complete phrase is missing then Navit will be silent. In that case a warning will be printed. There is a list of the samples required for the Dutch language. Lists for other languages can be created by reading the log file. Look for lines containing "Cannot speak text" and create the missing audio files. The list for Dutch can be used as a starting point (the list for the numbers is the same in every language). Other texts are probably different because of the order of words in a sentence.
+
+WARNING: THERE ARE ANNOUNCEMENTS THAT CONTAIN GEOGRAPHICAL NAMES. SO THERE IS NO PRACTICAL USE FOR THIS FEATURE AT THIS MOMENT SINCE IT IS IMPOSSIBLE TO CREATE AUDIO FILES FOR ALL THE NAMES.
+A SOLUTION TO USE TEXT TO SPEECH FOR MISSING AUDIO FILES IS BEING TESTED.
 
 By default Navit is trying to announce street names. To disable this feature you can set ''vocabulary_name'' and ''vocabulary_name_systematic'' to 0 in the speech tag which will specify that the speech synthesizer isn't capable of speaking names. Also there is ''vocabulary_distances'' which you can set to 0 so only the minimum set of 1,2,3,4,5,10,25,50,75,100,150,200,250,300,400,500,750 as numbers is used.
 


### PR DESCRIPTION
Edit documentation and add a Dutch sample files list to use for speech.

Fixes #1482