### PR TITLE
Add:gui_internal:Add town to destination description

### DIFF
--- a/navit/gui/internal/gui_internal_search.c
+++ b/navit/gui/internal/gui_internal_search.c
@@ -336,6 +336,10 @@ static void gui_internal_search_idle(struct gui_priv *this, char *wm_name, struc
     struct widget *search_input = NULL;
     struct widget *menu, *resultlist_row, *resultlist_entry;
 
+    gchar *address_label;
+    gchar *town_label;
+    int town_label_level = 1;
+
     res = search_list_get_result(this->sl);
     if (!res) {
         gui_internal_search_idle_end(this);
@@ -359,9 +363,18 @@ static void gui_internal_search_idle(struct gui_priv *this, char *wm_name, struc
         result_sublabel = town_display_label(res, 2, 1);
     } else if (!strcmp(wm_name, "House number")) {
         item_name = res->house_number->house_number;
+
+        // label: order of address elements
+
+        dbg(lvl_debug,"town_label_level: '%i'", town_label_level);
+        town_label = town_display_label(res, town_label_level, 0);
+        dbg(lvl_debug,"town_label: '%s'", town_label);
+        address_label = g_strdup_printf("%s, %s %s", item_name, res->street->name, town_label);
+
         result_main_label = g_strdup_printf("%s, %s", item_name, res->street->name);
         result_sublabel = town_display_label(res, 3, 0);
-        widget_name = g_strdup(result_main_label);
+
+        widget_name = g_strdup(address_label);
     }
     if (!item_name) {
         dbg(lvl_error, "Skipping nameless item in search (search type: %s). Please report this as a bug.", wm_name);

--- a/navit/gui/internal/gui_internal_search.c
+++ b/navit/gui/internal/gui_internal_search.c
@@ -341,6 +341,10 @@ static void gui_internal_search_idle(struct gui_priv *this, char *wm_name, struc
     struct widget *search_input = NULL;
     struct widget *menu, *resultlist_row, *resultlist_entry;
 
+    gchar *address_label;
+    gchar *town_label;
+    int town_label_level = 1;
+
     res = search_list_get_result(this->sl);
     if (!res) {
         gui_internal_search_idle_end(this);
@@ -364,9 +368,18 @@ static void gui_internal_search_idle(struct gui_priv *this, char *wm_name, struc
         result_sublabel = town_display_label(res, 2, 1);
     } else if (!strcmp(wm_name, "House number")) {
         item_name = res->house_number->house_number;
+
+        // label: order of address elements
+
+        dbg(lvl_debug, "town_label_level: '%i'", town_label_level);
+        town_label = town_display_label(res, town_label_level, 0);
+        dbg(lvl_debug, "town_label: '%s'", town_label);
+        address_label = g_strdup_printf("%s, %s %s", item_name, res->street->name, town_label);
+
         result_main_label = g_strdup_printf("%s, %s", item_name, res->street->name);
         result_sublabel = town_display_label(res, 3, 0);
-        widget_name = g_strdup(result_main_label);
+
+        widget_name = g_strdup(address_label);
     }
     if (!item_name) {
         dbg(lvl_error, "Skipping nameless item in search (search type: %s). Please report this as a bug.", wm_name);


### PR DESCRIPTION
When you choose a destination from the former destination list, the town isn't shown in the list.
Also the case when #1528 is used.

This adds the name of the town.

