### PR TITLE
Fix:WinCE: Fix posix enviroment functions

### DIFF
--- a/navit/support/libc/libc.c
+++ b/navit/support/libc/libc.c
@@ -31,7 +31,7 @@ static void cleanup_libc(void)
 }
 
 char *
-_getenv(const char *name)
+getenv(const char *name)
 {
 	int i;
 	for (i=0; i < MAXENV; i++) {

--- a/navit/support/libc/libc.h
+++ b/navit/support/libc/libc.h
@@ -47,8 +47,5 @@ size_t strftime (char *s, size_t maxsize, const char *format, const struct tm *t
 
 #endif
 
-#ifdef WIN32
-#define getenv      _getenv
-#endif
 
 #endif

--- a/navit/support/libc/stdlib.h
+++ b/navit/support/libc/stdlib.h
@@ -1,0 +1,32 @@
+/**
+ * stdlib.h wrapper for WinCE — see navit-gps/navit#1499
+ *
+ * The WinCE cross-compiler (mingw32ce) provides broken static inline
+ * stubs for getenv/setenv/unsetenv in its <stdlib.h> that always
+ * return failure. These stubs are inlined into every translation unit,
+ * making them impossible to override at link time.
+ *
+ * This wrapper renames the broken stubs before including the real
+ * <stdlib.h>, then declares navit's working implementations from
+ * support/libc/libc.c.
+ */
+#ifndef NAVIT_STDLIB_WRAPPER_H
+#define NAVIT_STDLIB_WRAPPER_H
+
+/* Rename broken inline stubs so they compile harmlessly */
+#define getenv   _navit_broken_getenv
+#define setenv   _navit_broken_setenv
+#define unsetenv _navit_broken_unsetenv
+
+#include_next <stdlib.h>
+
+#undef getenv
+#undef setenv
+#undef unsetenv
+
+/* Declare navit's working implementations (defined in libc.c) */
+extern char *getenv(const char *name);
+extern int setenv(const char *name, const char *value, int overwrite);
+extern int unsetenv(const char *name);
+
+#endif /* NAVIT_STDLIB_WRAPPER_H */


### PR DESCRIPTION
At https://github.com/pgrandin/navit/tree/fix-wince-setenv @pgrandin implemented a fix for #1499 and worked on a smoke test which seems to not be ready yet. But the fix is already working. 
I tested it on read hardware . The snip it i used is:
```xml
<mapset enabled="yes">
    <map type="binfile" data="$NAVIT_SHAREDIR/maps/europe-germany-niedersachsen-2026-01-01.bin"/>
</mapset>
```