### PR TITLE
fix(#1323): For Germany, allow town search, utilize amtlicher_gemeind…

### DIFF
--- a/navit/maptool/boundaries.c
+++ b/navit/maptool/boundaries.c
@@ -99,6 +99,19 @@ static GList *process_boundaries_setup(FILE *boundaries, struct relations *relat
                 osm_warning("relation", item_bin_get_relationid(ib), 0,
                             "Country Boundary doesn't contain an ISO3166-1 tag\n");
         }
+        if (!boundary->country) {
+            char *iso2 = osm_tag_value(ib, "ISO3166-2");
+            if (iso2 && !strncmp(iso2, "DE-", 3))
+                boundary->country = country_from_iso2("DE");
+        }
+        if (!boundary->country) {
+            char *ags = osm_tag_value(ib, "de:amtlicher_gemeindeschluessel");
+            char *rs = osm_tag_value(ib, "de:regionalschluessel");
+            if (ags || rs) {
+                boundary->country = country_from_iso2("DE");
+            }
+        }
+
         while ((member = item_bin_get_attr(ib, attr_osm_member, member))) {
             long long osm_id;
             int read = 0;

--- a/navit/maptool/osm.c
+++ b/navit/maptool/osm.c
@@ -2134,8 +2134,12 @@ static void osm_process_town_by_boundary_update_attrs(struct item_bin *town, str
     for (l = matches; l; l = g_list_next(l)) {
         struct boundary *b = l->data;
         char *boundary_admin_level_string;
-        char *name;
-        char *postal = osm_tag_value(b->ib, "postal_code");
+        char *name, *postal;
+
+        if (!g_strcmp0(osm_tag_value(b->ib, "boundary"), "postal_code"))
+            continue;
+
+        postal = osm_tag_value(b->ib, "postal_code");
 
         if (postal) {
             tc->attrs[0].type = attr_town_postal;


### PR DESCRIPTION
…eschluessel to assign country

This adds german towns to the search index properly without hard-coding. Tested on Niedersachsen and Sachsen-Anhalt.