### PR TITLE
Feature/navit safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup requirements
         run: |
            bash scripts/setup_common_requirements.sh
-           apt-get install -y libpng-dev libfreetype6-dev libdbus-glib-1-dev libgtk2.0-dev curl
+           apt-get install -y libpng-dev libfreetype6-dev libdbus-glib-1-dev libgtk2.0-dev libsqlite3-dev curl
       - name: Build for Linux
         run: bash scripts/build_linux.sh
       - uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,19 @@ if (GETTEXT_FOUND)
 	set_with_reason(USE_NATIVE_LANGUAGE_SUPPORT "Gettext found" TRUE)
 endif(GETTEXT_FOUND)
 
+# SQLite3 is the optional backend for the Navit Safety POI confirmation cache.
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+	pkg_check_modules(SQLITE3 sqlite3)
+endif()
+if(NOT SQLITE3_FOUND)
+	find_library(SQLITE3_LIBRARIES NAMES sqlite3)
+	find_path(SQLITE3_INCLUDE_DIRS NAMES sqlite3.h)
+	if(SQLITE3_LIBRARIES AND SQLITE3_INCLUDE_DIRS)
+		set(SQLITE3_FOUND TRUE)
+	endif()
+endif()
+
 #Independent modules
 add_module(graphics/null "Default" TRUE)
 add_module(osd/core "Default" TRUE)
@@ -556,6 +569,13 @@ add_module(map/csv "Default" TRUE)
 #Modules without test yet
 add_module(plugin/pedestrian "Default" FALSE)
 add_module(plugin/j1850 "Default" FALSE)
+add_module(plugin/navit_safety "Default" FALSE)
+# set_with_reason must run after add_module so the plugin is enabled in place.
+if(SQLITE3_FOUND)
+	set_with_reason(plugin/navit_safety "SQLite3 found" TRUE)
+else()
+	set_with_reason(plugin/navit_safety "SQLite3 not found" FALSE)
+endif()
 add_module(speech/android "Default" FALSE)
 add_module(speech/espeak "Default" FALSE)
 add_module(speech/iphone "Default" FALSE)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Main Features
    user/platforms/index
    user/configuration/basic
    user/configuration/advanced
+   user/plugins/index
    user/community/index
    user/faq/index
 

--- a/docs/user/plugins/index.rst
+++ b/docs/user/plugins/index.rst
@@ -1,0 +1,7 @@
+Plugins
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   safety/index

--- a/docs/user/plugins/safety/codemap.rst
+++ b/docs/user/plugins/safety/codemap.rst
@@ -1,0 +1,118 @@
+Source code map
+===============
+
+A map of the plugin's source tree to make navigation and debugging easier. All
+paths are under ``navit/plugin/navit_safety/``. For the planning pipeline these
+files implement, see :doc:`how_it_works`.
+
+Source files
+------------
+
+``navit_safety.h``
+    Public configuration: ``enum navit_safety_remote_mode``
+    (Off/Auto/Always), ``struct navit_safety_config`` (16 fields), and the
+    ``navit_safety_config_default`` prototype. Documents the deferred items as
+    TODOs.
+
+``navit_safety_route.{c,h}``
+    Live route integration. ``navit_safety_route_refresh`` samples the active
+    route, searches the mapset corridor for fuel or water POIs, scores them,
+    and runs the planning engines. ``navit_safety_format_status`` composes the
+    OSD text. Confirm/deny helpers update the cache and recalculate.
+
+``navit_safety.c`` (OSD section)
+    OSD widget, command table (``navit_safety_toggle_remote``,
+    ``navit_safety_confirm_poi``, ``navit_safety_deny_poi``,
+    ``navit_safety_show_plan``, ``navit_safety_toggle_foot``), attribute
+    parsing, and graphics lifecycle.
+
+``navit_safety_confidence.{c,h}``
+    POI confidence scoring. ``navit_safety_score_poi`` maps source and age to a
+    confidence level; ``navit_safety_confidence_counts_as_resupply`` is the
+    Medium-or-higher predicate. Age thresholds are named constants at the top
+    of the ``.c``.
+
+``navit_safety_koppen.{c,h}``
+    Climate classification. ``navit_safety_koppen_lookup`` resolves a
+    coordinate via the static ``koppen_boxes`` table; the predicates
+    ``navit_safety_koppen_is_arid`` / ``_is_semiarid`` / ``_triggers_remote``
+    and ``navit_safety_koppen_code`` round it out.
+
+``navit_safety_lookahead.{c,h}``
+    Gap detection. ``navit_safety_lookahead_plan`` produces a
+    ``struct navit_safety_gap_result`` (max gap, gap start, warning,
+    shortfall). Depends only on the confidence enum.
+
+``navit_safety_plan.{c,h}``
+    Resource-planning orchestrator. ``navit_safety_plan`` ties the config,
+    Koppen lookup, POI-density check (``density_is_sparse``), buffer selection
+    (``select_buffer``), and lookahead together into a
+    ``struct navit_safety_plan_result``. This is the entry point a route hook
+    will call.
+
+``navit_safety_heat.{c,h}``
+    Foot-travel heat model. ``navit_safety_heat_assess`` (WBGT to risk level),
+    ``navit_safety_heat_water_ml_per_hour`` (water requirement), and
+    ``navit_safety_heat_plan`` (config-driven combination). Depends only on the
+    config struct.
+
+``navit_safety_cache.{c,h}``
+    SQLite confirmation cache (only built when SQLite3 is available).
+    ``navit_safety_cache_open`` / ``_close`` manage the handle;
+    ``navit_safety_cache_confirm`` / ``_is_confirmed`` read and write the
+    ``poi_confirmations`` table (keyed by ``poi_id`` and ``trip_id``).
+
+Build wiring
+------------
+
+``CMakeLists.txt`` (plugin)
+    Builds the engines into ``plugin_navit_safety`` (output
+    ``libosd_navit_safety.so``). ``navit_safety_cache.c`` is added and
+    ``NAVIT_SAFETY_WITH_SQLITE=1`` is defined only when SQLite3 is found.
+    ``NAVIT_SAFETY_WITH_OSD=1`` is scoped to the plugin target.
+
+``CMakeLists.txt`` (root, excerpt)
+    Detects SQLite3 and registers ``add_module(plugin/navit_safety ...)``,
+    enabling it when SQLite3 is present.
+
+Tests
+-----
+
+Under ``tests/`` (built when ``BUILD_NAVIT_SAFETY_TESTS=ON``):
+
+- ``test_navit_safety_config.c`` — defaults, via the ``navit_safety_config_obj``
+  OBJECT library compiled with ``NAVIT_SAFETY_WITH_OSD=0`` to isolate it from
+  the OSD/core symbols.
+- ``test_navit_safety_confidence.c`` — the source-ranking table and downgrades.
+- ``test_navit_safety_koppen.c`` — zone predicates and the coarse lookup.
+- ``test_navit_safety_lookahead.c`` — gaps, ignored low-confidence stops, final
+  leg.
+- ``test_navit_safety_plan.c`` — buffer selection, POI-density trigger, and the
+  desert warning across terrain and modes.
+- ``test_navit_safety_heat.c`` — WBGT thresholds, the water formula, and the
+  config-gated heat plan.
+- ``test_navit_safety_route.c`` — stop-list builder and idle status formatting.
+
+- ``test_navit_safety_cache.c`` — confirm/query round-trips (in-memory DB);
+  only built with SQLite3.
+
+Run them with::
+
+   cmake -S . -B build -DBUILD_NAVIT_SAFETY_TESTS=ON
+   cmake --build build -j"$(nproc)"
+   ctest --test-dir build/navit/plugin/navit_safety/tests --output-on-failure
+
+Debugging tips
+--------------
+
+- The OSD logs through ``dbg(...)``; raise the Navit debug level to see
+  ``Navit Safety`` messages. Useful breakpoints: ``navit_safety_osd_new`` (OSD
+  lifecycle) and ``navit_safety_plan`` (planning entry point).
+- The pure engines have no Navit dependencies, so the unit tests are the
+  fastest way to reproduce and step through scoring, classification, lookahead,
+  and planning logic in isolation.
+- For cache issues, open ``~/.navit/navit_safety.db`` with the ``sqlite3`` CLI
+  and inspect the ``poi_confirmations`` table.
+- Remember the two compile guards: a symbol missing from a build is usually
+  explained by ``NAVIT_SAFETY_WITH_OSD`` (OSD path) or
+  ``NAVIT_SAFETY_WITH_SQLITE`` (cache).

--- a/docs/user/plugins/safety/commands.rst
+++ b/docs/user/plugins/safety/commands.rst
@@ -1,0 +1,64 @@
+On-screen elements and commands
+===============================
+
+This page lists what the Navit Safety plugin exposes on screen and through commands.
+
+Enabling the OSD
+----------------
+
+Load the shared object and add an OSD instance in your Navit configuration:
+
+.. code-block:: xml
+
+   <plugin path="$NAVIT_LIBDIR/plugin/${NAVIT_LIBPREFIX}libosd_navit_safety.so" active="yes"/>
+   <osd type="navit_safety" enabled="yes" label="mytrip" update_period="30" data="range=600"/>
+
+Optional OSD attributes:
+
+- ``label`` — trip identifier used by the confirmation cache (default ``default``).
+- ``update_period`` — minimum seconds between corridor rescans (default 30).
+- ``data="range=NNN"`` — full tank or water range in km before buffers (default 600).
+- ``data="wbgt=NN.N"`` — wet-bulb globe temperature in degrees Celsius for the foot-travel heat model (default 28).
+
+On-screen display
+-----------------
+
+The OSD draws a status panel showing:
+
+- remote mode (Off / Auto / Always) and whether remote planning is active;
+- the selected buffer and usable range;
+- the worst resupply gap along the route, with **WARN** when it exceeds usable range;
+- a desert consumption warning when arid remote planning applies;
+- water requirement and heat-stress level when foot-travel mode is enabled.
+
+The panel refreshes when the route changes (``attr_destination``) and on position updates, throttled by ``update_period``. Gap warnings are drawn in red.
+
+Registered commands
+-------------------
+
+The plugin registers these Navit commands (usable from OSD buttons, menus, or the command line):
+
+``navit_safety_toggle_remote``
+    Cycle remote mode: Off, then Auto, then Always, then Off.
+
+``navit_safety_confirm_poi``
+    Mark the nearest unconfirmed resupply POI as operational, store the confirmation in the SQLite cache, and recalculate the plan.
+
+``navit_safety_deny_poi``
+    Mark the nearest actionable POI as denied for the current trip and recalculate the plan as if that stop does not exist.
+
+``navit_safety_show_plan``
+    Speak the current plan summary through Navit's speech output.
+
+``navit_safety_toggle_foot``
+    Toggle foot-travel mode (water planning and heat-stress assessment).
+
+Example OSD button bindings:
+
+.. code-block:: xml
+
+   <osd type="button" command="navit_safety_toggle_remote" label="Remote"/>
+   <osd type="button" command="navit_safety_confirm_poi" label="Confirm POI"/>
+   <osd type="button" command="navit_safety_show_plan" label="Plan"/>
+
+See :doc:`how_it_works` for the planning pipeline and :doc:`codemap` for source locations.

--- a/docs/user/plugins/safety/how_it_works.rst
+++ b/docs/user/plugins/safety/how_it_works.rst
@@ -1,0 +1,135 @@
+How the Navit Safety plugin works
+=================================
+
+This page explains the plugin's planning pipeline and how the pieces fit
+together. For the full feature specification see :doc:`navit_safety`; for a
+file-by-file map see :doc:`codemap`.
+
+Pipeline overview
+-----------------
+
+The plugin turns POI reliability and terrain into a conservative resupply plan:
+
+1. **Configuration** provides the thresholds and buffers (conservative defaults).
+2. **POI confidence scoring** decides which stops may count as resupply.
+3. **Remote-mode detection** decides whether conservative planning applies.
+4. **Buffer selection** picks the standard, remote, or arid buffer.
+5. **Lookahead** finds the worst gap between reliable stops and warns if it
+   exceeds the usable range.
+6. **Confirmation cache** persists user confirmations across sessions.
+
+The orchestrator ``navit_safety_plan`` (in ``navit_safety_plan.c``) runs steps
+3 to 5 for a single resource (fuel or water).
+
+Configuration
+-------------
+
+``struct navit_safety_config`` (in ``navit_safety.h``) holds 16 fields;
+``navit_safety_config_default`` fills them with the spec defaults, for example
+remote mode Auto, fuel buffers 25 / 85 / 140 km and water buffers 5 / 20 /
+30 km. The defaults are intentionally cautious so users in populated areas
+rarely need to change anything.
+
+POI confidence scoring
+----------------------
+
+``navit_safety_score_poi`` (in ``navit_safety_confidence.c``) maps a POI's
+source and age to ``High``, ``Medium``, ``Low``, or ``Unknown``:
+
+- live chain operator APIs and NREL rank High;
+- an OSM/NREL match within 30 days is High, otherwise Medium;
+- iOverlander within 60 days is Medium, otherwise Low;
+- an OSM chain operator is Medium; an independent operator is Medium within 12
+  months and Low beyond that;
+- any source is capped at Low when the data is older than three years or the
+  POI is in a known depopulating region;
+- a user confirmation on the current trip overrides everything to High.
+
+Only ``Medium`` or ``High`` stops count as resupply
+(``navit_safety_confidence_counts_as_resupply``); ``Low`` and ``Unknown`` stops
+are planned around as if they did not exist.
+
+Remote-mode detection
+---------------------
+
+``navit_safety_koppen_lookup`` (in ``navit_safety_koppen.c``) classifies a
+coordinate into a Koppen zone using a compact, built-in table of the major arid
+belts. It is a coarse approximation, not a gridded Koppen-Geiger dataset.
+``navit_safety_koppen_triggers_remote`` returns true for any group-B
+(desert/semi-arid) zone.
+
+A second automatic signal is POI density: the orchestrator measures the average
+spacing between confirmed (Medium-or-higher) stops over the route, including the
+legs from the start to the first stop and from the last stop to the
+destination. When that spacing exceeds ``poi_density_threshold_km`` (halved for
+water on foot, matching the 80 km fuel / 40 km water defaults) the route is
+treated as sparse.
+
+The orchestrator then decides remote mode from the configuration:
+
+- **Always** — remote planning is always on;
+- **Auto** — remote planning is on when the Koppen trigger is enabled and the
+  sampled midpoint is a group-B zone, or when the POI density is sparse;
+- **Off** — remote planning is never auto-enabled.
+
+In arid remote planning the result also carries a desert consumption warning
+(gated by ``desert_consumption_warning``) noting that real consumption may
+exceed the kinematic model.
+
+Buffer selection and usable range
+---------------------------------
+
+With remote mode decided, the orchestrator selects the buffer: the arid buffer
+in desert zones (when remote is active), the remote buffer for other remote
+terrain, and the standard buffer in populated terrain. The usable range is the
+full tank or water load minus the selected buffer (never negative).
+
+Lookahead gap detection
+-----------------------
+
+``navit_safety_lookahead_plan`` (in ``navit_safety_lookahead.c``) walks the
+reliable stops in order and measures each leg, including the leg from the start
+to the first reliable stop and from the last reliable stop to the destination.
+It reports the largest gap, where it begins, whether it exceeds the usable
+range, and by how much (the shortfall). This is what allows a warning before
+departure rather than a discovery mid-journey.
+
+Heat stress and water (foot travel)
+-----------------------------------
+
+``navit_safety_heat.c`` provides the foot-travel model.
+``navit_safety_heat_assess`` maps a WBGT value to a risk level (caution at
+28 °C, warning at 32 °C, danger at 35 °C).
+``navit_safety_heat_water_ml_per_hour`` estimates water use from a resting term
+scaled by ``body_weight_kg``, an exertion term for strenuous activity, and a
+heat term above 25 °C. ``navit_safety_heat_plan`` combines these from the
+configuration: the water requirement always uses the configured body weight,
+while the risk level and the avoid-exertion flag are only reported when
+``heat_stress_warnings`` is enabled.
+
+Confirmation cache
+------------------
+
+``navit_safety_cache.c`` stores confirmations in an SQLite table keyed by POI
+and trip, so a stop the user verifies stays High for the rest of the trip and
+across sessions. The cache is optional and only compiled when SQLite3 is
+available (guarded by ``NAVIT_SAFETY_WITH_SQLITE``).
+
+Build-time guards
+-----------------
+
+- ``NAVIT_SAFETY_WITH_OSD`` — set to 1 for the plugin build and 0 for the
+  configuration unit test, so the OSD/core dependencies are compiled out of the
+  isolated test.
+- ``NAVIT_SAFETY_WITH_SQLITE`` — set when SQLite3 is found; gates the cache
+  source and its use in the OSD.
+
+Not yet wired
+-------------
+
+Chain operator API queries remain deferred (network client and API keys). The census depopulation dataset feed is not bundled (the scoring engine consumes a per-POI flag when callers supply it). The foot-travel temperature source is limited to manual WBGT via ``data="wbgt=..."`` on the OSD until a weather feed is integrated.
+
+Live integration (implemented)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the OSD is active, ``navit_safety_route.c`` scans the calculated route corridor (25 km sample spacing, 50 km total width), collects fuel or water POIs from the mapset, scores them, and calls ``navit_safety_plan``. The OSD redraws on route and position updates; the five ``navit_safety_*`` commands adjust mode, confirm or deny POIs, and speak the plan.

--- a/docs/user/plugins/safety/index.rst
+++ b/docs/user/plugins/safety/index.rst
@@ -1,0 +1,20 @@
+Plugins
+=======
+
+Navit includes the Navit Safety plugin, which extends Navit for remote and arid-region routing and resource planning.
+
+.. toctree::
+   :maxdepth: 1
+
+   navit_safety
+   how_it_works
+   commands
+   codemap
+   test_results
+
+Navit Safety Plugin
+-------------------
+
+The Navit Safety plugin provides POI confidence scoring, location-aware remote mode, and resource planning for desert driving and foot travel in arid or sparsely serviced terrain. It treats POI reliability as a first-class input and uses conservative buffers when route segments are in remote or desert regions.
+
+See :doc:`navit_safety` for complete documentation.

--- a/docs/user/plugins/safety/navit_safety.rst
+++ b/docs/user/plugins/safety/navit_safety.rst
@@ -1,0 +1,160 @@
+Navit Safety Plugin
+===================
+
+Overview
+--------
+
+The Navit Safety plugin addresses POI reliability and resource planning in remote, arid, or sparsely serviced terrain. In populated areas with good map coverage, finding fuel, water, or shelter is straightforward. In remote or depopulating regions, POI data cannot be trusted at face value: a fuel station on the map may have closed years ago; a spring may be seasonal or dry. This plugin treats POI reliability as a first-class input to resource planning and provides location-aware remote mode with conservative buffer thresholds.
+
+The plugin handles:
+
+- **POI confidence scoring** — Sources are ranked by reliability; only confirmed or reasonably recent POIs count as reliable resupply points.
+- **Location-aware remote mode** — Automatic detection via POI density, Köppen climate classification, and known sparse-region polygons; manual override available.
+- **Resource planning** — Fuel and water buffers, lookahead planning, carry capacity, and handling of unconfirmed stops for desert driving and foot travel.
+
+Core problem
+------------
+
+Map data (including OSM) reflects the world at last edit time, not necessarily today. In remote areas a POI may be years or decades stale. A closed fuel station 120 km into a desert crossing or a dry spring on a waterless stretch is a life-safety failure. The plugin does not count unverifiable POIs as reliable resupply in minimum-range calculations.
+
+POI confidence hierarchy
+-------------------------
+
+Confidence levels
+~~~~~~~~~~~~~~~~~
+
+- **High** — Confirmed operational from a live or recently verified authoritative source. Counts fully toward resupply; no extra buffer.
+- **Medium** — Likely operational from reasonably recent data but not independently verified. Counts toward resupply with a modest buffer increase.
+- **Low** — Exists in map data but operational status unverifiable or data is old. Does not count as reliable resupply; plugin plans as if the stop does not exist and warns.
+- **Unknown** — No usable metadata; treated as Low until confirmed.
+
+Source ranking (summary)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Live chain operator APIs (e.g. Shell, Circle K, NREL): High.
+- OSM cross-referenced with NREL (match within 30 days): Medium–High.
+- iOverlander CSV import, verified within 60 days: Medium–High (offline sync only).
+- OSM with known chain operator tag: Medium.
+- OSM independent operator, edited within 12 months: Medium–Low.
+- OSM independent operator, 1–3 years old: Low in remote areas.
+- OSM any operator, more than 3 years old: Low (high closure risk in depopulating areas).
+- OSM in known depopulating county/region: Very Low.
+- User-confirmed on current trip: High (overrides others until trip end).
+
+Chain operator APIs (with public or partner endpoints)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Shell** — https://developer.shell.com/api-catalog (OAuth 2.0, free developer account).
+- **Circle K** — https://www.developer.circlek.com/ (partner access).
+- **NREL Alternative Fuel Stations** (US/Canada) — https://developer.nrel.gov/docs/transportation/alt-fuel-stations-v1/ (free API key, conventional fuel, LPG, CNG, hydrogen, EV).
+
+Operators without public API (use OSM + operator name, and NREL where applicable): Esso/ExxonMobil, BP, Costco Fuel, Pilot/Flying J, Love's, TA/Petro, Uno-X, St1, Ampol, Caltex, 7-Eleven Fuel.
+
+Location-aware remote mode
+--------------------------
+
+Automatic detection
+~~~~~~~~~~~~~~~~~~~
+
+Remote mode activates when any of the following hold along the planned route:
+
+- **POI density** — Average spacing between confirmed Medium-or-higher POIs exceeds a threshold (default 80 km fuel, 40 km water on foot) in the route corridor (default 50 km width).
+- **Köppen climate** — Route segment midpoint in BWh, BWk, BSh, or BSk (hot/cold desert, hot/cold semi-arid). Uses a bundled lightweight Köppen–Geiger–derived dataset.
+- **Known sparse regions** — Route enters maintained bounding polygons for depopulation, remoteness, or difficult access (e.g. US Great Plains counties, Alaska highway, Australian Cape York/Kimberley, Nordic Finnmark/Hardangervidda/Svalbard, Central Asia corridors, Atacama/altiplano/Patagonia, Canadian northern highways). Custom regions configurable.
+- **Census/population layer** (optional) — US Census county-level population change; counties with >20% loss since 2000 trigger confidence downgrade. Similar datasets for Australia, Canada, Norway can be integrated.
+- **OSM terrain tags** — natural=desert, natural=scrub, etc. used as a supporting signal only; not primary trigger.
+
+Manual override
+~~~~~~~~~~~~~~~
+
+Remote mode can be forced on or off in the configuration UI (per-trip, not global): to force conservative planning, or to disable when auto-detection incorrectly flags a region.
+
+Resource planning in remote mode
+--------------------------------
+
+Buffer thresholds (defaults)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Standard: fuel 25 km, water (foot) 5 km.
+- Remote (auto): fuel 85 km, water 20 km.
+- Remote (arid/desert): fuel 140 km, water 30 km.
+- User-configured overrides available.
+
+Buffers apply to confirmed resupply points only. Low-confidence POIs do not reduce the buffer requirement.
+
+Lookahead planning
+~~~~~~~~~~~~~~~~~
+
+In remote mode the plugin scans the full route at calculation time, assigns confidence, and builds a resupply plan. If any gap between confirmed stops exceeds usable range (with buffer), it warns before departure. This allows carrying extra fuel or choosing an alternative route instead of discovering a long unserviced gap mid-journey.
+
+Carry capacity and desert warnings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a gap exceeds standard tank range, the plugin can indicate extra fuel (litres), need for jerry can/auxiliary tank, and weight impact on consumption. For desert conditions it warns that actual consumption may be higher than the kinematic model (AC load, high temperature, unpaved/sand Crr).
+
+Unconfirmed stops
+~~~~~~~~~~~~~~~~~
+
+Low-confidence POIs are shown with a distinct indicator (e.g. question mark or warning). The planning engine does not rely on them. If the user confirms a stop as operational during the trip, confidence is upgraded to High for the remainder and the plan is recalculated; the confirmation can be stored (e.g. SQLite) for future reference.
+
+Foot travel and water sources
+-----------------------------
+
+The same resource model applies with water in place of fuel. Water consumption can be estimated from body weight, temperature, exertion (grade/pace), and humidity. The plugin can apply a heat stress check (e.g. WBGT approximation): warn above 28°C WBGT for strenuous activity, strong warning above 32°C, and avoid planning sustained exertion above 35°C without explicit user override.
+
+OSM tags for water: amenity=drinking_water, natural=spring, man_made=water_well, amenity=water_point, amenity=shelter. Natural sources in arid regions may get a seasonal/drought downgrade.
+
+Configuration UI (Remote Planning section)
+------------------------------------------
+
+- **Remote mode** — Off / Auto-detect / Always on. Default: Auto-detect.
+- **POI density threshold** — km; default 80.
+- **Köppen classification trigger** — On/Off; default On.
+- **Fuel buffer (standard / remote / arid)** — km; defaults 25, 85, 140.
+- **Water buffer (standard / remote / arid)** — km; defaults 5, 20, 30.
+- **Desert consumption warning** — On/Off; default On.
+- **Census depopulation layer** — On/Off; default On where data available.
+- **Chain API queries** — On/Off; default On (disable for offline).
+- **Unconfirmed POI display** — Show/Hide; default Show with warning.
+- **Custom sparse regions** — User-defined bounding areas that always trigger remote mode.
+- **Foot travel mode** — Enables water source planning and water consumption model.
+- **Body weight** (foot) — kg for water calculation.
+- **Temperature source** (foot) — Weather feed or manual entry.
+- **Heat stress warnings** (foot) — On/Off; default On.
+
+Enabling the plugin
+-------------------
+
+Build with SQLite3 available (the optional dependency used for caching and user confirmations). Add the plugin to your Navit config and enable the OSD:
+
+- Load the plugin (e.g. in navit.xml or your config): ``<plugin path="$NAVIT_LIBDIR/plugin/${NAVIT_LIBPREFIX}libosd_navit_safety.so" .../>``
+- Add an OSD instance: ``<osd type="navit_safety" enabled="yes"/>``
+
+Data sources and licensing
+--------------------------
+
+- **NREL Alternative Fuel Stations** — US Government open data.
+- **Köppen–Geiger** (e.g. Beck et al., gloh2o.org/koppen) — Check dataset licence for bundling.
+- **OSM** — ODbL; credit OpenStreetMap contributors.
+- **iOverlander CSV** — CC BY-SA; offline import only.
+
+Implementation status
+---------------------
+
+The core planning engines are implemented and unit tested:
+
+- **POI confidence scoring** (``navit_safety_confidence.c``) — source ranking with age and depopulation downgrades.
+- **Köppen classification** (``navit_safety_koppen.c``) — zone trigger decision plus a coarse, built-in lat/lon lookup of the major arid belts (an approximation, not a gridded Köppen–Geiger dataset).
+- **Lookahead gap detection** (``navit_safety_lookahead.c``) — largest gap between confirmed (Medium-or-higher) stops, with a pre-departure warning and shortfall.
+- **Resource planning** (``navit_safety_plan.c``) — selects standard/remote/arid buffers from terrain and remote mode, triggers remote mode on POI density (``poi_density_threshold_km``, halved for water) as well as climate, and raises the desert consumption warning (``desert_consumption_warning``) in arid remote planning, then runs lookahead.
+- **Heat stress and water** (``navit_safety_heat.c``) — WBGT-based heat-illness level (caution 28 °C, warning 32 °C, danger 35 °C) and a water requirement from ``body_weight_kg``, heat, and exertion; the level is gated by ``heat_stress_warnings``.
+- **Confirmation cache** (``navit_safety_cache.c``) — SQLite persistence of user-confirmed POIs (built only when SQLite3 is available).
+
+Still deferred (require external data or network access the plugin does not bundle): chain operator API queries (network client and keys), custom sparse-region polygons, the census depopulation dataset feed, and an automatic weather feed for foot-travel WBGT (manual ``data="wbgt=..."`` on the OSD is supported).
+
+Live route integration is implemented: the OSD scans the calculated route corridor, runs the planning engines, draws the status panel, and exposes five interactive commands.
+
+Notes
+-----
+
+The conservative defaults are intentional. In remote areas, erring on the side of caution is justified; users can reduce buffers in the UI if needed. Automatic detection is designed so that most users in populated areas never need to change settings; remote mode activates only when the route enters sparse or arid terrain.

--- a/docs/user/plugins/safety/test_results.rst
+++ b/docs/user/plugins/safety/test_results.rst
@@ -1,0 +1,103 @@
+Test results
+============
+
+This page records the unit test status of the Navit Safety plugin. The tests
+cover the pure planning engines and the route-state helpers in isolation, with
+no dependency on the Navit core or a display.
+
+How to reproduce
+----------------
+
+.. code-block:: sh
+
+   cmake -S . -B build -DBUILD_NAVIT_SAFETY_TESTS=ON
+   cmake --build build -j"$(nproc)"
+   ctest --test-dir build/navit/plugin/navit_safety/tests --output-on-failure
+
+The confirmation cache suite is built and run only when SQLite3 is available.
+
+Summary
+-------
+
+All suites pass: 8 of 8 test executables, 28 individual test cases, 0 failures.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 12 54
+
+   * - Suite
+     - Cases
+     - Coverage
+   * - ``test_navit_safety_config``
+     - 2
+     - Configuration defaults and NULL-argument safety.
+   * - ``test_navit_safety_confidence``
+     - 5
+     - Source ranking, age dependence, OSM operators, downgrades, resupply predicate.
+   * - ``test_navit_safety_koppen``
+     - 4
+     - Zone predicates, arid and non-arid lookup, code strings.
+   * - ``test_navit_safety_lookahead``
+     - 4
+     - No-stop warning, gap closing, low-confidence stops ignored, final-leg gap.
+   * - ``test_navit_safety_plan``
+     - 6
+     - Populated route, density trigger, arid buffer, desert-warning toggle, Koppen toggle, Always mode.
+   * - ``test_navit_safety_heat``
+     - 3
+     - WBGT thresholds, water formula, config-gated heat plan.
+   * - ``test_navit_safety_route``
+     - 2
+     - Stop-list builder (denied stops), idle status formatting.
+   * - ``test_navit_safety_cache``
+     - 2
+     - Confirm/query round-trips (in-memory DB), NULL safety. SQLite3 only.
+
+Latest run
+----------
+
+::
+
+   Test project build/navit/plugin/navit_safety/tests
+       Start 1: test_navit_safety_config
+   1/8 Test #1: test_navit_safety_config .........   Passed    0.00 sec
+       Start 2: test_navit_safety_confidence
+   2/8 Test #2: test_navit_safety_confidence .....   Passed    0.00 sec
+       Start 3: test_navit_safety_koppen
+   3/8 Test #3: test_navit_safety_koppen .........   Passed    0.00 sec
+       Start 4: test_navit_safety_lookahead
+   4/8 Test #4: test_navit_safety_lookahead ......   Passed    0.00 sec
+       Start 5: test_navit_safety_plan
+   5/8 Test #5: test_navit_safety_plan ...........   Passed    0.00 sec
+       Start 6: test_navit_safety_heat
+   6/8 Test #6: test_navit_safety_heat ...........   Passed    0.00 sec
+       Start 7: test_navit_safety_route
+   7/8 Test #7: test_navit_safety_route ..........   Passed    0.00 sec
+       Start 8: test_navit_safety_cache
+   8/8 Test #8: test_navit_safety_cache ..........   Passed    0.00 sec
+
+   100% tests passed, 0 tests failed out of 8
+
+Plugin compile check
+--------------------
+
+Beyond the unit tests, the shared object is built against the Navit core to
+confirm the OSD, command table, and route-corridor integration link correctly::
+
+   cmake --build build --target plugin_navit_safety
+   ... Linking C shared module libosd_navit_safety.so
+   ... Built target plugin_navit_safety
+
+What the tests do not cover
+---------------------------
+
+The unit tests exercise logic that runs without a display or map. The following
+require a running Navit instance with graphics and a loaded mapset and are
+verified by the compile check plus manual testing, not by ctest:
+
+- OSD drawing and redraw callbacks.
+- The five registered commands (``navit_safety_toggle_remote`` and friends).
+- Live mapset corridor scanning in ``navit_safety_route_refresh``.
+
+See :doc:`codemap` for the source layout and :doc:`how_it_works` for the
+behaviour under test.

--- a/navit/plugin/navit_safety/CMakeLists.txt
+++ b/navit/plugin/navit_safety/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Navit Safety plugin: POI confidence, remote mode, resource planning for desert/arid travel.
+
+# Pure planning engines (no Navit core or SQLite dependency).
+set(NAVIT_SAFETY_SOURCES
+    navit_safety.c
+    navit_safety_confidence.c
+    navit_safety_koppen.c
+    navit_safety_lookahead.c
+    navit_safety_plan.c
+    navit_safety_heat.c
+    navit_safety_route.c
+)
+
+# SQLite backs the optional user-confirmation cache.
+if(SQLITE3_FOUND)
+    list(APPEND NAVIT_SAFETY_SOURCES navit_safety_cache.c)
+    set(plugin_navit_safety_LIBS ${SQLITE3_LIBRARIES})
+    set(plugin_navit_safety_INCLUDES ${SQLITE3_INCLUDE_DIRS})
+    if(SQLITE3_CFLAGS_OTHER)
+        set(plugin_navit_safety_FLAGS ${SQLITE3_CFLAGS_OTHER})
+    endif()
+endif()
+
+module_add_library(plugin_navit_safety ${NAVIT_SAFETY_SOURCES})
+
+# Scope the OSD guard to the plugin target only so it does not leak into the
+# tests subdirectory (which compiles navit_safety.c with NAVIT_SAFETY_WITH_OSD=0).
+# An explicit value keeps the arithmetic guard `#if NAVIT_SAFETY_WITH_OSD` unambiguous.
+target_compile_definitions(plugin_navit_safety PRIVATE NAVIT_SAFETY_WITH_OSD=1)
+if(SQLITE3_FOUND)
+    target_compile_definitions(plugin_navit_safety PRIVATE NAVIT_SAFETY_WITH_SQLITE=1)
+endif()
+
+# Output name for Navit OSD lookup: libosd_navit_safety.so
+set_target_properties(plugin_navit_safety PROPERTIES
+    C_VISIBILITY_PRESET default
+    VISIBILITY_INLINES_HIDDEN 0
+    OUTPUT_NAME "osd_navit_safety"
+    PREFIX "lib"
+)
+
+# Unit tests for Navit Safety plugin
+option(BUILD_NAVIT_SAFETY_TESTS "Build Navit Safety plugin unit tests" ON)
+if(BUILD_NAVIT_SAFETY_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/navit/plugin/navit_safety/navit_safety.c
+++ b/navit/plugin/navit_safety/navit_safety.c
@@ -1,0 +1,436 @@
+/**
+ * @file navit_safety.c
+ * @brief Navit Safety plugin: POI confidence, remote mode, resource planning for desert/arid travel.
+ *
+ * Handles POI confidence scoring, location-aware remote mode activation, and
+ * resource planning (fuel/water) for desert driving and foot travel in arid or
+ * sparsely serviced terrain. See docs/user/plugins/navit_safety.rst for full spec.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include <string.h>
+#include "navit_safety.h"
+
+/**
+ * @brief Set configuration to spec defaults.
+ * @param config Configuration structure to fill (ignored if NULL)
+ */
+void navit_safety_config_default(struct navit_safety_config *config) {
+    if (!config)
+        return;
+    memset(config, 0, sizeof(*config));
+    config->remote_mode = NAVIT_SAFETY_REMOTE_AUTO;
+    config->poi_density_threshold_km = 80;
+    config->koppen_trigger = 1;
+    config->fuel_buffer_standard_km = 25;
+    config->fuel_buffer_remote_km = 85;
+    config->fuel_buffer_arid_km = 140;
+    config->water_buffer_standard_km = 5;
+    config->water_buffer_remote_km = 20;
+    config->water_buffer_arid_km = 30;
+    config->desert_consumption_warning = 1;
+    config->census_depopulation_layer = 1;
+    config->chain_api_queries = 1;
+    config->unconfirmed_poi_display = 1;
+    config->foot_travel_mode = 0;
+    config->body_weight_kg = 70;
+    config->heat_stress_warnings = 1;
+}
+
+/* The following definitions are only needed when building Navit itself.
+ * Unit tests for configuration defaults link only against navit_safety_config_default. */
+#if NAVIT_SAFETY_WITH_OSD
+
+#include <math.h>
+#include <stdio.h>
+#include <sys/time.h>
+#include <glib.h>
+#include "attr.h"
+#include "callback.h"
+#include "color.h"
+#include "command.h"
+#include "coord.h"
+#include "debug.h"
+#include "graphics.h"
+#include "navit.h"
+#include "navit_nls.h"
+#include "osd.h"
+#include "plugin.h"
+#include "point.h"
+#include "vehicle.h"
+#include "xmlconfig.h"
+#include "navit_safety_route.h"
+#if NAVIT_SAFETY_WITH_SQLITE
+#include "navit_safety_cache.h"
+#endif
+
+#define NAVIT_SAFETY_DEFAULT_RANGE_KM 600
+#define NAVIT_SAFETY_DEFAULT_UPDATE_S 30
+#define NAVIT_SAFETY_DEFAULT_WBGT_C 28.0
+
+/** @brief OSD private data; @p item must remain the first member. */
+struct navit_safety_priv {
+    struct osd_item item;
+    struct navit *nav;
+    struct navit_safety_config config;
+    struct navit_safety_route_state route_state;
+    int active;
+    int full_range_km;
+    int update_period;
+    double wbgt_c;
+    double last_refresh;
+    int width;
+    struct graphics_gc *warn_gc;
+    char trip_id[64];
+#if NAVIT_SAFETY_WITH_SQLITE
+    struct navit_safety_cache *cache;
+#endif
+};
+
+static GList *navit_safety_instances;
+static int navit_safety_commands_registered;
+
+#if NAVIT_SAFETY_WITH_SQLITE
+static struct navit_safety_cache *navit_safety_open_cache(void) {
+    struct navit_safety_cache *cache;
+    char *path;
+
+    path = g_build_filename(g_get_home_dir(), ".navit", "navit_safety.db", NULL);
+    cache = navit_safety_cache_open(path);
+    if (!cache)
+        dbg(lvl_warning, "Navit Safety: could not open confirmation cache at %s", path);
+    g_free(path);
+    return cache;
+}
+#endif
+
+static double navit_safety_now(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
+}
+
+static int navit_safety_vehicle_geo(struct vehicle *v, double *lat, double *lon) {
+    struct attr pos;
+
+    if (!v || !lat || !lon)
+        return 0;
+    if (!vehicle_get_attr(v, attr_position_coord_geo, &pos, NULL))
+        return 0;
+    *lat = pos.u.coord_geo->lat;
+    *lon = pos.u.coord_geo->lng;
+    return 1;
+}
+
+static void navit_safety_refresh(struct navit_safety_priv *priv, struct vehicle *v, int force) {
+    double lat = NAN;
+    double lon = NAN;
+    double now;
+
+    if (!priv || !priv->active)
+        return;
+    now = navit_safety_now();
+    if (!force && priv->last_refresh > 0.0 && now - priv->last_refresh < priv->update_period)
+        return;
+    navit_safety_vehicle_geo(v, &lat, &lon);
+    navit_safety_route_refresh(&priv->route_state, priv->nav, &priv->config,
+#if NAVIT_SAFETY_WITH_SQLITE
+                               priv->cache,
+#else
+                               NULL,
+#endif
+                               priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon);
+    priv->last_refresh = now;
+}
+
+static void navit_safety_draw_text_lines(struct navit_safety_priv *priv, const char *text,
+                                         struct graphics_gc *gc) {
+    char *copy;
+    char *line;
+    char *save;
+    struct point p;
+    int y;
+
+    if (!text || !priv->item.gr)
+        return;
+    copy = g_strdup(text);
+    p.x = 4;
+    y = 4;
+    line = strtok_r(copy, "\n", &save);
+    while (line) {
+        p.y = y;
+        graphics_draw_text(priv->item.gr, gc, NULL, priv->item.font, line, &p, 0x10000, 0);
+        y += priv->item.font_size / 50 + 12;
+        line = strtok_r(NULL, "\n", &save);
+    }
+    g_free(copy);
+}
+
+static void navit_safety_osd_draw(struct osd_priv *osd, struct navit *nav, struct vehicle *v) {
+    struct navit_safety_priv *priv = (struct navit_safety_priv *)osd;
+    struct graphics_gc *gc;
+
+    if (!priv || !priv->item.configured)
+        return;
+
+    navit_safety_refresh(priv, v, 0);
+    osd_fill_with_bgcolor(&priv->item);
+
+    gc = priv->item.graphic_fg;
+    if (priv->route_state.valid && priv->route_state.fuel_plan.gap.warning && priv->warn_gc)
+        gc = priv->warn_gc;
+
+    navit_safety_draw_text_lines(priv, priv->route_state.status, gc);
+    graphics_draw_mode(priv->item.gr, draw_mode_end);
+}
+
+static void navit_safety_osd_init(struct osd_priv *osd, struct navit *nav) {
+    struct navit_safety_priv *priv = (struct navit_safety_priv *)osd;
+    struct color warn_color = {0xffff, 0x4000, 0x0000, 0xffff};
+
+    osd_set_std_graphic(nav, &priv->item, (struct osd_priv *)priv);
+    priv->item.graphic_fg = graphics_gc_new(priv->item.gr);
+    graphics_gc_set_foreground(priv->item.graphic_fg, &priv->item.text_color);
+    graphics_gc_set_linewidth(priv->item.graphic_fg, priv->width);
+    priv->warn_gc = graphics_gc_new(priv->item.gr);
+    graphics_gc_set_foreground(priv->warn_gc, &warn_color);
+    graphics_gc_set_linewidth(priv->warn_gc, priv->width);
+
+    navit_add_callback(nav, callback_new_attr_1(callback_cast(navit_safety_osd_draw), attr_destination, priv));
+    navit_add_callback(nav, callback_new_attr_1(callback_cast(navit_safety_osd_draw), attr_position_coord_geo, priv));
+    navit_safety_refresh(priv, NULL, 1);
+    navit_safety_osd_draw((struct osd_priv *)priv, nav, NULL);
+}
+
+static void navit_safety_apply_attr(struct navit_safety_priv *priv, struct attr *attr) {
+    if (!priv || !attr)
+        return;
+    if (attr->type == attr_update_period) {
+        priv->update_period = attr->u.num > 0 ? attr->u.num : NAVIT_SAFETY_DEFAULT_UPDATE_S;
+        return;
+    }
+    if (attr->type == attr_label && attr->u.str) {
+        g_strlcpy(priv->trip_id, attr->u.str, sizeof(priv->trip_id));
+        return;
+    }
+    if (attr->type == attr_data && attr->u.str) {
+        if (!strncmp(attr->u.str, "wbgt=", 5))
+            priv->wbgt_c = g_ascii_strtod(attr->u.str + 5, NULL);
+        else if (!strncmp(attr->u.str, "range=", 6))
+            priv->full_range_km = (int)g_ascii_strtod(attr->u.str + 6, NULL);
+        return;
+    }
+}
+
+static void navit_safety_parse_attrs(struct navit_safety_priv *priv, struct attr **attrs) {
+    int i;
+
+    osd_set_std_attr(attrs, &priv->item, ITEM_HAS_TEXT | TRANSPARENT_BG);
+    priv->full_range_km = NAVIT_SAFETY_DEFAULT_RANGE_KM;
+    priv->update_period = NAVIT_SAFETY_DEFAULT_UPDATE_S;
+    priv->wbgt_c = NAVIT_SAFETY_DEFAULT_WBGT_C;
+    g_strlcpy(priv->trip_id, "default", sizeof(priv->trip_id));
+    priv->width = 2;
+
+    if (attrs) {
+        for (i = 0; attrs[i]; i++)
+            navit_safety_apply_attr(priv, attrs[i]);
+    }
+}
+
+static void navit_safety_osd_destroy(struct osd_priv *osd) {
+    struct navit_safety_priv *priv = (struct navit_safety_priv *)osd;
+
+    if (!priv)
+        return;
+    priv->active = 0;
+    navit_safety_instances = g_list_remove(navit_safety_instances, priv);
+    navit_safety_route_state_clear(&priv->route_state);
+#if NAVIT_SAFETY_WITH_SQLITE
+    navit_safety_cache_close(priv->cache);
+    priv->cache = NULL;
+#endif
+    g_free(priv);
+}
+
+static int navit_safety_osd_set_attr(struct osd_priv *osd, struct attr *attr) {
+    struct navit_safety_priv *priv = (struct navit_safety_priv *)osd;
+    navit_safety_apply_attr(priv, attr);
+    navit_safety_refresh(priv, NULL, 1);
+    return 1;
+}
+
+static struct navit_safety_priv *navit_safety_from_navit(struct navit *nav) {
+    GList *l;
+
+    for (l = navit_safety_instances; l; l = l->next) {
+        struct navit_safety_priv *priv = l->data;
+        if (priv->nav == nav)
+            return priv;
+    }
+    return NULL;
+}
+
+static int navit_safety_cmd_toggle_remote(void *data, char *cmd, struct attr **in, struct attr ***out) {
+    struct navit_safety_priv *priv = navit_safety_from_navit((struct navit *)data);
+    (void)cmd;
+    (void)in;
+    (void)out;
+    if (!priv)
+        return -1;
+    priv->config.remote_mode = (priv->config.remote_mode + 1) % 3;
+    navit_safety_refresh(priv, NULL, 1);
+    navit_say(priv->nav, _("Remote mode updated"));
+    return 0;
+}
+
+static int navit_safety_cmd_confirm_poi(void *data, char *cmd, struct attr **in, struct attr ***out) {
+    struct navit_safety_priv *priv = navit_safety_from_navit((struct navit *)data);
+    struct attr vehicle_attr;
+    struct vehicle *v = NULL;
+    double lat = NAN;
+    double lon = NAN;
+    (void)cmd;
+    (void)in;
+    (void)out;
+    if (!priv)
+        return -1;
+    if (navit_get_attr(priv->nav, attr_vehicle, &vehicle_attr, NULL))
+        v = vehicle_attr.u.vehicle;
+    navit_safety_vehicle_geo(v, &lat, &lon);
+    if (navit_safety_route_confirm_nearest(&priv->route_state, priv->nav, &priv->config,
+#if NAVIT_SAFETY_WITH_SQLITE
+                                           priv->cache,
+#else
+                                           NULL,
+#endif
+                                           priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon) != 0) {
+        navit_say(priv->nav, _("No POI to confirm"));
+        return -1;
+    }
+    navit_say(priv->nav, _("POI confirmed"));
+    return 0;
+}
+
+static int navit_safety_cmd_deny_poi(void *data, char *cmd, struct attr **in, struct attr ***out) {
+    struct navit_safety_priv *priv = navit_safety_from_navit((struct navit *)data);
+    struct attr vehicle_attr;
+    struct vehicle *v = NULL;
+    double lat = NAN;
+    double lon = NAN;
+    (void)cmd;
+    (void)in;
+    (void)out;
+    if (!priv)
+        return -1;
+    if (navit_get_attr(priv->nav, attr_vehicle, &vehicle_attr, NULL))
+        v = vehicle_attr.u.vehicle;
+    navit_safety_vehicle_geo(v, &lat, &lon);
+    if (navit_safety_route_deny_nearest(&priv->route_state, priv->nav, &priv->config,
+#if NAVIT_SAFETY_WITH_SQLITE
+                                        priv->cache,
+#else
+                                        NULL,
+#endif
+                                        priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon) != 0) {
+        navit_say(priv->nav, _("No POI to deny"));
+        return -1;
+    }
+    navit_say(priv->nav, _("POI denied for this trip"));
+    return 0;
+}
+
+static int navit_safety_cmd_show_plan(void *data, char *cmd, struct attr **in, struct attr ***out) {
+    struct navit_safety_priv *priv = navit_safety_from_navit((struct navit *)data);
+    (void)cmd;
+    (void)in;
+    (void)out;
+    if (!priv)
+        return -1;
+    navit_safety_refresh(priv, NULL, 1);
+    if (!priv->route_state.valid) {
+        navit_say(priv->nav, _("No active route to plan"));
+        return -1;
+    }
+    navit_say(priv->nav, priv->route_state.status);
+    return 0;
+}
+
+static int navit_safety_cmd_toggle_foot(void *data, char *cmd, struct attr **in, struct attr ***out) {
+    struct navit_safety_priv *priv = navit_safety_from_navit((struct navit *)data);
+    (void)cmd;
+    (void)in;
+    (void)out;
+    if (!priv)
+        return -1;
+    priv->config.foot_travel_mode = !priv->config.foot_travel_mode;
+    navit_safety_refresh(priv, NULL, 1);
+    navit_say(priv->nav, priv->config.foot_travel_mode ? _("Foot travel enabled") : _("Foot travel disabled"));
+    return 0;
+}
+
+static struct command_table navit_safety_commands[] = {
+    {"navit_safety_toggle_remote", command_cast(navit_safety_cmd_toggle_remote)},
+    {"navit_safety_confirm_poi",   command_cast(navit_safety_cmd_confirm_poi)  },
+    {"navit_safety_deny_poi",      command_cast(navit_safety_cmd_deny_poi)     },
+    {"navit_safety_show_plan",     command_cast(navit_safety_cmd_show_plan)    },
+    {"navit_safety_toggle_foot",   command_cast(navit_safety_cmd_toggle_foot)  },
+};
+
+static struct osd_methods navit_safety_osd_meth;
+
+static struct osd_priv *navit_safety_osd_new(struct navit *nav, struct osd_methods *meth, struct attr **attrs) {
+    struct navit_safety_priv *priv;
+
+    if (!nav) {
+        dbg(lvl_error, "Navit Safety: osd_new called with NULL nav");
+        return NULL;
+    }
+
+    priv = g_new0(struct navit_safety_priv, 1);
+    navit_safety_route_state_init(&priv->route_state);
+    priv->item.navit = nav;
+    priv->item.rel_x = 10;
+    priv->item.rel_y = 10;
+    priv->item.rel_w = 220;
+    priv->item.rel_h = 120;
+    priv->item.font_size = 180;
+    priv->item.meth.draw = osd_draw_cast(navit_safety_osd_draw);
+    priv->nav = nav;
+    priv->active = 1;
+    navit_safety_config_default(&priv->config);
+    navit_safety_parse_attrs(priv, attrs);
+#if NAVIT_SAFETY_WITH_SQLITE
+    priv->cache = navit_safety_open_cache();
+#endif
+
+    navit_safety_osd_meth.osd_destroy = navit_safety_osd_destroy;
+    navit_safety_osd_meth.set_attr = navit_safety_osd_set_attr;
+    navit_safety_osd_meth.destroy = navit_safety_osd_destroy;
+    navit_safety_osd_meth.get_attr = NULL;
+    *meth = navit_safety_osd_meth;
+
+    if (!navit_safety_commands_registered) {
+        navit_command_add_table(nav, navit_safety_commands, sizeof(navit_safety_commands) / sizeof(struct command_table));
+        navit_safety_commands_registered = 1;
+    }
+    navit_safety_instances = g_list_append(navit_safety_instances, priv);
+    navit_add_callback(nav, callback_new_attr_1(callback_cast(navit_safety_osd_init), attr_graphics_ready, priv));
+
+    dbg(lvl_info, "Navit Safety plugin: OSD initialized (remote_mode=%d, fuel_buffer_remote=%d km)",
+        priv->config.remote_mode, priv->config.fuel_buffer_remote_km);
+
+    return (struct osd_priv *)priv;
+}
+
+void plugin_init(void) {
+    dbg(lvl_debug, "Navit Safety plugin initializing");
+    plugin_register_category_osd("navit_safety", navit_safety_osd_new);
+}
+
+#endif /* NAVIT_SAFETY_WITH_OSD */

--- a/navit/plugin/navit_safety/navit_safety.c
+++ b/navit/plugin/navit_safety/navit_safety.c
@@ -13,8 +13,8 @@
  * as published by the Free Software Foundation.
  */
 
-#include <string.h>
 #include "navit_safety.h"
+#include <string.h>
 
 /**
  * @brief Set configuration to spec defaults.
@@ -46,32 +46,32 @@ void navit_safety_config_default(struct navit_safety_config *config) {
  * Unit tests for configuration defaults link only against navit_safety_config_default. */
 #if NAVIT_SAFETY_WITH_OSD
 
-#include <math.h>
-#include <stdio.h>
-#include <sys/time.h>
-#include <glib.h>
-#include "attr.h"
-#include "callback.h"
-#include "color.h"
-#include "command.h"
-#include "coord.h"
-#include "debug.h"
-#include "graphics.h"
-#include "navit.h"
-#include "navit_nls.h"
-#include "osd.h"
-#include "plugin.h"
-#include "point.h"
-#include "vehicle.h"
-#include "xmlconfig.h"
-#include "navit_safety_route.h"
-#if NAVIT_SAFETY_WITH_SQLITE
-#include "navit_safety_cache.h"
-#endif
+#    include "attr.h"
+#    include "callback.h"
+#    include "color.h"
+#    include "command.h"
+#    include "coord.h"
+#    include "debug.h"
+#    include "graphics.h"
+#    include "navit.h"
+#    include "navit_nls.h"
+#    include "navit_safety_route.h"
+#    include "osd.h"
+#    include "plugin.h"
+#    include "point.h"
+#    include "vehicle.h"
+#    include "xmlconfig.h"
+#    include <glib.h>
+#    include <math.h>
+#    include <stdio.h>
+#    include <sys/time.h>
+#    if NAVIT_SAFETY_WITH_SQLITE
+#        include "navit_safety_cache.h"
+#    endif
 
-#define NAVIT_SAFETY_DEFAULT_RANGE_KM 600
-#define NAVIT_SAFETY_DEFAULT_UPDATE_S 30
-#define NAVIT_SAFETY_DEFAULT_WBGT_C 28.0
+#    define NAVIT_SAFETY_DEFAULT_RANGE_KM 600
+#    define NAVIT_SAFETY_DEFAULT_UPDATE_S 30
+#    define NAVIT_SAFETY_DEFAULT_WBGT_C 28.0
 
 /** @brief OSD private data; @p item must remain the first member. */
 struct navit_safety_priv {
@@ -87,15 +87,15 @@ struct navit_safety_priv {
     int width;
     struct graphics_gc *warn_gc;
     char trip_id[64];
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
     struct navit_safety_cache *cache;
-#endif
+#    endif
 };
 
 static GList *navit_safety_instances;
 static int navit_safety_commands_registered;
 
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
 static struct navit_safety_cache *navit_safety_open_cache(void) {
     struct navit_safety_cache *cache;
     char *path;
@@ -107,7 +107,7 @@ static struct navit_safety_cache *navit_safety_open_cache(void) {
     g_free(path);
     return cache;
 }
-#endif
+#    endif
 
 static double navit_safety_now(void) {
     struct timeval tv;
@@ -139,17 +139,16 @@ static void navit_safety_refresh(struct navit_safety_priv *priv, struct vehicle 
         return;
     navit_safety_vehicle_geo(v, &lat, &lon);
     navit_safety_route_refresh(&priv->route_state, priv->nav, &priv->config,
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
                                priv->cache,
-#else
+#    else
                                NULL,
-#endif
+#    endif
                                priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon);
     priv->last_refresh = now;
 }
 
-static void navit_safety_draw_text_lines(struct navit_safety_priv *priv, const char *text,
-                                         struct graphics_gc *gc) {
+static void navit_safety_draw_text_lines(struct navit_safety_priv *priv, const char *text, struct graphics_gc *gc) {
     char *copy;
     char *line;
     char *save;
@@ -251,10 +250,10 @@ static void navit_safety_osd_destroy(struct osd_priv *osd) {
     priv->active = 0;
     navit_safety_instances = g_list_remove(navit_safety_instances, priv);
     navit_safety_route_state_clear(&priv->route_state);
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
     navit_safety_cache_close(priv->cache);
     priv->cache = NULL;
-#endif
+#    endif
     g_free(priv);
 }
 
@@ -304,12 +303,13 @@ static int navit_safety_cmd_confirm_poi(void *data, char *cmd, struct attr **in,
         v = vehicle_attr.u.vehicle;
     navit_safety_vehicle_geo(v, &lat, &lon);
     if (navit_safety_route_confirm_nearest(&priv->route_state, priv->nav, &priv->config,
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
                                            priv->cache,
-#else
+#    else
                                            NULL,
-#endif
-                                           priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon) != 0) {
+#    endif
+                                           priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon)
+        != 0) {
         navit_say(priv->nav, _("No POI to confirm"));
         return -1;
     }
@@ -332,12 +332,13 @@ static int navit_safety_cmd_deny_poi(void *data, char *cmd, struct attr **in, st
         v = vehicle_attr.u.vehicle;
     navit_safety_vehicle_geo(v, &lat, &lon);
     if (navit_safety_route_deny_nearest(&priv->route_state, priv->nav, &priv->config,
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
                                         priv->cache,
-#else
+#    else
                                         NULL,
-#endif
-                                        priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon) != 0) {
+#    endif
+                                        priv->trip_id, priv->full_range_km, priv->wbgt_c, lat, lon)
+        != 0) {
         navit_say(priv->nav, _("No POI to deny"));
         return -1;
     }
@@ -405,9 +406,9 @@ static struct osd_priv *navit_safety_osd_new(struct navit *nav, struct osd_metho
     priv->active = 1;
     navit_safety_config_default(&priv->config);
     navit_safety_parse_attrs(priv, attrs);
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
     priv->cache = navit_safety_open_cache();
-#endif
+#    endif
 
     navit_safety_osd_meth.osd_destroy = navit_safety_osd_destroy;
     navit_safety_osd_meth.set_attr = navit_safety_osd_set_attr;
@@ -416,7 +417,8 @@ static struct osd_priv *navit_safety_osd_new(struct navit *nav, struct osd_metho
     *meth = navit_safety_osd_meth;
 
     if (!navit_safety_commands_registered) {
-        navit_command_add_table(nav, navit_safety_commands, sizeof(navit_safety_commands) / sizeof(struct command_table));
+        navit_command_add_table(nav, navit_safety_commands,
+                                sizeof(navit_safety_commands) / sizeof(struct command_table));
         navit_safety_commands_registered = 1;
     }
     navit_safety_instances = g_list_append(navit_safety_instances, priv);

--- a/navit/plugin/navit_safety/navit_safety.h
+++ b/navit/plugin/navit_safety/navit_safety.h
@@ -1,0 +1,66 @@
+/**
+ * @file navit_safety.h
+ * @brief Public configuration types for the Navit Safety plugin.
+ *
+ * This header exposes configuration structures and enums used by the
+ * Navit Safety plugin so they can be tested and, if needed, reused by
+ * other components.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_H
+
+/** @brief Remote mode: off, auto-detect, or always on */
+enum navit_safety_remote_mode {
+    NAVIT_SAFETY_REMOTE_OFF = 0,
+    NAVIT_SAFETY_REMOTE_AUTO = 1,
+    NAVIT_SAFETY_REMOTE_ALWAYS = 2
+};
+
+/** @brief Plugin configuration (defaults per spec) */
+struct navit_safety_config {
+    int remote_mode;                /**< Off / Auto / Always; default Auto */
+    int poi_density_threshold_km;   /**< Inter-POI spacing above which remote activates; default 80 */
+    int koppen_trigger;             /**< Use Köppen climate zone; default 1 */
+    int fuel_buffer_standard_km;    /**< Standard fuel buffer; default 25 */
+    int fuel_buffer_remote_km;      /**< Remote fuel buffer; default 85 */
+    int fuel_buffer_arid_km;        /**< Arid/desert fuel buffer; default 140 */
+    int water_buffer_standard_km;   /**< Standard water buffer (foot); default 5 */
+    int water_buffer_remote_km;     /**< Remote water buffer; default 20 */
+    int water_buffer_arid_km;       /**< Arid water buffer; default 30 */
+    int desert_consumption_warning; /**< Warn when desert conditions increase consumption; default 1 */
+    int census_depopulation_layer;  /**< Downgrade POIs in depopulating counties; default 1 */
+    int chain_api_queries;          /**< Query chain operator APIs at plan time; default 1 */
+    int unconfirmed_poi_display;    /**< Show low-confidence POIs with warning; default 1 */
+    int foot_travel_mode;           /**< Enable water source planning; default 0 */
+    int body_weight_kg;             /**< For water consumption (foot); default 70. Integer kg granularity;
+                                         a float would give finer resolution once the water consumption
+                                         model is implemented (tradeoff: simpler config vs precision). */
+    int heat_stress_warnings;       /**< WBGT-based heat illness warnings; default 1 */
+    /* Planning engines: navit_safety_confidence.c (POI confidence scoring),
+     * navit_safety_koppen.c (climate-zone classification, consumes
+     * koppen_trigger above), navit_safety_lookahead.c (gap detection and
+     * departure warnings), navit_safety_plan.c (resource orchestration,
+     * consuming poi_density_threshold_km and desert_consumption_warning),
+     * navit_safety_heat.c (WBGT heat stress and foot-travel water, consuming
+     * body_weight_kg and heat_stress_warnings), and navit_safety_cache.c
+     * (SQLite confirmation cache).
+     * TODO(deferred): items still out of scope:
+     *   - chain operator API queries (network client, keys, offline fallback)
+     *   - custom sparse regions (user-defined bounding areas that always trigger remote mode)
+     *   - census_depopulation_layer data feed (engine consumes the per-POI flag; the dataset is not bundled)
+     *   - temperature source (foot travel): weather feed vs manual entry (WBGT may be set via osd data="wbgt=...") */
+};
+
+/** @brief Initialize configuration to default values. */
+void navit_safety_config_default(struct navit_safety_config *config);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_H */

--- a/navit/plugin/navit_safety/navit_safety_cache.c
+++ b/navit/plugin/navit_safety/navit_safety_cache.c
@@ -11,21 +11,20 @@
  * as published by the Free Software Foundation.
  */
 
-#include <stdlib.h>
-#include <sqlite3.h>
 #include "navit_safety_cache.h"
+#include <sqlite3.h>
+#include <stdlib.h>
 
 struct navit_safety_cache {
     sqlite3 *db;
 };
 
 static int cache_create_schema(sqlite3 *db) {
-    static const char *sql =
-        "CREATE TABLE IF NOT EXISTS poi_confirmations ("
-        "poi_id TEXT NOT NULL,"
-        "trip_id TEXT NOT NULL,"
-        "confirmed_at INTEGER NOT NULL,"
-        "PRIMARY KEY (poi_id, trip_id));";
+    static const char *sql = "CREATE TABLE IF NOT EXISTS poi_confirmations ("
+                             "poi_id TEXT NOT NULL,"
+                             "trip_id TEXT NOT NULL,"
+                             "confirmed_at INTEGER NOT NULL,"
+                             "PRIMARY KEY (poi_id, trip_id));";
     return sqlite3_exec(db, sql, NULL, NULL, NULL) == SQLITE_OK;
 }
 
@@ -60,11 +59,10 @@ void navit_safety_cache_close(struct navit_safety_cache *cache) {
     free(cache);
 }
 
-int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi_id,
-                               const char *trip_id, long timestamp) {
-    static const char *sql =
-        "INSERT OR REPLACE INTO poi_confirmations (poi_id, trip_id, confirmed_at) "
-        "VALUES (?, ?, ?);";
+int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi_id, const char *trip_id,
+                               long timestamp) {
+    static const char *sql = "INSERT OR REPLACE INTO poi_confirmations (poi_id, trip_id, confirmed_at) "
+                             "VALUES (?, ?, ?);";
     sqlite3_stmt *stmt = NULL;
     int ok = 0;
 
@@ -74,9 +72,9 @@ int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi
     if (sqlite3_prepare_v2(cache->db, sql, -1, &stmt, NULL) != SQLITE_OK)
         return 0;
 
-    if (sqlite3_bind_text(stmt, 1, poi_id, -1, SQLITE_TRANSIENT) == SQLITE_OK &&
-            sqlite3_bind_text(stmt, 2, trip_id, -1, SQLITE_TRANSIENT) == SQLITE_OK &&
-            sqlite3_bind_int64(stmt, 3, (sqlite3_int64)timestamp) == SQLITE_OK) {
+    if (sqlite3_bind_text(stmt, 1, poi_id, -1, SQLITE_TRANSIENT) == SQLITE_OK
+        && sqlite3_bind_text(stmt, 2, trip_id, -1, SQLITE_TRANSIENT) == SQLITE_OK
+        && sqlite3_bind_int64(stmt, 3, (sqlite3_int64)timestamp) == SQLITE_OK) {
         ok = sqlite3_step(stmt) == SQLITE_DONE;
     }
 
@@ -84,10 +82,8 @@ int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi
     return ok;
 }
 
-int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char *poi_id,
-                                    const char *trip_id) {
-    static const char *sql =
-        "SELECT 1 FROM poi_confirmations WHERE poi_id = ? AND trip_id = ? LIMIT 1;";
+int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char *poi_id, const char *trip_id) {
+    static const char *sql = "SELECT 1 FROM poi_confirmations WHERE poi_id = ? AND trip_id = ? LIMIT 1;";
     sqlite3_stmt *stmt = NULL;
     int confirmed = 0;
 
@@ -97,8 +93,8 @@ int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char
     if (sqlite3_prepare_v2(cache->db, sql, -1, &stmt, NULL) != SQLITE_OK)
         return 0;
 
-    if (sqlite3_bind_text(stmt, 1, poi_id, -1, SQLITE_TRANSIENT) == SQLITE_OK &&
-            sqlite3_bind_text(stmt, 2, trip_id, -1, SQLITE_TRANSIENT) == SQLITE_OK) {
+    if (sqlite3_bind_text(stmt, 1, poi_id, -1, SQLITE_TRANSIENT) == SQLITE_OK
+        && sqlite3_bind_text(stmt, 2, trip_id, -1, SQLITE_TRANSIENT) == SQLITE_OK) {
         confirmed = sqlite3_step(stmt) == SQLITE_ROW;
     }
 

--- a/navit/plugin/navit_safety/navit_safety_cache.c
+++ b/navit/plugin/navit_safety/navit_safety_cache.c
@@ -1,0 +1,107 @@
+/**
+ * @file navit_safety_cache.c
+ * @brief SQLite-backed confirmation cache implementation.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include <stdlib.h>
+#include <sqlite3.h>
+#include "navit_safety_cache.h"
+
+struct navit_safety_cache {
+    sqlite3 *db;
+};
+
+static int cache_create_schema(sqlite3 *db) {
+    static const char *sql =
+        "CREATE TABLE IF NOT EXISTS poi_confirmations ("
+        "poi_id TEXT NOT NULL,"
+        "trip_id TEXT NOT NULL,"
+        "confirmed_at INTEGER NOT NULL,"
+        "PRIMARY KEY (poi_id, trip_id));";
+    return sqlite3_exec(db, sql, NULL, NULL, NULL) == SQLITE_OK;
+}
+
+struct navit_safety_cache *navit_safety_cache_open(const char *path) {
+    struct navit_safety_cache *cache;
+
+    if (!path)
+        return NULL;
+
+    cache = calloc(1, sizeof(*cache));
+    if (!cache)
+        return NULL;
+
+    if (sqlite3_open(path, &cache->db) != SQLITE_OK || !cache->db) {
+        navit_safety_cache_close(cache);
+        return NULL;
+    }
+
+    if (!cache_create_schema(cache->db)) {
+        navit_safety_cache_close(cache);
+        return NULL;
+    }
+
+    return cache;
+}
+
+void navit_safety_cache_close(struct navit_safety_cache *cache) {
+    if (!cache)
+        return;
+    if (cache->db)
+        sqlite3_close(cache->db);
+    free(cache);
+}
+
+int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi_id,
+                               const char *trip_id, long timestamp) {
+    static const char *sql =
+        "INSERT OR REPLACE INTO poi_confirmations (poi_id, trip_id, confirmed_at) "
+        "VALUES (?, ?, ?);";
+    sqlite3_stmt *stmt = NULL;
+    int ok = 0;
+
+    if (!cache || !cache->db || !poi_id || !trip_id)
+        return 0;
+
+    if (sqlite3_prepare_v2(cache->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+
+    if (sqlite3_bind_text(stmt, 1, poi_id, -1, SQLITE_TRANSIENT) == SQLITE_OK &&
+            sqlite3_bind_text(stmt, 2, trip_id, -1, SQLITE_TRANSIENT) == SQLITE_OK &&
+            sqlite3_bind_int64(stmt, 3, (sqlite3_int64)timestamp) == SQLITE_OK) {
+        ok = sqlite3_step(stmt) == SQLITE_DONE;
+    }
+
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char *poi_id,
+                                    const char *trip_id) {
+    static const char *sql =
+        "SELECT 1 FROM poi_confirmations WHERE poi_id = ? AND trip_id = ? LIMIT 1;";
+    sqlite3_stmt *stmt = NULL;
+    int confirmed = 0;
+
+    if (!cache || !cache->db || !poi_id || !trip_id)
+        return 0;
+
+    if (sqlite3_prepare_v2(cache->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+        return 0;
+
+    if (sqlite3_bind_text(stmt, 1, poi_id, -1, SQLITE_TRANSIENT) == SQLITE_OK &&
+            sqlite3_bind_text(stmt, 2, trip_id, -1, SQLITE_TRANSIENT) == SQLITE_OK) {
+        confirmed = sqlite3_step(stmt) == SQLITE_ROW;
+    }
+
+    sqlite3_finalize(stmt);
+    return confirmed;
+}

--- a/navit/plugin/navit_safety/navit_safety_cache.h
+++ b/navit/plugin/navit_safety/navit_safety_cache.h
@@ -1,0 +1,59 @@
+/**
+ * @file navit_safety_cache.h
+ * @brief SQLite-backed confirmation cache for user-verified POIs.
+ *
+ * Persists which POIs a user has confirmed operational on a given trip so the
+ * confidence of those stops can be upgraded to High for the rest of the trip
+ * and across sessions. See docs/user/plugins/navit_safety.rst ("Unconfirmed
+ * stops"). The cache is optional and only compiled when SQLite3 is available.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_CACHE_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_CACHE_H
+
+/** @brief Opaque handle to a confirmation cache. */
+struct navit_safety_cache;
+
+/**
+ * @brief Open (and create if needed) a confirmation cache.
+ * @param path Database file path; ":memory:" for a transient cache.
+ * @return A cache handle, or NULL on failure (caller owns it).
+ */
+struct navit_safety_cache *navit_safety_cache_open(const char *path);
+
+/**
+ * @brief Close a cache and release its resources.
+ * @param cache Cache to close (NULL is ignored).
+ */
+void navit_safety_cache_close(struct navit_safety_cache *cache);
+
+/**
+ * @brief Record that a POI was confirmed operational on a trip.
+ * @param cache Open cache (NULL fails).
+ * @param poi_id Stable POI identifier (NULL fails).
+ * @param trip_id Trip identifier (NULL fails).
+ * @param timestamp Confirmation time (e.g. Unix seconds).
+ * @return Nonzero on success, zero on failure.
+ */
+int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi_id,
+                               const char *trip_id, long timestamp);
+
+/**
+ * @brief Test whether a POI is confirmed for a trip.
+ * @param cache Open cache (NULL yields not-confirmed).
+ * @param poi_id POI identifier.
+ * @param trip_id Trip identifier.
+ * @return Nonzero if a confirmation exists, zero otherwise.
+ */
+int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char *poi_id,
+                                    const char *trip_id);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_CACHE_H */

--- a/navit/plugin/navit_safety/navit_safety_cache.h
+++ b/navit/plugin/navit_safety/navit_safety_cache.h
@@ -43,8 +43,8 @@ void navit_safety_cache_close(struct navit_safety_cache *cache);
  * @param timestamp Confirmation time (e.g. Unix seconds).
  * @return Nonzero on success, zero on failure.
  */
-int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi_id,
-                               const char *trip_id, long timestamp);
+int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi_id, const char *trip_id,
+                               long timestamp);
 
 /**
  * @brief Test whether a POI is confirmed for a trip.
@@ -53,7 +53,6 @@ int navit_safety_cache_confirm(struct navit_safety_cache *cache, const char *poi
  * @param trip_id Trip identifier.
  * @return Nonzero if a confirmation exists, zero otherwise.
  */
-int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char *poi_id,
-                                    const char *trip_id);
+int navit_safety_cache_is_confirmed(struct navit_safety_cache *cache, const char *poi_id, const char *trip_id);
 
 #endif /* NAVIT_PLUGIN_NAVIT_SAFETY_CACHE_H */

--- a/navit/plugin/navit_safety/navit_safety_confidence.c
+++ b/navit/plugin/navit_safety/navit_safety_confidence.c
@@ -25,8 +25,34 @@ int navit_safety_confidence_counts_as_resupply(enum navit_safety_confidence conf
 
 /* Clamp a confidence so it never exceeds a ceiling (used for downgrades). */
 static enum navit_safety_confidence cap_confidence(enum navit_safety_confidence value,
-        enum navit_safety_confidence ceiling) {
+                                                   enum navit_safety_confidence ceiling) {
     return value > ceiling ? ceiling : value;
+}
+
+/* Map source and age to a base confidence before global downgrades. */
+static enum navit_safety_confidence score_by_source(enum navit_safety_poi_source source, int age) {
+    switch (source) {
+    case NAVIT_SAFETY_SRC_CHAIN_API:
+    case NAVIT_SAFETY_SRC_NREL:
+        return NAVIT_SAFETY_CONFIDENCE_HIGH;
+    case NAVIT_SAFETY_SRC_OSM_NREL_MATCH:
+        return (age >= 0 && age <= NAVIT_SAFETY_AGE_30_DAYS) ? NAVIT_SAFETY_CONFIDENCE_HIGH
+                                                             : NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+    case NAVIT_SAFETY_SRC_IOVERLANDER:
+        return (age >= 0 && age <= NAVIT_SAFETY_AGE_60_DAYS) ? NAVIT_SAFETY_CONFIDENCE_MEDIUM
+                                                             : NAVIT_SAFETY_CONFIDENCE_LOW;
+    case NAVIT_SAFETY_SRC_OSM_CHAIN:
+        return NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+    case NAVIT_SAFETY_SRC_OSM_INDEPENDENT:
+        if (age < 0 || age > NAVIT_SAFETY_AGE_3_YEARS)
+            return NAVIT_SAFETY_CONFIDENCE_LOW;
+        if (age <= NAVIT_SAFETY_AGE_12_MONTHS)
+            return NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+        return NAVIT_SAFETY_CONFIDENCE_LOW;
+    case NAVIT_SAFETY_SRC_UNKNOWN:
+    default:
+        return NAVIT_SAFETY_CONFIDENCE_UNKNOWN;
+    }
 }
 
 enum navit_safety_confidence navit_safety_score_poi(const struct navit_safety_poi *poi) {
@@ -36,40 +62,11 @@ enum navit_safety_confidence navit_safety_score_poi(const struct navit_safety_po
     if (!poi)
         return NAVIT_SAFETY_CONFIDENCE_UNKNOWN;
 
-    age = poi->age_days;
-
-    switch (poi->source) {
-    case NAVIT_SAFETY_SRC_USER_CONFIRMED:
-        /* User confirmation on the current trip overrides everything. */
+    if (poi->source == NAVIT_SAFETY_SRC_USER_CONFIRMED)
         return NAVIT_SAFETY_CONFIDENCE_HIGH;
-    case NAVIT_SAFETY_SRC_CHAIN_API:
-    case NAVIT_SAFETY_SRC_NREL:
-        result = NAVIT_SAFETY_CONFIDENCE_HIGH;
-        break;
-    case NAVIT_SAFETY_SRC_OSM_NREL_MATCH:
-        result = (age >= 0 && age <= NAVIT_SAFETY_AGE_30_DAYS)
-                 ? NAVIT_SAFETY_CONFIDENCE_HIGH : NAVIT_SAFETY_CONFIDENCE_MEDIUM;
-        break;
-    case NAVIT_SAFETY_SRC_IOVERLANDER:
-        result = (age >= 0 && age <= NAVIT_SAFETY_AGE_60_DAYS)
-                 ? NAVIT_SAFETY_CONFIDENCE_MEDIUM : NAVIT_SAFETY_CONFIDENCE_LOW;
-        break;
-    case NAVIT_SAFETY_SRC_OSM_CHAIN:
-        result = NAVIT_SAFETY_CONFIDENCE_MEDIUM;
-        break;
-    case NAVIT_SAFETY_SRC_OSM_INDEPENDENT:
-        if (age < 0 || age > NAVIT_SAFETY_AGE_3_YEARS)
-            result = NAVIT_SAFETY_CONFIDENCE_LOW;
-        else if (age <= NAVIT_SAFETY_AGE_12_MONTHS)
-            result = NAVIT_SAFETY_CONFIDENCE_MEDIUM;
-        else
-            result = NAVIT_SAFETY_CONFIDENCE_LOW;
-        break;
-    case NAVIT_SAFETY_SRC_UNKNOWN:
-    default:
-        result = NAVIT_SAFETY_CONFIDENCE_UNKNOWN;
-        break;
-    }
+
+    age = poi->age_days;
+    result = score_by_source(poi->source, age);
 
     /* Data older than three years has a high closure risk regardless of source
      * (except the live/authoritative and user-confirmed sources handled above). */

--- a/navit/plugin/navit_safety/navit_safety_confidence.c
+++ b/navit/plugin/navit_safety/navit_safety_confidence.c
@@ -1,0 +1,84 @@
+/**
+ * @file navit_safety_confidence.c
+ * @brief POI confidence scoring implementation.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include "navit_safety_confidence.h"
+
+/* Age thresholds (days) used by the source ranking table. */
+#define NAVIT_SAFETY_AGE_30_DAYS 30
+#define NAVIT_SAFETY_AGE_60_DAYS 60
+#define NAVIT_SAFETY_AGE_12_MONTHS 365
+#define NAVIT_SAFETY_AGE_3_YEARS 1095
+
+int navit_safety_confidence_counts_as_resupply(enum navit_safety_confidence confidence) {
+    return confidence >= NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+}
+
+/* Clamp a confidence so it never exceeds a ceiling (used for downgrades). */
+static enum navit_safety_confidence cap_confidence(enum navit_safety_confidence value,
+        enum navit_safety_confidence ceiling) {
+    return value > ceiling ? ceiling : value;
+}
+
+enum navit_safety_confidence navit_safety_score_poi(const struct navit_safety_poi *poi) {
+    enum navit_safety_confidence result;
+    int age;
+
+    if (!poi)
+        return NAVIT_SAFETY_CONFIDENCE_UNKNOWN;
+
+    age = poi->age_days;
+
+    switch (poi->source) {
+    case NAVIT_SAFETY_SRC_USER_CONFIRMED:
+        /* User confirmation on the current trip overrides everything. */
+        return NAVIT_SAFETY_CONFIDENCE_HIGH;
+    case NAVIT_SAFETY_SRC_CHAIN_API:
+    case NAVIT_SAFETY_SRC_NREL:
+        result = NAVIT_SAFETY_CONFIDENCE_HIGH;
+        break;
+    case NAVIT_SAFETY_SRC_OSM_NREL_MATCH:
+        result = (age >= 0 && age <= NAVIT_SAFETY_AGE_30_DAYS)
+                 ? NAVIT_SAFETY_CONFIDENCE_HIGH : NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+        break;
+    case NAVIT_SAFETY_SRC_IOVERLANDER:
+        result = (age >= 0 && age <= NAVIT_SAFETY_AGE_60_DAYS)
+                 ? NAVIT_SAFETY_CONFIDENCE_MEDIUM : NAVIT_SAFETY_CONFIDENCE_LOW;
+        break;
+    case NAVIT_SAFETY_SRC_OSM_CHAIN:
+        result = NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+        break;
+    case NAVIT_SAFETY_SRC_OSM_INDEPENDENT:
+        if (age < 0 || age > NAVIT_SAFETY_AGE_3_YEARS)
+            result = NAVIT_SAFETY_CONFIDENCE_LOW;
+        else if (age <= NAVIT_SAFETY_AGE_12_MONTHS)
+            result = NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+        else
+            result = NAVIT_SAFETY_CONFIDENCE_LOW;
+        break;
+    case NAVIT_SAFETY_SRC_UNKNOWN:
+    default:
+        result = NAVIT_SAFETY_CONFIDENCE_UNKNOWN;
+        break;
+    }
+
+    /* Data older than three years has a high closure risk regardless of source
+     * (except the live/authoritative and user-confirmed sources handled above). */
+    if (age > NAVIT_SAFETY_AGE_3_YEARS)
+        result = cap_confidence(result, NAVIT_SAFETY_CONFIDENCE_LOW);
+
+    /* Known depopulating regions cap any map-derived POI at Low. */
+    if (poi->depopulating_region)
+        result = cap_confidence(result, NAVIT_SAFETY_CONFIDENCE_LOW);
+
+    return result;
+}

--- a/navit/plugin/navit_safety/navit_safety_confidence.h
+++ b/navit/plugin/navit_safety/navit_safety_confidence.h
@@ -29,14 +29,14 @@ enum navit_safety_confidence {
 
 /** @brief Data source a POI was obtained from, used for source ranking. */
 enum navit_safety_poi_source {
-    NAVIT_SAFETY_SRC_UNKNOWN = 0,       /**< Source not known. */
-    NAVIT_SAFETY_SRC_CHAIN_API,         /**< Live chain operator API (Shell, Circle K). */
-    NAVIT_SAFETY_SRC_NREL,              /**< NREL Alternative Fuel Stations. */
-    NAVIT_SAFETY_SRC_OSM_NREL_MATCH,    /**< OSM cross-referenced with NREL. */
-    NAVIT_SAFETY_SRC_IOVERLANDER,       /**< iOverlander CSV import (offline). */
-    NAVIT_SAFETY_SRC_OSM_CHAIN,         /**< OSM with a known chain operator tag. */
-    NAVIT_SAFETY_SRC_OSM_INDEPENDENT,   /**< OSM independent operator. */
-    NAVIT_SAFETY_SRC_USER_CONFIRMED     /**< Confirmed by the user on the current trip. */
+    NAVIT_SAFETY_SRC_UNKNOWN = 0,     /**< Source not known. */
+    NAVIT_SAFETY_SRC_CHAIN_API,       /**< Live chain operator API (Shell, Circle K). */
+    NAVIT_SAFETY_SRC_NREL,            /**< NREL Alternative Fuel Stations. */
+    NAVIT_SAFETY_SRC_OSM_NREL_MATCH,  /**< OSM cross-referenced with NREL. */
+    NAVIT_SAFETY_SRC_IOVERLANDER,     /**< iOverlander CSV import (offline). */
+    NAVIT_SAFETY_SRC_OSM_CHAIN,       /**< OSM with a known chain operator tag. */
+    NAVIT_SAFETY_SRC_OSM_INDEPENDENT, /**< OSM independent operator. */
+    NAVIT_SAFETY_SRC_USER_CONFIRMED   /**< Confirmed by the user on the current trip. */
 };
 
 /** @brief A POI candidate to be scored. */

--- a/navit/plugin/navit_safety/navit_safety_confidence.h
+++ b/navit/plugin/navit_safety/navit_safety_confidence.h
@@ -1,0 +1,63 @@
+/**
+ * @file navit_safety_confidence.h
+ * @brief POI confidence scoring for the Navit Safety plugin.
+ *
+ * Ranks a point of interest by the reliability of its source and age so that
+ * only confirmed or reasonably recent stops count toward resupply in
+ * minimum-range calculations. See docs/user/plugins/navit_safety.rst
+ * ("POI confidence hierarchy").
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_CONFIDENCE_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_CONFIDENCE_H
+
+/** @brief Reliability of a resupply point, lowest to highest. */
+enum navit_safety_confidence {
+    NAVIT_SAFETY_CONFIDENCE_UNKNOWN = 0, /**< No usable metadata; treated as Low. */
+    NAVIT_SAFETY_CONFIDENCE_LOW,         /**< Unverifiable or stale; not reliable resupply. */
+    NAVIT_SAFETY_CONFIDENCE_MEDIUM,      /**< Likely operational; counts with a buffer. */
+    NAVIT_SAFETY_CONFIDENCE_HIGH         /**< Confirmed operational; counts fully. */
+};
+
+/** @brief Data source a POI was obtained from, used for source ranking. */
+enum navit_safety_poi_source {
+    NAVIT_SAFETY_SRC_UNKNOWN = 0,       /**< Source not known. */
+    NAVIT_SAFETY_SRC_CHAIN_API,         /**< Live chain operator API (Shell, Circle K). */
+    NAVIT_SAFETY_SRC_NREL,              /**< NREL Alternative Fuel Stations. */
+    NAVIT_SAFETY_SRC_OSM_NREL_MATCH,    /**< OSM cross-referenced with NREL. */
+    NAVIT_SAFETY_SRC_IOVERLANDER,       /**< iOverlander CSV import (offline). */
+    NAVIT_SAFETY_SRC_OSM_CHAIN,         /**< OSM with a known chain operator tag. */
+    NAVIT_SAFETY_SRC_OSM_INDEPENDENT,   /**< OSM independent operator. */
+    NAVIT_SAFETY_SRC_USER_CONFIRMED     /**< Confirmed by the user on the current trip. */
+};
+
+/** @brief A POI candidate to be scored. */
+struct navit_safety_poi {
+    enum navit_safety_poi_source source; /**< Where the POI came from. */
+    int age_days;                        /**< Age of the data in days; negative if unknown. */
+    int depopulating_region;             /**< Nonzero if in a known depopulating county/region. */
+};
+
+/**
+ * @brief Score a POI's reliability from its source and age.
+ * @param poi POI to score (NULL yields UNKNOWN).
+ * @return Confidence level per the source ranking table.
+ */
+enum navit_safety_confidence navit_safety_score_poi(const struct navit_safety_poi *poi);
+
+/**
+ * @brief Whether a confidence level counts as reliable resupply.
+ * @param confidence Level to test.
+ * @return Nonzero for Medium or High; zero otherwise.
+ */
+int navit_safety_confidence_counts_as_resupply(enum navit_safety_confidence confidence);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_CONFIDENCE_H */

--- a/navit/plugin/navit_safety/navit_safety_heat.c
+++ b/navit/plugin/navit_safety/navit_safety_heat.c
@@ -11,8 +11,8 @@
  * as published by the Free Software Foundation.
  */
 
-#include "navit_safety.h"
 #include "navit_safety_heat.h"
+#include "navit_safety.h"
 
 /* WBGT thresholds (degrees Celsius) for heat-illness risk, per the spec. */
 #define NAVIT_SAFETY_WBGT_CAUTION 28.0
@@ -20,10 +20,10 @@
 #define NAVIT_SAFETY_WBGT_DANGER 35.0
 
 /* Water model constants. */
-#define NAVIT_SAFETY_WATER_REST_ML_PER_KG 1   /* resting maintenance, ml/kg/hr */
+#define NAVIT_SAFETY_WATER_REST_ML_PER_KG 1     /* resting maintenance, ml/kg/hr */
 #define NAVIT_SAFETY_WATER_EXERTION_ML_PER_KG 4 /* added when strenuous, ml/kg/hr */
-#define NAVIT_SAFETY_WATER_HEAT_BASE_C 25.0   /* heat term starts above this WBGT */
-#define NAVIT_SAFETY_WATER_HEAT_ML_PER_C 20.0 /* added per degree above the base */
+#define NAVIT_SAFETY_WATER_HEAT_BASE_C 25.0     /* heat term starts above this WBGT */
+#define NAVIT_SAFETY_WATER_HEAT_ML_PER_C 20.0   /* added per degree above the base */
 
 enum navit_safety_heat_level navit_safety_heat_assess(double wbgt_c) {
     if (wbgt_c >= NAVIT_SAFETY_WBGT_DANGER)

--- a/navit/plugin/navit_safety/navit_safety_heat.c
+++ b/navit/plugin/navit_safety/navit_safety_heat.c
@@ -1,0 +1,71 @@
+/**
+ * @file navit_safety_heat.c
+ * @brief Heat-stress assessment and foot-travel water requirement implementation.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include "navit_safety.h"
+#include "navit_safety_heat.h"
+
+/* WBGT thresholds (degrees Celsius) for heat-illness risk, per the spec. */
+#define NAVIT_SAFETY_WBGT_CAUTION 28.0
+#define NAVIT_SAFETY_WBGT_WARNING 32.0
+#define NAVIT_SAFETY_WBGT_DANGER 35.0
+
+/* Water model constants. */
+#define NAVIT_SAFETY_WATER_REST_ML_PER_KG 1   /* resting maintenance, ml/kg/hr */
+#define NAVIT_SAFETY_WATER_EXERTION_ML_PER_KG 4 /* added when strenuous, ml/kg/hr */
+#define NAVIT_SAFETY_WATER_HEAT_BASE_C 25.0   /* heat term starts above this WBGT */
+#define NAVIT_SAFETY_WATER_HEAT_ML_PER_C 20.0 /* added per degree above the base */
+
+enum navit_safety_heat_level navit_safety_heat_assess(double wbgt_c) {
+    if (wbgt_c >= NAVIT_SAFETY_WBGT_DANGER)
+        return NAVIT_SAFETY_HEAT_DANGER;
+    if (wbgt_c >= NAVIT_SAFETY_WBGT_WARNING)
+        return NAVIT_SAFETY_HEAT_WARNING;
+    if (wbgt_c >= NAVIT_SAFETY_WBGT_CAUTION)
+        return NAVIT_SAFETY_HEAT_CAUTION;
+    return NAVIT_SAFETY_HEAT_NONE;
+}
+
+int navit_safety_heat_water_ml_per_hour(int body_weight_kg, double wbgt_c, int strenuous) {
+    int ml;
+
+    if (body_weight_kg <= 0)
+        return 0;
+
+    ml = body_weight_kg * NAVIT_SAFETY_WATER_REST_ML_PER_KG;
+    if (strenuous)
+        ml += body_weight_kg * NAVIT_SAFETY_WATER_EXERTION_ML_PER_KG;
+    if (wbgt_c > NAVIT_SAFETY_WATER_HEAT_BASE_C)
+        ml += (int)((wbgt_c - NAVIT_SAFETY_WATER_HEAT_BASE_C) * NAVIT_SAFETY_WATER_HEAT_ML_PER_C);
+
+    return ml;
+}
+
+void navit_safety_heat_plan(const struct navit_safety_config *config, double wbgt_c, int strenuous,
+                            struct navit_safety_heat_result *out) {
+    if (!out)
+        return;
+
+    out->level = NAVIT_SAFETY_HEAT_NONE;
+    out->water_ml_per_hour = 0;
+    out->avoid_exertion = 0;
+
+    if (!config)
+        return;
+
+    out->water_ml_per_hour = navit_safety_heat_water_ml_per_hour(config->body_weight_kg, wbgt_c, strenuous);
+
+    if (config->heat_stress_warnings) {
+        out->level = navit_safety_heat_assess(wbgt_c);
+        out->avoid_exertion = (out->level == NAVIT_SAFETY_HEAT_DANGER);
+    }
+}

--- a/navit/plugin/navit_safety/navit_safety_heat.h
+++ b/navit/plugin/navit_safety/navit_safety_heat.h
@@ -1,0 +1,74 @@
+/**
+ * @file navit_safety_heat.h
+ * @brief Heat-stress assessment and foot-travel water requirement.
+ *
+ * Implements the foot-travel heat model from the spec: a WBGT-based heat
+ * illness level (caution / warning / danger) and an estimated water
+ * requirement derived from body weight, heat, and exertion. See
+ * docs/user/plugins/navit_safety.rst ("Foot travel and water sources").
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_HEAT_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_HEAT_H
+
+struct navit_safety_config;
+
+/** @brief Heat-illness risk level by WBGT (wet-bulb globe temperature). */
+enum navit_safety_heat_level {
+    NAVIT_SAFETY_HEAT_NONE = 0, /**< Below 28 C WBGT: no specific warning. */
+    NAVIT_SAFETY_HEAT_CAUTION,  /**< 28 C and above: caution for strenuous activity. */
+    NAVIT_SAFETY_HEAT_WARNING,  /**< 32 C and above: strong warning. */
+    NAVIT_SAFETY_HEAT_DANGER    /**< 35 C and above: avoid sustained exertion. */
+};
+
+/** @brief Outcome of a foot-travel heat plan. */
+struct navit_safety_heat_result {
+    enum navit_safety_heat_level level; /**< Risk level (NONE when warnings are disabled). */
+    int water_ml_per_hour;              /**< Estimated water requirement, millilitres per hour. */
+    int avoid_exertion;                 /**< Nonzero when sustained exertion should be avoided. */
+};
+
+/**
+ * @brief Classify a WBGT value into a heat-illness level.
+ * @param wbgt_c Wet-bulb globe temperature in degrees Celsius.
+ * @return The heat-illness level.
+ */
+enum navit_safety_heat_level navit_safety_heat_assess(double wbgt_c);
+
+/**
+ * @brief Estimate water requirement for one hour of travel.
+ *
+ * Combines a resting maintenance term (scaled by body weight), an exertion term
+ * for strenuous activity, and a heat term above 25 C WBGT.
+ *
+ * @param body_weight_kg Body weight in kilograms (non-positive yields 0).
+ * @param wbgt_c Wet-bulb globe temperature in degrees Celsius.
+ * @param strenuous Nonzero for strenuous activity (hiking with load, fast pace).
+ * @return Water requirement in millilitres per hour.
+ */
+int navit_safety_heat_water_ml_per_hour(int body_weight_kg, double wbgt_c, int strenuous);
+
+/**
+ * @brief Build a foot-travel heat plan from the plugin configuration.
+ *
+ * The water requirement always uses config->body_weight_kg. The heat level and
+ * the avoid-exertion flag are only reported when config->heat_stress_warnings is
+ * enabled.
+ *
+ * @param config Plugin configuration (NULL yields a zeroed result).
+ * @param wbgt_c Wet-bulb globe temperature in degrees Celsius.
+ * @param strenuous Nonzero for strenuous activity.
+ * @param out Result, filled on return (must not be NULL).
+ */
+void navit_safety_heat_plan(const struct navit_safety_config *config, double wbgt_c, int strenuous,
+                            struct navit_safety_heat_result *out);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_HEAT_H */

--- a/navit/plugin/navit_safety/navit_safety_koppen.c
+++ b/navit/plugin/navit_safety/navit_safety_koppen.c
@@ -1,0 +1,109 @@
+/**
+ * @file navit_safety_koppen.c
+ * @brief Koppen climate-zone classification implementation.
+ *
+ * The lookup uses a small table of axis-aligned bounding boxes covering the
+ * world's major arid and semi-arid regions. It is a coarse approximation
+ * meant to flag obviously remote/arid terrain for conservative planning, not
+ * a substitute for a gridded Koppen-Geiger dataset.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include "navit_safety_koppen.h"
+
+#define NAVIT_SAFETY_LAT_MAX 90.0
+#define NAVIT_SAFETY_LON_MAX 180.0
+
+/* One arid/semi-arid region as a bounding box (degrees) plus its zone. */
+struct koppen_box {
+    double lat_min;
+    double lat_max;
+    double lon_min;
+    double lon_max;
+    enum navit_safety_koppen zone;
+};
+
+/* Coarse coverage of the major arid belts. Boxes are deliberately broad;
+ * earlier entries win when boxes overlap. */
+static const struct koppen_box koppen_boxes[] = {
+    /* Sahara and Sahel. */
+    { 15.0, 31.0, -17.0, 38.0, NAVIT_SAFETY_KOPPEN_BWH },
+    { 11.0, 15.0, -17.0, 38.0, NAVIT_SAFETY_KOPPEN_BSH },
+    /* Arabian Peninsula. */
+    { 15.0, 31.0, 34.0, 60.0, NAVIT_SAFETY_KOPPEN_BWH },
+    /* Iran, Thar and Central Asia deserts. */
+    { 27.0, 40.0, 44.0, 78.0, NAVIT_SAFETY_KOPPEN_BWK },
+    /* Gobi and Taklamakan. */
+    { 36.0, 48.0, 78.0, 116.0, NAVIT_SAFETY_KOPPEN_BWK },
+    /* Australian interior. */
+    { -33.0, -19.0, 117.0, 142.0, NAVIT_SAFETY_KOPPEN_BWH },
+    { -28.0, -19.0, 142.0, 148.0, NAVIT_SAFETY_KOPPEN_BSH },
+    /* Kalahari and Namib. */
+    { -29.0, -18.0, 12.0, 25.0, NAVIT_SAFETY_KOPPEN_BWH },
+    /* Karoo. */
+    { -33.0, -29.0, 18.0, 26.0, NAVIT_SAFETY_KOPPEN_BSK },
+    /* North American south-west deserts. */
+    { 28.0, 42.0, -120.0, -103.0, NAVIT_SAFETY_KOPPEN_BWK },
+    /* US Great Plains (cold semi-arid). */
+    { 32.0, 49.0, -103.0, -97.0, NAVIT_SAFETY_KOPPEN_BSK },
+    /* Atacama and Peruvian coast. */
+    { -30.0, -5.0, -76.0, -69.0, NAVIT_SAFETY_KOPPEN_BWK },
+    /* Patagonian steppe. */
+    { -52.0, -38.0, -72.0, -65.0, NAVIT_SAFETY_KOPPEN_BWK }
+};
+
+#define NAVIT_SAFETY_KOPPEN_BOX_COUNT (sizeof(koppen_boxes) / sizeof(koppen_boxes[0]))
+
+int navit_safety_koppen_is_arid(enum navit_safety_koppen zone) {
+    return zone == NAVIT_SAFETY_KOPPEN_BWH || zone == NAVIT_SAFETY_KOPPEN_BWK;
+}
+
+int navit_safety_koppen_is_semiarid(enum navit_safety_koppen zone) {
+    return zone == NAVIT_SAFETY_KOPPEN_BSH || zone == NAVIT_SAFETY_KOPPEN_BSK;
+}
+
+int navit_safety_koppen_triggers_remote(enum navit_safety_koppen zone) {
+    return navit_safety_koppen_is_arid(zone) || navit_safety_koppen_is_semiarid(zone);
+}
+
+enum navit_safety_koppen navit_safety_koppen_lookup(double lat, double lon) {
+    unsigned int i;
+
+    if (lat < -NAVIT_SAFETY_LAT_MAX || lat > NAVIT_SAFETY_LAT_MAX ||
+            lon < -NAVIT_SAFETY_LON_MAX || lon > NAVIT_SAFETY_LON_MAX)
+        return NAVIT_SAFETY_KOPPEN_UNKNOWN;
+
+    for (i = 0; i < NAVIT_SAFETY_KOPPEN_BOX_COUNT; i++) {
+        const struct koppen_box *box = &koppen_boxes[i];
+        if (lat >= box->lat_min && lat <= box->lat_max &&
+                lon >= box->lon_min && lon <= box->lon_max)
+            return box->zone;
+    }
+
+    return NAVIT_SAFETY_KOPPEN_OTHER;
+}
+
+const char *navit_safety_koppen_code(enum navit_safety_koppen zone) {
+    switch (zone) {
+    case NAVIT_SAFETY_KOPPEN_BWH:
+        return "BWh";
+    case NAVIT_SAFETY_KOPPEN_BWK:
+        return "BWk";
+    case NAVIT_SAFETY_KOPPEN_BSH:
+        return "BSh";
+    case NAVIT_SAFETY_KOPPEN_BSK:
+        return "BSk";
+    case NAVIT_SAFETY_KOPPEN_OTHER:
+        return "other";
+    case NAVIT_SAFETY_KOPPEN_UNKNOWN:
+    default:
+        return "unknown";
+    }
+}

--- a/navit/plugin/navit_safety/navit_safety_koppen.c
+++ b/navit/plugin/navit_safety/navit_safety_koppen.c
@@ -34,29 +34,29 @@ struct koppen_box {
  * earlier entries win when boxes overlap. */
 static const struct koppen_box koppen_boxes[] = {
     /* Sahara and Sahel. */
-    { 15.0, 31.0, -17.0, 38.0, NAVIT_SAFETY_KOPPEN_BWH },
-    { 11.0, 15.0, -17.0, 38.0, NAVIT_SAFETY_KOPPEN_BSH },
+    {15.0,  31.0,  -17.0,  38.0,   NAVIT_SAFETY_KOPPEN_BWH},
+    {11.0,  15.0,  -17.0,  38.0,   NAVIT_SAFETY_KOPPEN_BSH},
     /* Arabian Peninsula. */
-    { 15.0, 31.0, 34.0, 60.0, NAVIT_SAFETY_KOPPEN_BWH },
+    {15.0,  31.0,  34.0,   60.0,   NAVIT_SAFETY_KOPPEN_BWH},
     /* Iran, Thar and Central Asia deserts. */
-    { 27.0, 40.0, 44.0, 78.0, NAVIT_SAFETY_KOPPEN_BWK },
+    {27.0,  40.0,  44.0,   78.0,   NAVIT_SAFETY_KOPPEN_BWK},
     /* Gobi and Taklamakan. */
-    { 36.0, 48.0, 78.0, 116.0, NAVIT_SAFETY_KOPPEN_BWK },
+    {36.0,  48.0,  78.0,   116.0,  NAVIT_SAFETY_KOPPEN_BWK},
     /* Australian interior. */
-    { -33.0, -19.0, 117.0, 142.0, NAVIT_SAFETY_KOPPEN_BWH },
-    { -28.0, -19.0, 142.0, 148.0, NAVIT_SAFETY_KOPPEN_BSH },
+    {-33.0, -19.0, 117.0,  142.0,  NAVIT_SAFETY_KOPPEN_BWH},
+    {-28.0, -19.0, 142.0,  148.0,  NAVIT_SAFETY_KOPPEN_BSH},
     /* Kalahari and Namib. */
-    { -29.0, -18.0, 12.0, 25.0, NAVIT_SAFETY_KOPPEN_BWH },
+    {-29.0, -18.0, 12.0,   25.0,   NAVIT_SAFETY_KOPPEN_BWH},
     /* Karoo. */
-    { -33.0, -29.0, 18.0, 26.0, NAVIT_SAFETY_KOPPEN_BSK },
+    {-33.0, -29.0, 18.0,   26.0,   NAVIT_SAFETY_KOPPEN_BSK},
     /* North American south-west deserts. */
-    { 28.0, 42.0, -120.0, -103.0, NAVIT_SAFETY_KOPPEN_BWK },
+    {28.0,  42.0,  -120.0, -103.0, NAVIT_SAFETY_KOPPEN_BWK},
     /* US Great Plains (cold semi-arid). */
-    { 32.0, 49.0, -103.0, -97.0, NAVIT_SAFETY_KOPPEN_BSK },
+    {32.0,  49.0,  -103.0, -97.0,  NAVIT_SAFETY_KOPPEN_BSK},
     /* Atacama and Peruvian coast. */
-    { -30.0, -5.0, -76.0, -69.0, NAVIT_SAFETY_KOPPEN_BWK },
+    {-30.0, -5.0,  -76.0,  -69.0,  NAVIT_SAFETY_KOPPEN_BWK},
     /* Patagonian steppe. */
-    { -52.0, -38.0, -72.0, -65.0, NAVIT_SAFETY_KOPPEN_BWK }
+    {-52.0, -38.0, -72.0,  -65.0,  NAVIT_SAFETY_KOPPEN_BWK}
 };
 
 #define NAVIT_SAFETY_KOPPEN_BOX_COUNT (sizeof(koppen_boxes) / sizeof(koppen_boxes[0]))
@@ -76,14 +76,13 @@ int navit_safety_koppen_triggers_remote(enum navit_safety_koppen zone) {
 enum navit_safety_koppen navit_safety_koppen_lookup(double lat, double lon) {
     unsigned int i;
 
-    if (lat < -NAVIT_SAFETY_LAT_MAX || lat > NAVIT_SAFETY_LAT_MAX ||
-            lon < -NAVIT_SAFETY_LON_MAX || lon > NAVIT_SAFETY_LON_MAX)
+    if (lat < -NAVIT_SAFETY_LAT_MAX || lat > NAVIT_SAFETY_LAT_MAX || lon < -NAVIT_SAFETY_LON_MAX
+        || lon > NAVIT_SAFETY_LON_MAX)
         return NAVIT_SAFETY_KOPPEN_UNKNOWN;
 
     for (i = 0; i < NAVIT_SAFETY_KOPPEN_BOX_COUNT; i++) {
         const struct koppen_box *box = &koppen_boxes[i];
-        if (lat >= box->lat_min && lat <= box->lat_max &&
-                lon >= box->lon_min && lon <= box->lon_max)
+        if (lat >= box->lat_min && lat <= box->lat_max && lon >= box->lon_min && lon <= box->lon_max)
             return box->zone;
     }
 

--- a/navit/plugin/navit_safety/navit_safety_koppen.h
+++ b/navit/plugin/navit_safety/navit_safety_koppen.h
@@ -1,0 +1,71 @@
+/**
+ * @file navit_safety_koppen.h
+ * @brief Koppen climate-zone classification for the Navit Safety plugin.
+ *
+ * Remote mode activates when a route segment lies in a hot/cold desert or
+ * hot/cold semi-arid zone (Koppen group B). This module provides the trigger
+ * decision plus a lightweight, coarse lat/lon lookup derived from the major
+ * arid regions; it is intentionally approximate and not a full Koppen-Geiger
+ * dataset. See docs/user/plugins/navit_safety.rst ("Location-aware remote
+ * mode").
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_KOPPEN_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_KOPPEN_H
+
+/** @brief Koppen zones relevant to remote-mode triggering. */
+enum navit_safety_koppen {
+    NAVIT_SAFETY_KOPPEN_UNKNOWN = 0, /**< Could not be determined. */
+    NAVIT_SAFETY_KOPPEN_OTHER,       /**< A non-arid zone (no trigger). */
+    NAVIT_SAFETY_KOPPEN_BWH,         /**< Hot desert. */
+    NAVIT_SAFETY_KOPPEN_BWK,         /**< Cold desert. */
+    NAVIT_SAFETY_KOPPEN_BSH,         /**< Hot semi-arid. */
+    NAVIT_SAFETY_KOPPEN_BSK          /**< Cold semi-arid. */
+};
+
+/**
+ * @brief Whether a zone is a desert (BWh/BWk).
+ * @param zone Zone to test.
+ * @return Nonzero for hot or cold desert.
+ */
+int navit_safety_koppen_is_arid(enum navit_safety_koppen zone);
+
+/**
+ * @brief Whether a zone is semi-arid (BSh/BSk).
+ * @param zone Zone to test.
+ * @return Nonzero for hot or cold semi-arid.
+ */
+int navit_safety_koppen_is_semiarid(enum navit_safety_koppen zone);
+
+/**
+ * @brief Whether a zone triggers remote mode (any Koppen group B zone).
+ * @param zone Zone to test.
+ * @return Nonzero for desert or semi-arid zones.
+ */
+int navit_safety_koppen_triggers_remote(enum navit_safety_koppen zone);
+
+/**
+ * @brief Coarse classification of a coordinate into a Koppen zone.
+ * @param lat Latitude in degrees (-90..90).
+ * @param lon Longitude in degrees (-180..180).
+ * @return The matching arid/semi-arid zone, OTHER for non-arid, or UNKNOWN
+ *         for out-of-range coordinates.
+ */
+enum navit_safety_koppen navit_safety_koppen_lookup(double lat, double lon);
+
+/**
+ * @brief Short code string for a zone, e.g. "BWh".
+ * @param zone Zone to format.
+ * @return A static, non-NULL string.
+ */
+const char *navit_safety_koppen_code(enum navit_safety_koppen zone);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_KOPPEN_H */

--- a/navit/plugin/navit_safety/navit_safety_lookahead.c
+++ b/navit/plugin/navit_safety/navit_safety_lookahead.c
@@ -1,0 +1,67 @@
+/**
+ * @file navit_safety_lookahead.c
+ * @brief Lookahead gap detection implementation.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include "navit_safety_lookahead.h"
+
+void navit_safety_lookahead_plan(const struct navit_safety_stop *stops, int n_stops,
+                                 int route_length_km, int usable_range_km,
+                                 struct navit_safety_gap_result *out) {
+    int previous_km;
+    int i;
+
+    if (!out)
+        return;
+
+    out->max_gap_km = 0;
+    out->gap_start_km = 0;
+    out->warning = 0;
+    out->shortfall_km = 0;
+
+    if (route_length_km <= 0)
+        return;
+
+    /* Walk reliable stops in order, measuring each leg from the previous
+     * reliable position. The route start counts as the first position and the
+     * destination as the final one. Stops are assumed ordered by distance. */
+    previous_km = 0;
+    for (i = 0; stops && i < n_stops; i++) {
+        const struct navit_safety_stop *stop = &stops[i];
+        int gap;
+
+        if (!navit_safety_confidence_counts_as_resupply(stop->confidence))
+            continue;
+        if (stop->distance_km < previous_km || stop->distance_km > route_length_km)
+            continue;
+
+        gap = stop->distance_km - previous_km;
+        if (gap > out->max_gap_km) {
+            out->max_gap_km = gap;
+            out->gap_start_km = previous_km;
+        }
+        previous_km = stop->distance_km;
+    }
+
+    /* Final leg from the last reliable position to the destination. */
+    {
+        int final_gap = route_length_km - previous_km;
+        if (final_gap > out->max_gap_km) {
+            out->max_gap_km = final_gap;
+            out->gap_start_km = previous_km;
+        }
+    }
+
+    if (usable_range_km > 0 && out->max_gap_km > usable_range_km) {
+        out->warning = 1;
+        out->shortfall_km = out->max_gap_km - usable_range_km;
+    }
+}

--- a/navit/plugin/navit_safety/navit_safety_lookahead.c
+++ b/navit/plugin/navit_safety/navit_safety_lookahead.c
@@ -13,9 +13,8 @@
 
 #include "navit_safety_lookahead.h"
 
-void navit_safety_lookahead_plan(const struct navit_safety_stop *stops, int n_stops,
-                                 int route_length_km, int usable_range_km,
-                                 struct navit_safety_gap_result *out) {
+void navit_safety_lookahead_plan(const struct navit_safety_stop *stops, int n_stops, int route_length_km,
+                                 int usable_range_km, struct navit_safety_gap_result *out) {
     int previous_km;
     int i;
 

--- a/navit/plugin/navit_safety/navit_safety_lookahead.h
+++ b/navit/plugin/navit_safety/navit_safety_lookahead.h
@@ -1,0 +1,58 @@
+/**
+ * @file navit_safety_lookahead.h
+ * @brief Lookahead gap detection for the Navit Safety plugin.
+ *
+ * Scans an ordered list of resupply stops along a route and finds the largest
+ * gap between reliable (Medium-or-higher confidence) stops, including the legs
+ * from the start to the first reliable stop and from the last reliable stop to
+ * the destination. If the worst gap exceeds the usable range it raises a
+ * pre-departure warning and reports the shortfall. See
+ * docs/user/plugins/navit_safety.rst ("Lookahead planning").
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_LOOKAHEAD_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_LOOKAHEAD_H
+
+#include "navit_safety_confidence.h"
+
+/** @brief A candidate resupply stop along the route. */
+struct navit_safety_stop {
+    int distance_km;                         /**< Distance from the route start. */
+    enum navit_safety_confidence confidence; /**< Reliability of this stop. */
+};
+
+/** @brief Result of a lookahead scan. */
+struct navit_safety_gap_result {
+    int max_gap_km;     /**< Largest gap between reliable stops (and the route ends). */
+    int gap_start_km;   /**< Distance from start where the worst gap begins. */
+    int warning;        /**< Nonzero if max_gap_km exceeds the usable range. */
+    int shortfall_km;   /**< How far max_gap_km exceeds the usable range (0 if none). */
+};
+
+/**
+ * @brief Build a resupply gap plan for a route.
+ *
+ * Only stops whose confidence counts as resupply (Medium or High) are used;
+ * low-confidence stops are ignored, as if they did not exist. Stops are
+ * expected to be ordered by distance; out-of-range stops (negative distance or
+ * beyond the route length) are skipped.
+ *
+ * @param stops Array of candidate stops (may be NULL when n_stops is 0).
+ * @param n_stops Number of entries in @p stops.
+ * @param route_length_km Total route length.
+ * @param usable_range_km Usable range with the applicable buffer already removed.
+ * @param out Result, filled on return (must not be NULL).
+ */
+void navit_safety_lookahead_plan(const struct navit_safety_stop *stops, int n_stops,
+                                 int route_length_km, int usable_range_km,
+                                 struct navit_safety_gap_result *out);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_LOOKAHEAD_H */

--- a/navit/plugin/navit_safety/navit_safety_lookahead.h
+++ b/navit/plugin/navit_safety/navit_safety_lookahead.h
@@ -31,10 +31,10 @@ struct navit_safety_stop {
 
 /** @brief Result of a lookahead scan. */
 struct navit_safety_gap_result {
-    int max_gap_km;     /**< Largest gap between reliable stops (and the route ends). */
-    int gap_start_km;   /**< Distance from start where the worst gap begins. */
-    int warning;        /**< Nonzero if max_gap_km exceeds the usable range. */
-    int shortfall_km;   /**< How far max_gap_km exceeds the usable range (0 if none). */
+    int max_gap_km;   /**< Largest gap between reliable stops (and the route ends). */
+    int gap_start_km; /**< Distance from start where the worst gap begins. */
+    int warning;      /**< Nonzero if max_gap_km exceeds the usable range. */
+    int shortfall_km; /**< How far max_gap_km exceeds the usable range (0 if none). */
 };
 
 /**
@@ -51,8 +51,7 @@ struct navit_safety_gap_result {
  * @param usable_range_km Usable range with the applicable buffer already removed.
  * @param out Result, filled on return (must not be NULL).
  */
-void navit_safety_lookahead_plan(const struct navit_safety_stop *stops, int n_stops,
-                                 int route_length_km, int usable_range_km,
-                                 struct navit_safety_gap_result *out);
+void navit_safety_lookahead_plan(const struct navit_safety_stop *stops, int n_stops, int route_length_km,
+                                 int usable_range_km, struct navit_safety_gap_result *out);
 
 #endif /* NAVIT_PLUGIN_NAVIT_SAFETY_LOOKAHEAD_H */

--- a/navit/plugin/navit_safety/navit_safety_plan.c
+++ b/navit/plugin/navit_safety/navit_safety_plan.c
@@ -1,0 +1,123 @@
+/**
+ * @file navit_safety_plan.c
+ * @brief Resource-planning orchestrator implementation.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include "navit_safety.h"
+#include "navit_safety_confidence.h"
+#include "navit_safety_plan.h"
+
+/* Average spacing between confirmed (Medium-or-higher) stops over the route,
+ * counting the legs from the start to the first stop and from the last stop to
+ * the destination. Returns nonzero when that spacing exceeds threshold_km,
+ * which is the POI-density signal for automatic remote mode. */
+static int density_is_sparse(const struct navit_safety_stop *stops, int n_stops,
+                             int route_length_km, int threshold_km) {
+    int reliable = 0;
+    int i;
+
+    if (route_length_km <= 0 || threshold_km <= 0)
+        return 0;
+
+    for (i = 0; stops && i < n_stops; i++) {
+        if (!navit_safety_confidence_counts_as_resupply(stops[i].confidence))
+            continue;
+        if (stops[i].distance_km < 0 || stops[i].distance_km > route_length_km)
+            continue;
+        reliable++;
+    }
+
+    return route_length_km / (reliable + 1) > threshold_km;
+}
+
+/* Pick the buffer for the conditions: arid zones use the arid buffer, other
+ * remote terrain uses the remote buffer, populated terrain the standard one. */
+static int select_buffer(const struct navit_safety_config *config,
+                         enum navit_safety_resource resource,
+                         int remote_active, int arid) {
+    if (resource == NAVIT_SAFETY_RESOURCE_WATER) {
+        if (arid)
+            return config->water_buffer_arid_km;
+        if (remote_active)
+            return config->water_buffer_remote_km;
+        return config->water_buffer_standard_km;
+    }
+    if (arid)
+        return config->fuel_buffer_arid_km;
+    if (remote_active)
+        return config->fuel_buffer_remote_km;
+    return config->fuel_buffer_standard_km;
+}
+
+void navit_safety_plan(const struct navit_safety_config *config,
+                       enum navit_safety_resource resource,
+                       double mid_lat, double mid_lon,
+                       const struct navit_safety_stop *stops, int n_stops,
+                       int route_length_km, int full_range_km,
+                       struct navit_safety_plan_result *out) {
+    enum navit_safety_koppen zone;
+    int koppen_remote;
+    int density_threshold;
+    int arid;
+
+    if (!out)
+        return;
+
+    out->zone = NAVIT_SAFETY_KOPPEN_UNKNOWN;
+    out->remote_active = 0;
+    out->density_sparse = 0;
+    out->desert_warning = 0;
+    out->buffer_km = 0;
+    out->usable_range_km = 0;
+    out->gap.max_gap_km = 0;
+    out->gap.gap_start_km = 0;
+    out->gap.warning = 0;
+    out->gap.shortfall_km = 0;
+
+    if (!config)
+        return;
+
+    zone = navit_safety_koppen_lookup(mid_lat, mid_lon);
+    arid = navit_safety_koppen_is_arid(zone);
+    koppen_remote = config->koppen_trigger && navit_safety_koppen_triggers_remote(zone);
+
+    /* Water on foot uses a tighter spacing threshold than fuel (spec: 40 vs 80 km). */
+    density_threshold = config->poi_density_threshold_km;
+    if (resource == NAVIT_SAFETY_RESOURCE_WATER)
+        density_threshold /= 2;
+    out->density_sparse = density_is_sparse(stops, n_stops, route_length_km, density_threshold);
+
+    switch (config->remote_mode) {
+    case NAVIT_SAFETY_REMOTE_ALWAYS:
+        out->remote_active = 1;
+        break;
+    case NAVIT_SAFETY_REMOTE_AUTO:
+        out->remote_active = koppen_remote || out->density_sparse;
+        break;
+    case NAVIT_SAFETY_REMOTE_OFF:
+    default:
+        out->remote_active = 0;
+        break;
+    }
+
+    /* Arid handling only applies when remote planning is in effect. */
+    arid = arid && out->remote_active;
+    out->desert_warning = arid && config->desert_consumption_warning;
+
+    out->zone = zone;
+    out->buffer_km = select_buffer(config, resource, out->remote_active, arid);
+
+    out->usable_range_km = full_range_km - out->buffer_km;
+    if (out->usable_range_km < 0)
+        out->usable_range_km = 0;
+
+    navit_safety_lookahead_plan(stops, n_stops, route_length_km, out->usable_range_km, &out->gap);
+}

--- a/navit/plugin/navit_safety/navit_safety_plan.c
+++ b/navit/plugin/navit_safety/navit_safety_plan.c
@@ -11,16 +11,16 @@
  * as published by the Free Software Foundation.
  */
 
+#include "navit_safety_plan.h"
 #include "navit_safety.h"
 #include "navit_safety_confidence.h"
-#include "navit_safety_plan.h"
 
 /* Average spacing between confirmed (Medium-or-higher) stops over the route,
  * counting the legs from the start to the first stop and from the last stop to
  * the destination. Returns nonzero when that spacing exceeds threshold_km,
  * which is the POI-density signal for automatic remote mode. */
-static int density_is_sparse(const struct navit_safety_stop *stops, int n_stops,
-                             int route_length_km, int threshold_km) {
+static int density_is_sparse(const struct navit_safety_stop *stops, int n_stops, int route_length_km,
+                             int threshold_km) {
     int reliable = 0;
     int i;
 
@@ -40,8 +40,7 @@ static int density_is_sparse(const struct navit_safety_stop *stops, int n_stops,
 
 /* Pick the buffer for the conditions: arid zones use the arid buffer, other
  * remote terrain uses the remote buffer, populated terrain the standard one. */
-static int select_buffer(const struct navit_safety_config *config,
-                         enum navit_safety_resource resource,
+static int select_buffer(const struct navit_safety_config *config, enum navit_safety_resource resource,
                          int remote_active, int arid) {
     if (resource == NAVIT_SAFETY_RESOURCE_WATER) {
         if (arid)
@@ -57,12 +56,9 @@ static int select_buffer(const struct navit_safety_config *config,
     return config->fuel_buffer_standard_km;
 }
 
-void navit_safety_plan(const struct navit_safety_config *config,
-                       enum navit_safety_resource resource,
-                       double mid_lat, double mid_lon,
-                       const struct navit_safety_stop *stops, int n_stops,
-                       int route_length_km, int full_range_km,
-                       struct navit_safety_plan_result *out) {
+void navit_safety_plan(const struct navit_safety_config *config, enum navit_safety_resource resource, double mid_lat,
+                       double mid_lon, const struct navit_safety_stop *stops, int n_stops, int route_length_km,
+                       int full_range_km, struct navit_safety_plan_result *out) {
     enum navit_safety_koppen zone;
     int koppen_remote;
     int density_threshold;

--- a/navit/plugin/navit_safety/navit_safety_plan.h
+++ b/navit/plugin/navit_safety/navit_safety_plan.h
@@ -1,0 +1,73 @@
+/**
+ * @file navit_safety_plan.h
+ * @brief Resource-planning orchestrator for the Navit Safety plugin.
+ *
+ * Ties the individual engines together: it classifies the route's terrain
+ * (Koppen), decides whether remote mode applies, selects the appropriate fuel
+ * or water buffer, and runs lookahead gap detection over the confirmed
+ * resupply stops. This is the engine the route hook calls once a route is
+ * available. See docs/user/plugins/navit_safety.rst ("Resource planning in
+ * remote mode").
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_PLAN_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_PLAN_H
+
+#include "navit_safety.h"
+#include "navit_safety_koppen.h"
+#include "navit_safety_lookahead.h"
+
+/** @brief Resource being planned for. */
+enum navit_safety_resource {
+    NAVIT_SAFETY_RESOURCE_FUEL = 0, /**< Vehicle fuel. */
+    NAVIT_SAFETY_RESOURCE_WATER     /**< Foot-travel water. */
+};
+
+/** @brief Outcome of a resource plan over a route. */
+struct navit_safety_plan_result {
+    enum navit_safety_koppen zone;        /**< Terrain zone at the sampled midpoint. */
+    int remote_active;                    /**< Nonzero if remote-mode planning applies. */
+    int density_sparse;                   /**< Nonzero if confirmed-POI spacing exceeded the density threshold. */
+    int desert_warning;                   /**< Nonzero if arid conditions warrant a higher-consumption warning. */
+    int buffer_km;                        /**< Buffer selected for the conditions. */
+    int usable_range_km;                  /**< Range after the buffer is removed. */
+    struct navit_safety_gap_result gap;   /**< Lookahead gap result. */
+};
+
+/**
+ * @brief Plan a single resource over a route.
+ *
+ * Remote mode is active when the configured mode is Always, or when it is Auto
+ * and either the Koppen trigger (if enabled) classifies the sampled midpoint as
+ * a group-B (arid/semi-arid) zone, or the confirmed-POI spacing is sparser than
+ * the density threshold (config->poi_density_threshold_km, halved for water).
+ * The buffer is the arid buffer in desert zones, the remote buffer when remote
+ * mode is otherwise active, and the standard buffer in populated terrain.
+ * Lookahead then runs over @p stops with the resulting usable range.
+ *
+ * @param config Plugin configuration (NULL fails).
+ * @param resource Fuel or water.
+ * @param mid_lat Latitude of a representative route midpoint.
+ * @param mid_lon Longitude of a representative route midpoint.
+ * @param stops Ordered candidate resupply stops (may be NULL when n_stops is 0).
+ * @param n_stops Number of stops.
+ * @param route_length_km Total route length.
+ * @param full_range_km Range on a full tank/water load before any buffer.
+ * @param out Result, filled on return (must not be NULL).
+ */
+void navit_safety_plan(const struct navit_safety_config *config,
+                       enum navit_safety_resource resource,
+                       double mid_lat, double mid_lon,
+                       const struct navit_safety_stop *stops, int n_stops,
+                       int route_length_km, int full_range_km,
+                       struct navit_safety_plan_result *out);
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_PLAN_H */

--- a/navit/plugin/navit_safety/navit_safety_plan.h
+++ b/navit/plugin/navit_safety/navit_safety_plan.h
@@ -33,13 +33,13 @@ enum navit_safety_resource {
 
 /** @brief Outcome of a resource plan over a route. */
 struct navit_safety_plan_result {
-    enum navit_safety_koppen zone;        /**< Terrain zone at the sampled midpoint. */
-    int remote_active;                    /**< Nonzero if remote-mode planning applies. */
-    int density_sparse;                   /**< Nonzero if confirmed-POI spacing exceeded the density threshold. */
-    int desert_warning;                   /**< Nonzero if arid conditions warrant a higher-consumption warning. */
-    int buffer_km;                        /**< Buffer selected for the conditions. */
-    int usable_range_km;                  /**< Range after the buffer is removed. */
-    struct navit_safety_gap_result gap;   /**< Lookahead gap result. */
+    enum navit_safety_koppen zone;      /**< Terrain zone at the sampled midpoint. */
+    int remote_active;                  /**< Nonzero if remote-mode planning applies. */
+    int density_sparse;                 /**< Nonzero if confirmed-POI spacing exceeded the density threshold. */
+    int desert_warning;                 /**< Nonzero if arid conditions warrant a higher-consumption warning. */
+    int buffer_km;                      /**< Buffer selected for the conditions. */
+    int usable_range_km;                /**< Range after the buffer is removed. */
+    struct navit_safety_gap_result gap; /**< Lookahead gap result. */
 };
 
 /**
@@ -63,11 +63,8 @@ struct navit_safety_plan_result {
  * @param full_range_km Range on a full tank/water load before any buffer.
  * @param out Result, filled on return (must not be NULL).
  */
-void navit_safety_plan(const struct navit_safety_config *config,
-                       enum navit_safety_resource resource,
-                       double mid_lat, double mid_lon,
-                       const struct navit_safety_stop *stops, int n_stops,
-                       int route_length_km, int full_range_km,
-                       struct navit_safety_plan_result *out);
+void navit_safety_plan(const struct navit_safety_config *config, enum navit_safety_resource resource, double mid_lat,
+                       double mid_lon, const struct navit_safety_stop *stops, int n_stops, int route_length_km,
+                       int full_range_km, struct navit_safety_plan_result *out);
 
 #endif /* NAVIT_PLUGIN_NAVIT_SAFETY_PLAN_H */

--- a/navit/plugin/navit_safety/navit_safety_route.c
+++ b/navit/plugin/navit_safety/navit_safety_route.c
@@ -18,20 +18,20 @@
 #include <string.h>
 #include <time.h>
 #if NAVIT_SAFETY_WITH_OSD
-#include <glib.h>
-#include "attr.h"
-#include "callback.h"
-#include "coord.h"
-#include "debug.h"
-#include "item.h"
-#include "map.h"
-#include "mapset.h"
-#include "navit.h"
-#include "route.h"
-#include "transform.h"
-#if NAVIT_SAFETY_WITH_SQLITE
-#include "navit_safety_cache.h"
-#endif
+#    include "attr.h"
+#    include "callback.h"
+#    include "coord.h"
+#    include "debug.h"
+#    include "item.h"
+#    include "map.h"
+#    include "mapset.h"
+#    include "navit.h"
+#    include "route.h"
+#    include "transform.h"
+#    include <glib.h>
+#    if NAVIT_SAFETY_WITH_SQLITE
+#        include "navit_safety_cache.h"
+#    endif
 #endif /* NAVIT_SAFETY_WITH_OSD */
 #include "navit_safety.h"
 #include "navit_safety_confidence.h"
@@ -80,12 +80,44 @@ void navit_safety_build_plan_stops(const struct navit_safety_poi_entry *pois, in
     *n_stops = out;
 }
 
-void navit_safety_format_status(const struct navit_safety_route_state *state,
-                                const struct navit_safety_config *config,
+static const char *remote_mode_label(int remote_mode) {
+    switch (remote_mode) {
+    case NAVIT_SAFETY_REMOTE_ALWAYS:
+        return "Always";
+    case NAVIT_SAFETY_REMOTE_OFF:
+        return "Off";
+    case NAVIT_SAFETY_REMOTE_AUTO:
+    default:
+        return "Auto";
+    }
+}
+
+static const char *heat_level_suffix(enum navit_safety_heat_level level) {
+    switch (level) {
+    case NAVIT_SAFETY_HEAT_CAUTION:
+        return "  Heat: caution";
+    case NAVIT_SAFETY_HEAT_WARNING:
+        return "  Heat: warning";
+    case NAVIT_SAFETY_HEAT_DANGER:
+        return "  Heat: danger";
+    default:
+        return "";
+    }
+}
+
+static void append_foot_travel_status(const struct navit_safety_route_state *state, char *out, int out_len) {
+    char extra[128];
+
+    snprintf(extra, sizeof(extra), "\nWater: %d ml/h%s", state->heat.water_ml_per_hour,
+             heat_level_suffix(state->heat.level));
+    strncat(out, extra, out_len - (int)strlen(out) - 1);
+}
+
+void navit_safety_format_status(const struct navit_safety_route_state *state, const struct navit_safety_config *config,
                                 char *out, int out_len) {
     const struct navit_safety_plan_result *plan;
-    const char *remote;
     const char *mode;
+    const char *remote;
 
     if (!out || out_len <= 0)
         return;
@@ -99,45 +131,15 @@ void navit_safety_format_status(const struct navit_safety_route_state *state,
     }
 
     plan = &state->fuel_plan;
-    switch (config->remote_mode) {
-    case NAVIT_SAFETY_REMOTE_ALWAYS:
-        mode = "Always";
-        break;
-    case NAVIT_SAFETY_REMOTE_OFF:
-        mode = "Off";
-        break;
-    case NAVIT_SAFETY_REMOTE_AUTO:
-    default:
-        mode = "Auto";
-        break;
-    }
+    mode = remote_mode_label(config->remote_mode);
     remote = plan->remote_active ? "active" : "inactive";
 
-    snprintf(out, out_len,
-             "Navit Safety\nRemote: %s (%s)\nBuffer: %d km  Range: %d km\nGap: %d km%s%s",
-             mode, remote, plan->buffer_km, plan->usable_range_km, plan->gap.max_gap_km,
-             plan->gap.warning ? "  WARN" : "",
+    snprintf(out, out_len, "Navit Safety\nRemote: %s (%s)\nBuffer: %d km  Range: %d km\nGap: %d km%s%s", mode, remote,
+             plan->buffer_km, plan->usable_range_km, plan->gap.max_gap_km, plan->gap.warning ? "  WARN" : "",
              plan->desert_warning ? "\nDesert: higher consumption likely" : "");
 
-    if (config->foot_travel_mode) {
-        char extra[128];
-        const char *heat = "";
-        switch (state->heat.level) {
-        case NAVIT_SAFETY_HEAT_CAUTION:
-            heat = "  Heat: caution";
-            break;
-        case NAVIT_SAFETY_HEAT_WARNING:
-            heat = "  Heat: warning";
-            break;
-        case NAVIT_SAFETY_HEAT_DANGER:
-            heat = "  Heat: danger";
-            break;
-        default:
-            break;
-        }
-        snprintf(extra, sizeof(extra), "\nWater: %d ml/h%s", state->heat.water_ml_per_hour, heat);
-        strncat(out, extra, out_len - (int)strlen(out) - 1);
-    }
+    if (config->foot_travel_mode)
+        append_foot_travel_status(state, out, out_len);
 }
 
 #if NAVIT_SAFETY_WITH_OSD
@@ -192,19 +194,20 @@ static void poi_label_from_item(struct item *item, char *out, int out_len) {
 }
 
 static enum navit_safety_confidence score_poi_entry(const struct navit_safety_config *config,
-        struct navit_safety_cache *cache, const char *trip_id, const char *poi_id, int denied) {
+                                                    struct navit_safety_cache *cache, const char *trip_id,
+                                                    const char *poi_id, int denied) {
     struct navit_safety_poi poi;
 
     if (denied)
         return NAVIT_SAFETY_CONFIDENCE_LOW;
 
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
     if (cache && trip_id && poi_id[0] && navit_safety_cache_is_confirmed(cache, poi_id, trip_id))
         return NAVIT_SAFETY_CONFIDENCE_HIGH;
-#else
+#    else
     (void)cache;
     (void)trip_id;
-#endif
+#    endif
 
     (void)config;
     memset(&poi, 0, sizeof(poi));
@@ -230,11 +233,11 @@ static void route_run_plan(struct navit_safety_route_state *state, const struct 
     int n_stops;
 
     navit_safety_build_plan_stops(state->pois, state->n_pois, stops, &n_stops);
-    navit_safety_plan(config, NAVIT_SAFETY_RESOURCE_FUEL, state->mid_lat, state->mid_lon,
-                      stops, n_stops, state->route_length_km, full_range_km, &state->fuel_plan);
+    navit_safety_plan(config, NAVIT_SAFETY_RESOURCE_FUEL, state->mid_lat, state->mid_lon, stops, n_stops,
+                      state->route_length_km, full_range_km, &state->fuel_plan);
     if (config->foot_travel_mode) {
-        navit_safety_plan(config, NAVIT_SAFETY_RESOURCE_WATER, state->mid_lat, state->mid_lon,
-                          stops, n_stops, state->route_length_km, full_range_km, &state->water_plan);
+        navit_safety_plan(config, NAVIT_SAFETY_RESOURCE_WATER, state->mid_lat, state->mid_lon, stops, n_stops,
+                          state->route_length_km, full_range_km, &state->water_plan);
         navit_safety_heat_plan(config, wbgt_c, 1, &state->heat);
     } else {
         memset(&state->water_plan, 0, sizeof(state->water_plan));
@@ -289,8 +292,7 @@ static struct route *route_from_navit(struct navit *nav) {
         return NULL;
     if (!route_get_attr(route_attr.u.route, attr_route_status, &route_status, NULL))
         return NULL;
-    if (route_status.u.num != route_status_path_done_new
-        && route_status.u.num != route_status_path_done_incremental)
+    if (route_status.u.num != route_status_path_done_new && route_status.u.num != route_status_path_done_incremental)
         return NULL;
     return route_attr.u.route;
 }
@@ -386,8 +388,8 @@ static void route_collect_pois(struct navit_safety_route_state *state, struct na
 
 void navit_safety_route_refresh(struct navit_safety_route_state *state, struct navit *nav,
                                 const struct navit_safety_config *config, struct navit_safety_cache *cache,
-                                const char *trip_id, int full_range_km, double wbgt_c,
-                                double vehicle_lat, double vehicle_lon) {
+                                const char *trip_id, int full_range_km, double wbgt_c, double vehicle_lat,
+                                double vehicle_lon) {
     struct route *route;
     struct attr length_attr;
     struct coord mid_coord;
@@ -430,8 +432,8 @@ void navit_safety_route_refresh(struct navit_safety_route_state *state, struct n
 
 int navit_safety_route_confirm_nearest(struct navit_safety_route_state *state, struct navit *nav,
                                        const struct navit_safety_config *config, struct navit_safety_cache *cache,
-                                       const char *trip_id, int full_range_km, double wbgt_c,
-                                       double vehicle_lat, double vehicle_lon) {
+                                       const char *trip_id, int full_range_km, double wbgt_c, double vehicle_lat,
+                                       double vehicle_lon) {
     struct navit_safety_poi_entry *entry;
 
     (void)nav;
@@ -439,15 +441,15 @@ int navit_safety_route_confirm_nearest(struct navit_safety_route_state *state, s
         return -1;
 
     entry = &state->pois[state->nearest_idx];
-#if NAVIT_SAFETY_WITH_SQLITE
+#    if NAVIT_SAFETY_WITH_SQLITE
     if (cache && trip_id) {
         time_t now = time(NULL);
         navit_safety_cache_confirm(cache, entry->poi_id, trip_id, (long)now);
     }
-#else
+#    else
     (void)cache;
     (void)trip_id;
-#endif
+#    endif
     entry->denied = 0;
     entry->confidence = NAVIT_SAFETY_CONFIDENCE_HIGH;
     route_run_plan(state, config, full_range_km, wbgt_c);
@@ -457,8 +459,8 @@ int navit_safety_route_confirm_nearest(struct navit_safety_route_state *state, s
 
 int navit_safety_route_deny_nearest(struct navit_safety_route_state *state, struct navit *nav,
                                     const struct navit_safety_config *config, struct navit_safety_cache *cache,
-                                    const char *trip_id, int full_range_km, double wbgt_c,
-                                    double vehicle_lat, double vehicle_lon) {
+                                    const char *trip_id, int full_range_km, double wbgt_c, double vehicle_lat,
+                                    double vehicle_lon) {
     struct navit_safety_poi_entry *entry;
 
     (void)nav;

--- a/navit/plugin/navit_safety/navit_safety_route.c
+++ b/navit/plugin/navit_safety/navit_safety_route.c
@@ -1,0 +1,478 @@
+/**
+ * @file navit_safety_route.c
+ * @brief Live route-corridor scanning and planning state implementation.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#if NAVIT_SAFETY_WITH_OSD
+#include <glib.h>
+#include "attr.h"
+#include "callback.h"
+#include "coord.h"
+#include "debug.h"
+#include "item.h"
+#include "map.h"
+#include "mapset.h"
+#include "navit.h"
+#include "route.h"
+#include "transform.h"
+#if NAVIT_SAFETY_WITH_SQLITE
+#include "navit_safety_cache.h"
+#endif
+#endif /* NAVIT_SAFETY_WITH_OSD */
+#include "navit_safety.h"
+#include "navit_safety_confidence.h"
+#include "navit_safety_heat.h"
+#include "navit_safety_route.h"
+
+#define NAVIT_SAFETY_CORRIDOR_HALF_M 25000
+#define NAVIT_SAFETY_SAMPLE_STEP_M 25000
+#define NAVIT_SAFETY_MAX_POIS 128
+
+void navit_safety_route_state_init(struct navit_safety_route_state *state) {
+    if (!state)
+        return;
+    memset(state, 0, sizeof(*state));
+    state->nearest_idx = -1;
+}
+
+void navit_safety_route_state_clear(struct navit_safety_route_state *state) {
+    if (!state)
+        return;
+    free(state->pois);
+    state->pois = NULL;
+    state->n_pois = 0;
+    state->valid = 0;
+    state->nearest_idx = -1;
+    state->status[0] = 0;
+}
+
+void navit_safety_build_plan_stops(const struct navit_safety_poi_entry *pois, int n_pois,
+                                   struct navit_safety_stop *stops, int *n_stops) {
+    int i;
+    int out;
+
+    if (!n_stops)
+        return;
+    out = 0;
+    for (i = 0; pois && i < n_pois; i++) {
+        if (pois[i].denied)
+            continue;
+        if (!stops)
+            continue;
+        stops[out].distance_km = pois[i].distance_km;
+        stops[out].confidence = pois[i].confidence;
+        out++;
+    }
+    *n_stops = out;
+}
+
+void navit_safety_format_status(const struct navit_safety_route_state *state,
+                                const struct navit_safety_config *config,
+                                char *out, int out_len) {
+    const struct navit_safety_plan_result *plan;
+    const char *remote;
+    const char *mode;
+
+    if (!out || out_len <= 0)
+        return;
+    out[0] = 0;
+    if (!state || !config)
+        return;
+
+    if (!state->valid) {
+        snprintf(out, out_len, "Navit Safety\nNo active route");
+        return;
+    }
+
+    plan = &state->fuel_plan;
+    switch (config->remote_mode) {
+    case NAVIT_SAFETY_REMOTE_ALWAYS:
+        mode = "Always";
+        break;
+    case NAVIT_SAFETY_REMOTE_OFF:
+        mode = "Off";
+        break;
+    case NAVIT_SAFETY_REMOTE_AUTO:
+    default:
+        mode = "Auto";
+        break;
+    }
+    remote = plan->remote_active ? "active" : "inactive";
+
+    snprintf(out, out_len,
+             "Navit Safety\nRemote: %s (%s)\nBuffer: %d km  Range: %d km\nGap: %d km%s%s",
+             mode, remote, plan->buffer_km, plan->usable_range_km, plan->gap.max_gap_km,
+             plan->gap.warning ? "  WARN" : "",
+             plan->desert_warning ? "\nDesert: higher consumption likely" : "");
+
+    if (config->foot_travel_mode) {
+        char extra[128];
+        const char *heat = "";
+        switch (state->heat.level) {
+        case NAVIT_SAFETY_HEAT_CAUTION:
+            heat = "  Heat: caution";
+            break;
+        case NAVIT_SAFETY_HEAT_WARNING:
+            heat = "  Heat: warning";
+            break;
+        case NAVIT_SAFETY_HEAT_DANGER:
+            heat = "  Heat: danger";
+            break;
+        default:
+            break;
+        }
+        snprintf(extra, sizeof(extra), "\nWater: %d ml/h%s", state->heat.water_ml_per_hour, heat);
+        strncat(out, extra, out_len - (int)strlen(out) - 1);
+    }
+}
+
+#if NAVIT_SAFETY_WITH_OSD
+
+static int poi_entry_compare(const void *a, const void *b) {
+    const struct navit_safety_poi_entry *pa = a;
+    const struct navit_safety_poi_entry *pb = b;
+    return pa->distance_km - pb->distance_km;
+}
+
+static int item_is_fuel(enum item_type type) {
+    return type == type_poi_fuel;
+}
+
+static int item_is_water(enum item_type type) {
+    return type == type_poi_drinking_water || type == type_poi_water_feature;
+}
+
+static int item_matches_resource(enum item_type type, int foot_travel) {
+    if (foot_travel)
+        return item_is_water(type);
+    return item_is_fuel(type);
+}
+
+static void poi_id_from_item(struct item *item, char *out, int out_len) {
+    struct attr attr;
+
+    if (!out || out_len <= 0)
+        return;
+    out[0] = 0;
+    if (!item)
+        return;
+    if (item_attr_get(item, attr_osm_wayid, &attr)) {
+        g_snprintf(out, out_len, "osm:%llu", (unsigned long long)*attr.u.num64);
+        return;
+    }
+    g_snprintf(out, out_len, "map:%d:%d", item->id_hi, item->id_lo);
+}
+
+static void poi_label_from_item(struct item *item, char *out, int out_len) {
+    struct attr attr;
+
+    if (!out || out_len <= 0)
+        return;
+    out[0] = 0;
+    if (!item)
+        return;
+    if (item_attr_get(item, attr_label, &attr))
+        g_snprintf(out, out_len, "%s", map_convert_string_tmp(item->map, attr.u.str));
+    else
+        g_snprintf(out, out_len, "%s", item_to_name(item->type));
+}
+
+static enum navit_safety_confidence score_poi_entry(const struct navit_safety_config *config,
+        struct navit_safety_cache *cache, const char *trip_id, const char *poi_id, int denied) {
+    struct navit_safety_poi poi;
+
+    if (denied)
+        return NAVIT_SAFETY_CONFIDENCE_LOW;
+
+#if NAVIT_SAFETY_WITH_SQLITE
+    if (cache && trip_id && poi_id[0] && navit_safety_cache_is_confirmed(cache, poi_id, trip_id))
+        return NAVIT_SAFETY_CONFIDENCE_HIGH;
+#else
+    (void)cache;
+    (void)trip_id;
+#endif
+
+    (void)config;
+    memset(&poi, 0, sizeof(poi));
+    poi.source = NAVIT_SAFETY_SRC_OSM_INDEPENDENT;
+    poi.age_days = -1;
+    poi.depopulating_region = 0;
+    return navit_safety_score_poi(&poi);
+}
+
+static int poi_index_by_id(struct navit_safety_poi_entry *pois, int n_pois, const char *poi_id) {
+    int i;
+
+    for (i = 0; i < n_pois; i++) {
+        if (!strcmp(pois[i].poi_id, poi_id))
+            return i;
+    }
+    return -1;
+}
+
+static void route_run_plan(struct navit_safety_route_state *state, const struct navit_safety_config *config,
+                           int full_range_km, double wbgt_c) {
+    struct navit_safety_stop stops[NAVIT_SAFETY_MAX_POIS];
+    int n_stops;
+
+    navit_safety_build_plan_stops(state->pois, state->n_pois, stops, &n_stops);
+    navit_safety_plan(config, NAVIT_SAFETY_RESOURCE_FUEL, state->mid_lat, state->mid_lon,
+                      stops, n_stops, state->route_length_km, full_range_km, &state->fuel_plan);
+    if (config->foot_travel_mode) {
+        navit_safety_plan(config, NAVIT_SAFETY_RESOURCE_WATER, state->mid_lat, state->mid_lon,
+                          stops, n_stops, state->route_length_km, full_range_km, &state->water_plan);
+        navit_safety_heat_plan(config, wbgt_c, 1, &state->heat);
+    } else {
+        memset(&state->water_plan, 0, sizeof(state->water_plan));
+        memset(&state->heat, 0, sizeof(state->heat));
+    }
+    navit_safety_format_status(state, config, state->status, (int)sizeof(state->status));
+}
+
+static void route_find_nearest(struct navit_safety_route_state *state, double vehicle_lat, double vehicle_lon) {
+    int i;
+    int best = -1;
+    double best_dist = 1e18;
+    struct coord_geo vehicle;
+    struct coord vcoord;
+    enum projection pro = projection_mg;
+
+    state->nearest_idx = -1;
+    if (!isfinite(vehicle_lat) || !isfinite(vehicle_lon))
+        return;
+
+    vehicle.lat = vehicle_lat;
+    vehicle.lng = vehicle_lon;
+    transform_from_geo(pro, &vehicle, &vcoord);
+
+    for (i = 0; i < state->n_pois; i++) {
+        struct coord_geo poi_geo;
+        struct coord pcoord;
+        double d;
+
+        if (state->pois[i].denied)
+            continue;
+        if (state->pois[i].confidence >= NAVIT_SAFETY_CONFIDENCE_HIGH)
+            continue;
+
+        poi_geo.lat = state->pois[i].lat;
+        poi_geo.lng = state->pois[i].lon;
+        transform_from_geo(pro, &poi_geo, &pcoord);
+        d = transform_distance(pro, &vcoord, &pcoord);
+        if (d < best_dist) {
+            best_dist = d;
+            best = i;
+        }
+    }
+    state->nearest_idx = best;
+}
+
+static struct route *route_from_navit(struct navit *nav) {
+    struct attr route_attr;
+    struct attr route_status;
+
+    if (!navit_get_attr(nav, attr_route, &route_attr, NULL))
+        return NULL;
+    if (!route_get_attr(route_attr.u.route, attr_route_status, &route_status, NULL))
+        return NULL;
+    if (route_status.u.num != route_status_path_done_new
+        && route_status.u.num != route_status_path_done_incremental)
+        return NULL;
+    return route_attr.u.route;
+}
+
+static void route_collect_pois(struct navit_safety_route_state *state, struct navit *nav,
+                               const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                               const char *trip_id, struct route *route, int route_length_m, int foot_travel) {
+    struct navit_safety_poi_entry *pois;
+    int n_pois;
+    int sample;
+    enum projection pro = projection_mg;
+
+    pois = g_new0(struct navit_safety_poi_entry, NAVIT_SAFETY_MAX_POIS);
+    n_pois = 0;
+
+    for (sample = 0; sample <= route_length_m; sample += NAVIT_SAFETY_SAMPLE_STEP_M) {
+        struct coord sample_coord;
+        struct pcoord pc;
+        struct map_selection *sel;
+        struct mapset_handle *handle;
+        struct map *map;
+
+        sample_coord = route_get_coord_dist(route, sample);
+        pc.x = sample_coord.x;
+        pc.y = sample_coord.y;
+        pc.pro = pro;
+
+        sel = map_selection_rect_new(&pc, NAVIT_SAFETY_CORRIDOR_HALF_M, 18);
+        if (!sel)
+            continue;
+
+        handle = mapset_open(navit_get_mapset(nav));
+        while ((map = mapset_next(handle, 1))) {
+            struct map_rect *mr;
+            struct item *item;
+            struct map_selection *sel_map;
+
+            sel_map = map_selection_dup_pro(sel, pro, map_projection(map));
+            mr = map_rect_new(map, sel_map);
+            if (!mr) {
+                map_selection_destroy(sel_map);
+                continue;
+            }
+            while ((item = map_rect_get_item(mr))) {
+                struct coord c;
+                struct coord_geo geo;
+                char poi_id[64];
+                int idx;
+                int along_m;
+
+                if (!item_matches_resource(item->type, foot_travel))
+                    continue;
+                if (!item_coord_get_pro(item, &c, 1, pro))
+                    continue;
+                if (!coord_rect_contains(&sel->u.c_rect, &c))
+                    continue;
+
+                route_get_distances(route, &c, 1, &along_m);
+                if (along_m < 0 || along_m == INT_MAX)
+                    continue;
+
+                poi_id_from_item(item, poi_id, sizeof(poi_id));
+                idx = poi_index_by_id(pois, n_pois, poi_id);
+                if (idx < 0) {
+                    struct navit_safety_poi_entry *entry;
+                    if (n_pois >= NAVIT_SAFETY_MAX_POIS)
+                        continue;
+                    entry = &pois[n_pois++];
+                    g_strlcpy(entry->poi_id, poi_id, sizeof(entry->poi_id));
+                    poi_label_from_item(item, entry->label, sizeof(entry->label));
+                    transform_to_geo(pro, &c, &geo);
+                    entry->lat = geo.lat;
+                    entry->lon = geo.lng;
+                    entry->distance_km = along_m / 1000;
+                    entry->denied = 0;
+                    entry->confidence = score_poi_entry(config, cache, trip_id, poi_id, 0);
+                }
+            }
+            map_rect_destroy(mr);
+            map_selection_destroy(sel_map);
+        }
+        mapset_close(handle);
+        map_selection_destroy(sel);
+    }
+
+    if (n_pois > 1)
+        qsort(pois, n_pois, sizeof(*pois), poi_entry_compare);
+
+    g_free(state->pois);
+    state->pois = pois;
+    state->n_pois = n_pois;
+}
+
+void navit_safety_route_refresh(struct navit_safety_route_state *state, struct navit *nav,
+                                const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                const char *trip_id, int full_range_km, double wbgt_c,
+                                double vehicle_lat, double vehicle_lon) {
+    struct route *route;
+    struct attr length_attr;
+    struct coord mid_coord;
+    struct coord_geo mid_geo;
+    int route_length_m;
+    enum projection pro;
+
+    if (!state || !nav || !config)
+        return;
+
+    state->valid = 0;
+    state->nearest_idx = -1;
+    state->status[0] = 0;
+
+    route = route_from_navit(nav);
+    if (!route) {
+        navit_safety_format_status(state, config, state->status, (int)sizeof(state->status));
+        return;
+    }
+
+    if (!route_get_attr(route, attr_destination_length, &length_attr, NULL) || length_attr.u.num <= 0) {
+        navit_safety_format_status(state, config, state->status, (int)sizeof(state->status));
+        return;
+    }
+
+    route_length_m = length_attr.u.num;
+    state->route_length_km = (route_length_m + 999) / 1000;
+
+    pro = projection_mg;
+    mid_coord = route_get_coord_dist(route, route_length_m / 2);
+    transform_to_geo(pro, &mid_coord, &mid_geo);
+    state->mid_lat = mid_geo.lat;
+    state->mid_lon = mid_geo.lng;
+
+    route_collect_pois(state, nav, config, cache, trip_id, route, route_length_m, config->foot_travel_mode);
+    route_run_plan(state, config, full_range_km, wbgt_c);
+    route_find_nearest(state, vehicle_lat, vehicle_lon);
+    state->valid = 1;
+}
+
+int navit_safety_route_confirm_nearest(struct navit_safety_route_state *state, struct navit *nav,
+                                       const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                       const char *trip_id, int full_range_km, double wbgt_c,
+                                       double vehicle_lat, double vehicle_lon) {
+    struct navit_safety_poi_entry *entry;
+
+    (void)nav;
+    if (!state || state->nearest_idx < 0 || state->nearest_idx >= state->n_pois)
+        return -1;
+
+    entry = &state->pois[state->nearest_idx];
+#if NAVIT_SAFETY_WITH_SQLITE
+    if (cache && trip_id) {
+        time_t now = time(NULL);
+        navit_safety_cache_confirm(cache, entry->poi_id, trip_id, (long)now);
+    }
+#else
+    (void)cache;
+    (void)trip_id;
+#endif
+    entry->denied = 0;
+    entry->confidence = NAVIT_SAFETY_CONFIDENCE_HIGH;
+    route_run_plan(state, config, full_range_km, wbgt_c);
+    route_find_nearest(state, vehicle_lat, vehicle_lon);
+    return 0;
+}
+
+int navit_safety_route_deny_nearest(struct navit_safety_route_state *state, struct navit *nav,
+                                    const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                    const char *trip_id, int full_range_km, double wbgt_c,
+                                    double vehicle_lat, double vehicle_lon) {
+    struct navit_safety_poi_entry *entry;
+
+    (void)nav;
+    (void)cache;
+    (void)trip_id;
+    if (!state || state->nearest_idx < 0 || state->nearest_idx >= state->n_pois)
+        return -1;
+
+    entry = &state->pois[state->nearest_idx];
+    entry->denied = 1;
+    entry->confidence = NAVIT_SAFETY_CONFIDENCE_LOW;
+    route_run_plan(state, config, full_range_km, wbgt_c);
+    route_find_nearest(state, vehicle_lat, vehicle_lon);
+    return 0;
+}
+
+#endif /* NAVIT_SAFETY_WITH_OSD */

--- a/navit/plugin/navit_safety/navit_safety_route.h
+++ b/navit/plugin/navit_safety/navit_safety_route.h
@@ -1,0 +1,128 @@
+/**
+ * @file navit_safety_route.h
+ * @brief Live route-corridor scanning and planning state for the Navit Safety plugin.
+ *
+ * Navit, a modular navigation system.
+ *
+ * Copyright (C) 2025-2026 Navit Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef NAVIT_PLUGIN_NAVIT_SAFETY_ROUTE_H
+#define NAVIT_PLUGIN_NAVIT_SAFETY_ROUTE_H
+
+#include "navit_safety_confidence.h"
+#include "navit_safety_heat.h"
+#include "navit_safety_lookahead.h"
+#include "navit_safety_plan.h"
+
+struct navit;
+struct navit_safety_cache;
+struct navit_safety_config;
+
+/** @brief A resupply POI found along the active route corridor. */
+struct navit_safety_poi_entry {
+    char poi_id[64];                     /**< Stable identifier (OSM way id or map item id). */
+    char label[96];                      /**< Display label. */
+    double lat;                          /**< WGS84 latitude. */
+    double lon;                          /**< WGS84 longitude. */
+    int distance_km;                     /**< Distance from the route start. */
+    enum navit_safety_confidence confidence; /**< Scored reliability. */
+    int denied;                          /**< Nonzero if the user denied this stop for the trip. */
+};
+
+/** @brief Cached planning state for the active route. */
+struct navit_safety_route_state {
+    struct navit_safety_plan_result fuel_plan;   /**< Fuel (or primary) resource plan. */
+    struct navit_safety_plan_result water_plan;  /**< Water plan when foot travel is enabled. */
+    struct navit_safety_heat_result heat;        /**< Foot-travel heat assessment. */
+    struct navit_safety_poi_entry *pois;         /**< POIs along the corridor (owned). */
+    int n_pois;                                  /**< Number of entries in @p pois. */
+    int route_length_km;                         /**< Active route length. */
+    double mid_lat;                            /**< Mid-route latitude for terrain lookup. */
+    double mid_lon;                            /**< Mid-route longitude for terrain lookup. */
+    int nearest_idx;                           /**< Index of the nearest actionable POI, or -1. */
+    char status[512];                          /**< Multi-line status for the OSD. */
+    int valid;                                 /**< Nonzero when a calculated route is loaded. */
+};
+
+/** @brief Initialise an empty route state (does not allocate POI storage). */
+void navit_safety_route_state_init(struct navit_safety_route_state *state);
+
+/** @brief Release POI storage held by @p state. */
+void navit_safety_route_state_clear(struct navit_safety_route_state *state);
+
+/**
+ * @brief Build the ordered stop list used by the planning engines.
+ *
+ * Denied POIs are omitted. @p stops must hold at least @p n_pois entries.
+ *
+ * @param pois POI array (may be NULL when @p n_pois is 0).
+ * @param n_pois Number of POIs.
+ * @param stops Output stop array.
+ * @param n_stops Filled with the number of stops written.
+ */
+void navit_safety_build_plan_stops(const struct navit_safety_poi_entry *pois, int n_pois,
+                                   struct navit_safety_stop *stops, int *n_stops);
+
+/**
+ * @brief Compose the multi-line OSD status string from a route state.
+ *
+ * @param state Route state (must not be NULL).
+ * @param config Plugin configuration (must not be NULL).
+ * @param out Output buffer.
+ * @param out_len Size of @p out.
+ */
+void navit_safety_format_status(const struct navit_safety_route_state *state,
+                                const struct navit_safety_config *config,
+                                char *out, int out_len);
+
+#if NAVIT_SAFETY_WITH_OSD
+
+/**
+ * @brief Scan the active route corridor and refresh the planning state.
+ *
+ * Reads the calculated route from @p nav, searches the mapset for fuel or water
+ * POIs within the corridor, scores them, and runs the planning engines. When
+ * @p vehicle_lat and @p vehicle_lon are finite, @p state->nearest_idx points at
+ * the closest POI that can be confirmed or denied.
+ *
+ * @param state State to refresh (must not be NULL).
+ * @param nav Navit instance.
+ * @param config Plugin configuration.
+ * @param cache Confirmation cache (may be NULL).
+ * @param trip_id Trip identifier for cache lookups.
+ * @param full_range_km Usable range on a full tank or water load, before buffers.
+ * @param wbgt_c Wet-bulb globe temperature for the foot-travel heat model.
+ * @param vehicle_lat Vehicle latitude (NaN to skip nearest-POI selection).
+ * @param vehicle_lon Vehicle longitude (NaN to skip nearest-POI selection).
+ */
+void navit_safety_route_refresh(struct navit_safety_route_state *state, struct navit *nav,
+                                const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                const char *trip_id, int full_range_km, double wbgt_c,
+                                double vehicle_lat, double vehicle_lon);
+
+/**
+ * @brief Mark the nearest actionable POI as confirmed and recalculate the plan.
+ * @return 0 on success, -1 when no POI is selected.
+ */
+int navit_safety_route_confirm_nearest(struct navit_safety_route_state *state, struct navit *nav,
+                                     const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                     const char *trip_id, int full_range_km, double wbgt_c,
+                                     double vehicle_lat, double vehicle_lon);
+
+/**
+ * @brief Mark the nearest actionable POI as denied and recalculate the plan.
+ * @return 0 on success, -1 when no POI is selected.
+ */
+int navit_safety_route_deny_nearest(struct navit_safety_route_state *state, struct navit *nav,
+                                  const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                  const char *trip_id, int full_range_km, double wbgt_c,
+                                  double vehicle_lat, double vehicle_lon);
+
+#endif /* NAVIT_SAFETY_WITH_OSD */
+
+#endif /* NAVIT_PLUGIN_NAVIT_SAFETY_ROUTE_H */

--- a/navit/plugin/navit_safety/navit_safety_route.h
+++ b/navit/plugin/navit_safety/navit_safety_route.h
@@ -25,28 +25,28 @@ struct navit_safety_config;
 
 /** @brief A resupply POI found along the active route corridor. */
 struct navit_safety_poi_entry {
-    char poi_id[64];                     /**< Stable identifier (OSM way id or map item id). */
-    char label[96];                      /**< Display label. */
-    double lat;                          /**< WGS84 latitude. */
-    double lon;                          /**< WGS84 longitude. */
-    int distance_km;                     /**< Distance from the route start. */
+    char poi_id[64];                         /**< Stable identifier (OSM way id or map item id). */
+    char label[96];                          /**< Display label. */
+    double lat;                              /**< WGS84 latitude. */
+    double lon;                              /**< WGS84 longitude. */
+    int distance_km;                         /**< Distance from the route start. */
     enum navit_safety_confidence confidence; /**< Scored reliability. */
-    int denied;                          /**< Nonzero if the user denied this stop for the trip. */
+    int denied;                              /**< Nonzero if the user denied this stop for the trip. */
 };
 
 /** @brief Cached planning state for the active route. */
 struct navit_safety_route_state {
-    struct navit_safety_plan_result fuel_plan;   /**< Fuel (or primary) resource plan. */
-    struct navit_safety_plan_result water_plan;  /**< Water plan when foot travel is enabled. */
-    struct navit_safety_heat_result heat;        /**< Foot-travel heat assessment. */
-    struct navit_safety_poi_entry *pois;         /**< POIs along the corridor (owned). */
-    int n_pois;                                  /**< Number of entries in @p pois. */
-    int route_length_km;                         /**< Active route length. */
-    double mid_lat;                            /**< Mid-route latitude for terrain lookup. */
-    double mid_lon;                            /**< Mid-route longitude for terrain lookup. */
-    int nearest_idx;                           /**< Index of the nearest actionable POI, or -1. */
-    char status[512];                          /**< Multi-line status for the OSD. */
-    int valid;                                 /**< Nonzero when a calculated route is loaded. */
+    struct navit_safety_plan_result fuel_plan;  /**< Fuel (or primary) resource plan. */
+    struct navit_safety_plan_result water_plan; /**< Water plan when foot travel is enabled. */
+    struct navit_safety_heat_result heat;       /**< Foot-travel heat assessment. */
+    struct navit_safety_poi_entry *pois;        /**< POIs along the corridor (owned). */
+    int n_pois;                                 /**< Number of entries in @p pois. */
+    int route_length_km;                        /**< Active route length. */
+    double mid_lat;                             /**< Mid-route latitude for terrain lookup. */
+    double mid_lon;                             /**< Mid-route longitude for terrain lookup. */
+    int nearest_idx;                            /**< Index of the nearest actionable POI, or -1. */
+    char status[512];                           /**< Multi-line status for the OSD. */
+    int valid;                                  /**< Nonzero when a calculated route is loaded. */
 };
 
 /** @brief Initialise an empty route state (does not allocate POI storage). */
@@ -76,8 +76,7 @@ void navit_safety_build_plan_stops(const struct navit_safety_poi_entry *pois, in
  * @param out Output buffer.
  * @param out_len Size of @p out.
  */
-void navit_safety_format_status(const struct navit_safety_route_state *state,
-                                const struct navit_safety_config *config,
+void navit_safety_format_status(const struct navit_safety_route_state *state, const struct navit_safety_config *config,
                                 char *out, int out_len);
 
 #if NAVIT_SAFETY_WITH_OSD
@@ -102,26 +101,26 @@ void navit_safety_format_status(const struct navit_safety_route_state *state,
  */
 void navit_safety_route_refresh(struct navit_safety_route_state *state, struct navit *nav,
                                 const struct navit_safety_config *config, struct navit_safety_cache *cache,
-                                const char *trip_id, int full_range_km, double wbgt_c,
-                                double vehicle_lat, double vehicle_lon);
+                                const char *trip_id, int full_range_km, double wbgt_c, double vehicle_lat,
+                                double vehicle_lon);
 
 /**
  * @brief Mark the nearest actionable POI as confirmed and recalculate the plan.
  * @return 0 on success, -1 when no POI is selected.
  */
 int navit_safety_route_confirm_nearest(struct navit_safety_route_state *state, struct navit *nav,
-                                     const struct navit_safety_config *config, struct navit_safety_cache *cache,
-                                     const char *trip_id, int full_range_km, double wbgt_c,
-                                     double vehicle_lat, double vehicle_lon);
+                                       const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                       const char *trip_id, int full_range_km, double wbgt_c, double vehicle_lat,
+                                       double vehicle_lon);
 
 /**
  * @brief Mark the nearest actionable POI as denied and recalculate the plan.
  * @return 0 on success, -1 when no POI is selected.
  */
 int navit_safety_route_deny_nearest(struct navit_safety_route_state *state, struct navit *nav,
-                                  const struct navit_safety_config *config, struct navit_safety_cache *cache,
-                                  const char *trip_id, int full_range_km, double wbgt_c,
-                                  double vehicle_lat, double vehicle_lon);
+                                    const struct navit_safety_config *config, struct navit_safety_cache *cache,
+                                    const char *trip_id, int full_range_km, double wbgt_c, double vehicle_lat,
+                                    double vehicle_lon);
 
 #endif /* NAVIT_SAFETY_WITH_OSD */
 

--- a/navit/plugin/navit_safety/tests/CMakeLists.txt
+++ b/navit/plugin/navit_safety/tests/CMakeLists.txt
@@ -1,0 +1,85 @@
+# Unit tests for Navit Safety plugin
+
+# navit_safety.c with the OSD path compiled out, exposing navit_safety_config_default
+# without the Navit OSD/core symbols.
+add_library(navit_safety_config_obj OBJECT
+    ../navit_safety.c
+)
+
+target_compile_definitions(navit_safety_config_obj PRIVATE NAVIT_SAFETY_WITH_OSD=0)
+
+target_include_directories(navit_safety_config_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+# Navit plugin modules are not added through CMake's normal add_subdirectory
+# chain, so enable_testing() must be called here for ctest to pick up the tests
+# from this directory (matches the other Navit plugin test directories).
+enable_testing()
+
+# Declare a Navit Safety test executable and register it with ctest.
+function(navit_safety_add_test name)
+    add_executable(${name} ${ARGN})
+    target_include_directories(${name} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+navit_safety_add_test(test_navit_safety_config
+    test_navit_safety_config.c
+    $<TARGET_OBJECTS:navit_safety_config_obj>
+)
+
+navit_safety_add_test(test_navit_safety_confidence
+    test_navit_safety_confidence.c
+    ../navit_safety_confidence.c
+)
+
+navit_safety_add_test(test_navit_safety_koppen
+    test_navit_safety_koppen.c
+    ../navit_safety_koppen.c
+)
+
+navit_safety_add_test(test_navit_safety_lookahead
+    test_navit_safety_lookahead.c
+    ../navit_safety_lookahead.c
+    ../navit_safety_confidence.c
+)
+
+navit_safety_add_test(test_navit_safety_plan
+    test_navit_safety_plan.c
+    ../navit_safety_plan.c
+    ../navit_safety_koppen.c
+    ../navit_safety_lookahead.c
+    ../navit_safety_confidence.c
+    $<TARGET_OBJECTS:navit_safety_config_obj>
+)
+
+navit_safety_add_test(test_navit_safety_heat
+    test_navit_safety_heat.c
+    ../navit_safety_heat.c
+    $<TARGET_OBJECTS:navit_safety_config_obj>
+)
+
+navit_safety_add_test(test_navit_safety_route
+    test_navit_safety_route.c
+    ../navit_safety_route.c
+    $<TARGET_OBJECTS:navit_safety_config_obj>
+)
+
+# The confirmation cache and its test only build when SQLite3 is available.
+if(SQLITE3_FOUND)
+    add_executable(test_navit_safety_cache
+        test_navit_safety_cache.c
+        ../navit_safety_cache.c
+    )
+    target_include_directories(test_navit_safety_cache PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${SQLITE3_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_navit_safety_cache ${SQLITE3_LIBRARIES})
+    add_test(NAME test_navit_safety_cache COMMAND test_navit_safety_cache)
+endif()

--- a/navit/plugin/navit_safety/tests/test_navit_safety_cache.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_cache.c
@@ -4,8 +4,8 @@
  * Unit tests for the Navit Safety SQLite confirmation cache.
  */
 
-#include <stdio.h>
 #include "navit_safety_cache.h"
+#include <stdio.h>
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \
@@ -19,20 +19,14 @@ static int test_confirm_and_query(void) {
     struct navit_safety_cache *cache = navit_safety_cache_open(":memory:");
     TEST_ASSERT(cache != NULL, "in-memory cache should open");
 
-    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-1", "trip-A"),
-                "unknown POI should not be confirmed");
-    TEST_ASSERT(navit_safety_cache_confirm(cache, "poi-1", "trip-A", 1000),
-                "confirming a POI should succeed");
-    TEST_ASSERT(navit_safety_cache_is_confirmed(cache, "poi-1", "trip-A"),
-                "confirmed POI should report confirmed");
-    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-1", "trip-B"),
-                "confirmation is scoped to its trip");
-    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-2", "trip-A"),
-                "other POIs remain unconfirmed");
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-1", "trip-A"), "unknown POI should not be confirmed");
+    TEST_ASSERT(navit_safety_cache_confirm(cache, "poi-1", "trip-A", 1000), "confirming a POI should succeed");
+    TEST_ASSERT(navit_safety_cache_is_confirmed(cache, "poi-1", "trip-A"), "confirmed POI should report confirmed");
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-1", "trip-B"), "confirmation is scoped to its trip");
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-2", "trip-A"), "other POIs remain unconfirmed");
 
     /* Re-confirming the same key must not fail (INSERT OR REPLACE). */
-    TEST_ASSERT(navit_safety_cache_confirm(cache, "poi-1", "trip-A", 2000),
-                "re-confirming should succeed");
+    TEST_ASSERT(navit_safety_cache_confirm(cache, "poi-1", "trip-A", 2000), "re-confirming should succeed");
 
     navit_safety_cache_close(cache);
     return 0;

--- a/navit/plugin/navit_safety/tests/test_navit_safety_cache.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_cache.c
@@ -1,0 +1,62 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for the Navit Safety SQLite confirmation cache.
+ */
+
+#include <stdio.h>
+#include "navit_safety_cache.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static int test_confirm_and_query(void) {
+    struct navit_safety_cache *cache = navit_safety_cache_open(":memory:");
+    TEST_ASSERT(cache != NULL, "in-memory cache should open");
+
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-1", "trip-A"),
+                "unknown POI should not be confirmed");
+    TEST_ASSERT(navit_safety_cache_confirm(cache, "poi-1", "trip-A", 1000),
+                "confirming a POI should succeed");
+    TEST_ASSERT(navit_safety_cache_is_confirmed(cache, "poi-1", "trip-A"),
+                "confirmed POI should report confirmed");
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-1", "trip-B"),
+                "confirmation is scoped to its trip");
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(cache, "poi-2", "trip-A"),
+                "other POIs remain unconfirmed");
+
+    /* Re-confirming the same key must not fail (INSERT OR REPLACE). */
+    TEST_ASSERT(navit_safety_cache_confirm(cache, "poi-1", "trip-A", 2000),
+                "re-confirming should succeed");
+
+    navit_safety_cache_close(cache);
+    return 0;
+}
+
+static int test_null_safety(void) {
+    TEST_ASSERT(navit_safety_cache_open(NULL) == NULL, "NULL path should fail to open");
+    TEST_ASSERT(!navit_safety_cache_confirm(NULL, "p", "t", 0), "confirm on NULL cache fails");
+    TEST_ASSERT(!navit_safety_cache_is_confirmed(NULL, "p", "t"), "query on NULL cache is false");
+    navit_safety_cache_close(NULL); /* must not crash */
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety cache tests...\n");
+    failures += test_confirm_and_query();
+    failures += test_null_safety();
+
+    if (failures == 0) {
+        printf("All Navit Safety cache tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_confidence.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_confidence.c
@@ -4,8 +4,8 @@
  * Unit tests for Navit Safety POI confidence scoring.
  */
 
-#include <stdio.h>
 #include "navit_safety_confidence.h"
+#include <stdio.h>
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \
@@ -24,8 +24,7 @@ static enum navit_safety_confidence score(enum navit_safety_poi_source source, i
 }
 
 static int test_high_sources(void) {
-    TEST_ASSERT(score(NAVIT_SAFETY_SRC_CHAIN_API, 0, 0) == NAVIT_SAFETY_CONFIDENCE_HIGH,
-                "Chain API should be High");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_CHAIN_API, 0, 0) == NAVIT_SAFETY_CONFIDENCE_HIGH, "Chain API should be High");
     TEST_ASSERT(score(NAVIT_SAFETY_SRC_NREL, 500, 0) == NAVIT_SAFETY_CONFIDENCE_HIGH,
                 "NREL should be High regardless of listed age");
     TEST_ASSERT(score(NAVIT_SAFETY_SRC_USER_CONFIRMED, 9999, 1) == NAVIT_SAFETY_CONFIDENCE_HIGH,
@@ -64,14 +63,12 @@ static int test_downgrades(void) {
                 "Data over 3 years caps at Low");
     TEST_ASSERT(score(NAVIT_SAFETY_SRC_UNKNOWN, 0, 0) == NAVIT_SAFETY_CONFIDENCE_UNKNOWN,
                 "Unknown source yields Unknown");
-    TEST_ASSERT(navit_safety_score_poi(NULL) == NAVIT_SAFETY_CONFIDENCE_UNKNOWN,
-                "NULL POI yields Unknown");
+    TEST_ASSERT(navit_safety_score_poi(NULL) == NAVIT_SAFETY_CONFIDENCE_UNKNOWN, "NULL POI yields Unknown");
     return 0;
 }
 
 static int test_resupply_predicate(void) {
-    TEST_ASSERT(navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_HIGH),
-                "High counts as resupply");
+    TEST_ASSERT(navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_HIGH), "High counts as resupply");
     TEST_ASSERT(navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_MEDIUM),
                 "Medium counts as resupply");
     TEST_ASSERT(!navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_LOW),

--- a/navit/plugin/navit_safety/tests/test_navit_safety_confidence.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_confidence.c
@@ -1,0 +1,100 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for Navit Safety POI confidence scoring.
+ */
+
+#include <stdio.h>
+#include "navit_safety_confidence.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static enum navit_safety_confidence score(enum navit_safety_poi_source source, int age_days, int depopulating) {
+    struct navit_safety_poi poi;
+    poi.source = source;
+    poi.age_days = age_days;
+    poi.depopulating_region = depopulating;
+    return navit_safety_score_poi(&poi);
+}
+
+static int test_high_sources(void) {
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_CHAIN_API, 0, 0) == NAVIT_SAFETY_CONFIDENCE_HIGH,
+                "Chain API should be High");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_NREL, 500, 0) == NAVIT_SAFETY_CONFIDENCE_HIGH,
+                "NREL should be High regardless of listed age");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_USER_CONFIRMED, 9999, 1) == NAVIT_SAFETY_CONFIDENCE_HIGH,
+                "User confirmation overrides age and depopulation");
+    return 0;
+}
+
+static int test_age_dependent(void) {
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_NREL_MATCH, 10, 0) == NAVIT_SAFETY_CONFIDENCE_HIGH,
+                "OSM/NREL match within 30 days should be High");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_NREL_MATCH, 90, 0) == NAVIT_SAFETY_CONFIDENCE_MEDIUM,
+                "OSM/NREL match older than 30 days should be Medium");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_IOVERLANDER, 30, 0) == NAVIT_SAFETY_CONFIDENCE_MEDIUM,
+                "iOverlander within 60 days should be Medium");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_IOVERLANDER, 120, 0) == NAVIT_SAFETY_CONFIDENCE_LOW,
+                "iOverlander older than 60 days should be Low");
+    return 0;
+}
+
+static int test_osm_operators(void) {
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_CHAIN, 200, 0) == NAVIT_SAFETY_CONFIDENCE_MEDIUM,
+                "OSM chain operator should be Medium");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_INDEPENDENT, 100, 0) == NAVIT_SAFETY_CONFIDENCE_MEDIUM,
+                "Independent operator within 12 months should be Medium");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_INDEPENDENT, 700, 0) == NAVIT_SAFETY_CONFIDENCE_LOW,
+                "Independent operator 1-3 years old should be Low");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_INDEPENDENT, 2000, 0) == NAVIT_SAFETY_CONFIDENCE_LOW,
+                "Independent operator over 3 years should be Low");
+    return 0;
+}
+
+static int test_downgrades(void) {
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_CHAIN, 100, 1) == NAVIT_SAFETY_CONFIDENCE_LOW,
+                "Depopulating region caps map POIs at Low");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_OSM_CHAIN, 2000, 0) == NAVIT_SAFETY_CONFIDENCE_LOW,
+                "Data over 3 years caps at Low");
+    TEST_ASSERT(score(NAVIT_SAFETY_SRC_UNKNOWN, 0, 0) == NAVIT_SAFETY_CONFIDENCE_UNKNOWN,
+                "Unknown source yields Unknown");
+    TEST_ASSERT(navit_safety_score_poi(NULL) == NAVIT_SAFETY_CONFIDENCE_UNKNOWN,
+                "NULL POI yields Unknown");
+    return 0;
+}
+
+static int test_resupply_predicate(void) {
+    TEST_ASSERT(navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_HIGH),
+                "High counts as resupply");
+    TEST_ASSERT(navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_MEDIUM),
+                "Medium counts as resupply");
+    TEST_ASSERT(!navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_LOW),
+                "Low does not count as resupply");
+    TEST_ASSERT(!navit_safety_confidence_counts_as_resupply(NAVIT_SAFETY_CONFIDENCE_UNKNOWN),
+                "Unknown does not count as resupply");
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety confidence tests...\n");
+    failures += test_high_sources();
+    failures += test_age_dependent();
+    failures += test_osm_operators();
+    failures += test_downgrades();
+    failures += test_resupply_predicate();
+
+    if (failures == 0) {
+        printf("All Navit Safety confidence tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_config.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_config.c
@@ -1,0 +1,88 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for Navit Safety plugin configuration defaults.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "debug.h"
+#include "navit_safety.h"
+
+/* Stub for debug_printf and max_debug_level for unit tests */
+dbg_level max_debug_level = lvl_error;
+
+void debug_printf(dbg_level level, const char *module, const int mlen, const char *function, const int flen, int prefix,
+                  const char *fmt, ...) {
+    (void)level;
+    (void)module;
+    (void)mlen;
+    (void)function;
+    (void)flen;
+    (void)prefix;
+    (void)fmt;
+}
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static int test_config_defaults(void) {
+    struct navit_safety_config config;
+
+    /* Pre-fill with a non-zero sentinel so fields that default to 0 are only
+     * accepted if navit_safety_config_default explicitly clears them, rather
+     * than passing merely because a memset(0) happened to zero them. */
+    memset(&config, 0xFF, sizeof(config));
+    navit_safety_config_default(&config);
+
+    TEST_ASSERT(config.remote_mode == NAVIT_SAFETY_REMOTE_AUTO, "Default remote mode should be AUTO");
+    TEST_ASSERT(config.poi_density_threshold_km == 80, "Default POI density threshold incorrect");
+    TEST_ASSERT(config.koppen_trigger == 1, "Koppen trigger should be enabled by default");
+
+    TEST_ASSERT(config.fuel_buffer_standard_km == 25, "Standard fuel buffer should be 25 km");
+    TEST_ASSERT(config.fuel_buffer_remote_km == 85, "Remote fuel buffer should be 85 km");
+    TEST_ASSERT(config.fuel_buffer_arid_km == 140, "Arid fuel buffer should be 140 km");
+
+    TEST_ASSERT(config.water_buffer_standard_km == 5, "Standard water buffer should be 5 km");
+    TEST_ASSERT(config.water_buffer_remote_km == 20, "Remote water buffer should be 20 km");
+    TEST_ASSERT(config.water_buffer_arid_km == 30, "Arid water buffer should be 30 km");
+
+    TEST_ASSERT(config.desert_consumption_warning == 1, "Desert consumption warning should be enabled");
+    TEST_ASSERT(config.census_depopulation_layer == 1, "Census depopulation layer should be enabled");
+    TEST_ASSERT(config.chain_api_queries == 1, "Chain API queries should be enabled by default");
+    TEST_ASSERT(config.unconfirmed_poi_display == 1, "Unconfirmed POI display should be enabled");
+
+    TEST_ASSERT(config.foot_travel_mode == 0, "Foot travel mode should be disabled by default");
+    TEST_ASSERT(config.body_weight_kg == 70, "Default body weight should be 70 kg");
+    TEST_ASSERT(config.heat_stress_warnings == 1, "Heat stress warnings should be enabled");
+
+    return 0;
+}
+
+/* navit_safety_config_default must tolerate a NULL pointer without crashing. */
+static int test_config_default_null(void) {
+    navit_safety_config_default(NULL);
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety plugin configuration tests...\n");
+
+    failures += test_config_defaults();
+    failures += test_config_default_null();
+
+    if (failures == 0) {
+        printf("All Navit Safety configuration tests passed!\n");
+        return 0;
+    }
+
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_config.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_config.c
@@ -4,10 +4,10 @@
  * Unit tests for Navit Safety plugin configuration defaults.
  */
 
-#include <stdio.h>
-#include <string.h>
 #include "debug.h"
 #include "navit_safety.h"
+#include <stdio.h>
+#include <string.h>
 
 /* Stub for debug_printf and max_debug_level for unit tests */
 dbg_level max_debug_level = lvl_error;

--- a/navit/plugin/navit_safety/tests/test_navit_safety_heat.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_heat.c
@@ -1,0 +1,74 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for the Navit Safety heat-stress and water-requirement engine.
+ */
+
+#include <stdio.h>
+#include "navit_safety.h"
+#include "navit_safety_heat.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+/* WBGT thresholds map to the documented risk levels. */
+static int test_assess_thresholds(void) {
+    TEST_ASSERT(navit_safety_heat_assess(27.9) == NAVIT_SAFETY_HEAT_NONE, "Below 28 C is no warning");
+    TEST_ASSERT(navit_safety_heat_assess(28.0) == NAVIT_SAFETY_HEAT_CAUTION, "28 C is caution");
+    TEST_ASSERT(navit_safety_heat_assess(31.9) == NAVIT_SAFETY_HEAT_CAUTION, "Just under 32 C is caution");
+    TEST_ASSERT(navit_safety_heat_assess(32.0) == NAVIT_SAFETY_HEAT_WARNING, "32 C is warning");
+    TEST_ASSERT(navit_safety_heat_assess(34.9) == NAVIT_SAFETY_HEAT_WARNING, "Just under 35 C is warning");
+    TEST_ASSERT(navit_safety_heat_assess(35.0) == NAVIT_SAFETY_HEAT_DANGER, "35 C is danger");
+    return 0;
+}
+
+/* The water model combines maintenance, exertion, and heat terms. */
+static int test_water_requirement(void) {
+    TEST_ASSERT(navit_safety_heat_water_ml_per_hour(0, 30.0, 1) == 0, "Non-positive weight yields zero");
+    TEST_ASSERT(navit_safety_heat_water_ml_per_hour(70, 20.0, 0) == 70, "Rest in mild conditions is maintenance only");
+    TEST_ASSERT(navit_safety_heat_water_ml_per_hour(70, 25.0, 1) == 350, "Strenuous at the heat base has no heat term");
+    /* 70 rest + 280 exertion + (32-25)*20 = 140 heat = 490 */
+    TEST_ASSERT(navit_safety_heat_water_ml_per_hour(70, 32.0, 1) == 490, "Strenuous in heat adds all three terms");
+    return 0;
+}
+
+/* The plan honours the configuration: water always computed, level gated. */
+static int test_heat_plan_config(void) {
+    struct navit_safety_config config;
+    struct navit_safety_heat_result result;
+
+    navit_safety_config_default(&config);
+    /* 70 rest + 280 exertion + (36-25)*20 = 220 heat = 570 */
+    navit_safety_heat_plan(&config, 36.0, 1, &result);
+    TEST_ASSERT(result.level == NAVIT_SAFETY_HEAT_DANGER, "36 C is danger with warnings enabled");
+    TEST_ASSERT(result.avoid_exertion, "Danger level advises avoiding exertion");
+    TEST_ASSERT(result.water_ml_per_hour == 570, "Water uses the configured body weight");
+
+    config.heat_stress_warnings = 0;
+    navit_safety_heat_plan(&config, 36.0, 1, &result);
+    TEST_ASSERT(result.level == NAVIT_SAFETY_HEAT_NONE, "Disabled warnings report no level");
+    TEST_ASSERT(!result.avoid_exertion, "Disabled warnings clear the avoid flag");
+    TEST_ASSERT(result.water_ml_per_hour == 570, "Water requirement is still computed");
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety heat tests...\n");
+    failures += test_assess_thresholds();
+    failures += test_water_requirement();
+    failures += test_heat_plan_config();
+
+    if (failures == 0) {
+        printf("All Navit Safety heat tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_heat.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_heat.c
@@ -4,9 +4,9 @@
  * Unit tests for the Navit Safety heat-stress and water-requirement engine.
  */
 
-#include <stdio.h>
 #include "navit_safety.h"
 #include "navit_safety_heat.h"
+#include <stdio.h>
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \

--- a/navit/plugin/navit_safety/tests/test_navit_safety_koppen.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_koppen.c
@@ -4,9 +4,9 @@
  * Unit tests for Navit Safety Koppen classification.
  */
 
+#include "navit_safety_koppen.h"
 #include <stdio.h>
 #include <string.h>
-#include "navit_safety_koppen.h"
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \
@@ -31,8 +31,7 @@ static int test_zone_predicates(void) {
 
 static int test_lookup_arid(void) {
     /* Central Sahara (Libya). */
-    TEST_ASSERT(navit_safety_koppen_is_arid(navit_safety_koppen_lookup(25.0, 15.0)),
-                "Central Sahara should be desert");
+    TEST_ASSERT(navit_safety_koppen_is_arid(navit_safety_koppen_lookup(25.0, 15.0)), "Central Sahara should be desert");
     /* Empty Quarter, Arabian Peninsula. */
     TEST_ASSERT(navit_safety_koppen_is_arid(navit_safety_koppen_lookup(20.0, 48.0)),
                 "Arabian Peninsula should be desert");

--- a/navit/plugin/navit_safety/tests/test_navit_safety_koppen.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_koppen.c
@@ -1,0 +1,77 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for Navit Safety Koppen classification.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "navit_safety_koppen.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static int test_zone_predicates(void) {
+    TEST_ASSERT(navit_safety_koppen_is_arid(NAVIT_SAFETY_KOPPEN_BWH), "BWh is arid");
+    TEST_ASSERT(navit_safety_koppen_is_arid(NAVIT_SAFETY_KOPPEN_BWK), "BWk is arid");
+    TEST_ASSERT(!navit_safety_koppen_is_arid(NAVIT_SAFETY_KOPPEN_BSH), "BSh is not desert");
+    TEST_ASSERT(navit_safety_koppen_is_semiarid(NAVIT_SAFETY_KOPPEN_BSH), "BSh is semi-arid");
+    TEST_ASSERT(navit_safety_koppen_is_semiarid(NAVIT_SAFETY_KOPPEN_BSK), "BSk is semi-arid");
+    TEST_ASSERT(navit_safety_koppen_triggers_remote(NAVIT_SAFETY_KOPPEN_BWH), "BWh triggers remote");
+    TEST_ASSERT(navit_safety_koppen_triggers_remote(NAVIT_SAFETY_KOPPEN_BSK), "BSk triggers remote");
+    TEST_ASSERT(!navit_safety_koppen_triggers_remote(NAVIT_SAFETY_KOPPEN_OTHER), "Other does not trigger");
+    TEST_ASSERT(!navit_safety_koppen_triggers_remote(NAVIT_SAFETY_KOPPEN_UNKNOWN), "Unknown does not trigger");
+    return 0;
+}
+
+static int test_lookup_arid(void) {
+    /* Central Sahara (Libya). */
+    TEST_ASSERT(navit_safety_koppen_is_arid(navit_safety_koppen_lookup(25.0, 15.0)),
+                "Central Sahara should be desert");
+    /* Empty Quarter, Arabian Peninsula. */
+    TEST_ASSERT(navit_safety_koppen_is_arid(navit_safety_koppen_lookup(20.0, 48.0)),
+                "Arabian Peninsula should be desert");
+    /* Australian interior. */
+    TEST_ASSERT(navit_safety_koppen_triggers_remote(navit_safety_koppen_lookup(-25.0, 130.0)),
+                "Australian interior should trigger remote");
+    return 0;
+}
+
+static int test_lookup_non_arid(void) {
+    /* London. */
+    TEST_ASSERT(navit_safety_koppen_lookup(51.5, -0.12) == NAVIT_SAFETY_KOPPEN_OTHER,
+                "London should be a non-arid zone");
+    /* Out of range. */
+    TEST_ASSERT(navit_safety_koppen_lookup(200.0, 0.0) == NAVIT_SAFETY_KOPPEN_UNKNOWN,
+                "Out-of-range latitude should be Unknown");
+    return 0;
+}
+
+static int test_code_strings(void) {
+    TEST_ASSERT(strcmp(navit_safety_koppen_code(NAVIT_SAFETY_KOPPEN_BWH), "BWh") == 0, "BWh code");
+    TEST_ASSERT(strcmp(navit_safety_koppen_code(NAVIT_SAFETY_KOPPEN_BSK), "BSk") == 0, "BSk code");
+    TEST_ASSERT(navit_safety_koppen_code(NAVIT_SAFETY_KOPPEN_UNKNOWN) != NULL, "code is never NULL");
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety Koppen tests...\n");
+    failures += test_zone_predicates();
+    failures += test_lookup_arid();
+    failures += test_lookup_non_arid();
+    failures += test_code_strings();
+
+    if (failures == 0) {
+        printf("All Navit Safety Koppen tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_lookahead.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_lookahead.c
@@ -1,0 +1,81 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for Navit Safety lookahead gap detection.
+ */
+
+#include <stdio.h>
+#include "navit_safety_confidence.h"
+#include "navit_safety_lookahead.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static int test_no_stops_warns(void) {
+    struct navit_safety_gap_result result;
+    navit_safety_lookahead_plan(NULL, 0, 300, 200, &result);
+    TEST_ASSERT(result.max_gap_km == 300, "Whole route is one gap with no stops");
+    TEST_ASSERT(result.warning, "300 km gap exceeds 200 km range");
+    TEST_ASSERT(result.shortfall_km == 100, "Shortfall is 100 km");
+    TEST_ASSERT(result.gap_start_km == 0, "Gap starts at the origin");
+    return 0;
+}
+
+static int test_reliable_stops_close_gap(void) {
+    struct navit_safety_stop stops[2];
+    struct navit_safety_gap_result result;
+    stops[0].distance_km = 150;
+    stops[0].confidence = NAVIT_SAFETY_CONFIDENCE_HIGH;
+    stops[1].distance_km = 280;
+    stops[1].confidence = NAVIT_SAFETY_CONFIDENCE_MEDIUM;
+    navit_safety_lookahead_plan(stops, 2, 300, 200, &result);
+    TEST_ASSERT(result.max_gap_km == 150, "Largest leg is start->150");
+    TEST_ASSERT(!result.warning, "150 km gap is within 200 km range");
+    TEST_ASSERT(result.shortfall_km == 0, "No shortfall");
+    return 0;
+}
+
+static int test_low_confidence_ignored(void) {
+    struct navit_safety_stop stops[1];
+    struct navit_safety_gap_result result;
+    stops[0].distance_km = 150;
+    stops[0].confidence = NAVIT_SAFETY_CONFIDENCE_LOW;
+    navit_safety_lookahead_plan(stops, 1, 300, 200, &result);
+    TEST_ASSERT(result.max_gap_km == 300, "Low-confidence stop is ignored, so 300 km gap");
+    TEST_ASSERT(result.warning, "Gap exceeds range because the stop does not count");
+    return 0;
+}
+
+static int test_final_leg_gap(void) {
+    struct navit_safety_stop stops[1];
+    struct navit_safety_gap_result result;
+    stops[0].distance_km = 50;
+    stops[0].confidence = NAVIT_SAFETY_CONFIDENCE_HIGH;
+    navit_safety_lookahead_plan(stops, 1, 300, 200, &result);
+    TEST_ASSERT(result.max_gap_km == 250, "Final leg 50->300 is the worst gap");
+    TEST_ASSERT(result.gap_start_km == 50, "Worst gap starts at the last reliable stop");
+    TEST_ASSERT(result.warning, "250 km exceeds 200 km range");
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety lookahead tests...\n");
+    failures += test_no_stops_warns();
+    failures += test_reliable_stops_close_gap();
+    failures += test_low_confidence_ignored();
+    failures += test_final_leg_gap();
+
+    if (failures == 0) {
+        printf("All Navit Safety lookahead tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_lookahead.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_lookahead.c
@@ -4,9 +4,9 @@
  * Unit tests for Navit Safety lookahead gap detection.
  */
 
-#include <stdio.h>
 #include "navit_safety_confidence.h"
 #include "navit_safety_lookahead.h"
+#include <stdio.h>
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \

--- a/navit/plugin/navit_safety/tests/test_navit_safety_plan.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_plan.c
@@ -4,12 +4,12 @@
  * Unit tests for the Navit Safety resource-planning orchestrator.
  */
 
-#include <stdio.h>
 #include "navit_safety.h"
 #include "navit_safety_confidence.h"
 #include "navit_safety_koppen.h"
 #include "navit_safety_lookahead.h"
 #include "navit_safety_plan.h"
+#include <stdio.h>
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \

--- a/navit/plugin/navit_safety/tests/test_navit_safety_plan.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_plan.c
@@ -1,0 +1,126 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for the Navit Safety resource-planning orchestrator.
+ */
+
+#include <stdio.h>
+#include "navit_safety.h"
+#include "navit_safety_confidence.h"
+#include "navit_safety_koppen.h"
+#include "navit_safety_lookahead.h"
+#include "navit_safety_plan.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+/* Closely spaced reliable stops keep average spacing under the density threshold. */
+static const struct navit_safety_stop dense_stops[] = {
+    {25, NAVIT_SAFETY_CONFIDENCE_HIGH},
+    {50, NAVIT_SAFETY_CONFIDENCE_HIGH},
+    {75, NAVIT_SAFETY_CONFIDENCE_HIGH},
+};
+
+/* London midpoint with dense stops: non-arid, so Auto mode keeps standard buffers. */
+static int test_populated_route(void) {
+    struct navit_safety_config config;
+    struct navit_safety_plan_result result;
+    navit_safety_config_default(&config);
+    navit_safety_plan(&config, NAVIT_SAFETY_RESOURCE_FUEL, 51.5, -0.12, dense_stops, 3, 100, 600, &result);
+    TEST_ASSERT(!result.density_sparse, "Stops every 25 km are not sparse");
+    TEST_ASSERT(!result.remote_active, "Auto mode in populated terrain is not remote");
+    TEST_ASSERT(result.buffer_km == config.fuel_buffer_standard_km, "Standard fuel buffer applies");
+    TEST_ASSERT(!result.desert_warning, "No desert warning in populated terrain");
+    TEST_ASSERT(!result.gap.warning, "600 km range covers a 100 km route");
+    return 0;
+}
+
+/* Auto mode in non-arid terrain still goes remote when confirmed POIs are sparse. */
+static int test_density_triggers_remote(void) {
+    struct navit_safety_config config;
+    struct navit_safety_plan_result result;
+    navit_safety_config_default(&config);
+    navit_safety_plan(&config, NAVIT_SAFETY_RESOURCE_FUEL, 51.5, -0.12, NULL, 0, 300, 600, &result);
+    TEST_ASSERT(result.density_sparse, "300 km with no confirmed stops is sparse");
+    TEST_ASSERT(result.remote_active, "Sparse density triggers remote in Auto mode");
+    TEST_ASSERT(!navit_safety_koppen_is_arid(result.zone), "London is not arid");
+    TEST_ASSERT(result.buffer_km == config.fuel_buffer_remote_km, "Remote (non-arid) fuel buffer applies");
+    TEST_ASSERT(!result.desert_warning, "Sparse-but-not-arid raises no desert warning");
+    return 0;
+}
+
+/* Sahara midpoint: Auto + Koppen trigger selects the arid buffer. */
+static int test_arid_route_uses_arid_buffer(void) {
+    struct navit_safety_config config;
+    struct navit_safety_plan_result result;
+    navit_safety_config_default(&config);
+    navit_safety_plan(&config, NAVIT_SAFETY_RESOURCE_FUEL, 25.0, 15.0, NULL, 0, 500, 600, &result);
+    TEST_ASSERT(result.remote_active, "Auto mode in the Sahara is remote");
+    TEST_ASSERT(navit_safety_koppen_is_arid(result.zone), "Sahara is classified arid");
+    TEST_ASSERT(result.buffer_km == config.fuel_buffer_arid_km, "Arid fuel buffer applies");
+    TEST_ASSERT(result.desert_warning, "Arid remote planning raises the desert consumption warning");
+    TEST_ASSERT(result.usable_range_km == 600 - config.fuel_buffer_arid_km, "Usable range removes the buffer");
+    TEST_ASSERT(result.gap.warning, "500 km route exceeds the buffered range");
+    return 0;
+}
+
+/* The desert consumption warning honours its config toggle. */
+static int test_desert_warning_toggle(void) {
+    struct navit_safety_config config;
+    struct navit_safety_plan_result result;
+    navit_safety_config_default(&config);
+    config.desert_consumption_warning = 0;
+    navit_safety_plan(&config, NAVIT_SAFETY_RESOURCE_FUEL, 25.0, 15.0, NULL, 0, 500, 600, &result);
+    TEST_ASSERT(result.remote_active, "Sahara is still remote with the warning disabled");
+    TEST_ASSERT(!result.desert_warning, "Disabled toggle suppresses the desert warning");
+    return 0;
+}
+
+/* Koppen trigger disabled with dense stops: Auto mode stays non-remote even in the desert. */
+static int test_koppen_trigger_disabled(void) {
+    struct navit_safety_config config;
+    struct navit_safety_plan_result result;
+    navit_safety_config_default(&config);
+    config.koppen_trigger = 0;
+    navit_safety_plan(&config, NAVIT_SAFETY_RESOURCE_FUEL, 25.0, 15.0, dense_stops, 3, 100, 600, &result);
+    TEST_ASSERT(!result.density_sparse, "Dense stops keep the density signal clear");
+    TEST_ASSERT(!result.remote_active, "Disabled Koppen trigger keeps Auto non-remote");
+    TEST_ASSERT(result.buffer_km == config.fuel_buffer_standard_km, "Standard buffer without trigger");
+    return 0;
+}
+
+/* Always mode forces remote planning regardless of terrain. */
+static int test_always_mode(void) {
+    struct navit_safety_config config;
+    struct navit_safety_plan_result result;
+    navit_safety_config_default(&config);
+    config.remote_mode = NAVIT_SAFETY_REMOTE_ALWAYS;
+    navit_safety_plan(&config, NAVIT_SAFETY_RESOURCE_WATER, 51.5, -0.12, NULL, 0, 30, 40, &result);
+    TEST_ASSERT(result.remote_active, "Always mode is remote in populated terrain");
+    TEST_ASSERT(result.buffer_km == config.water_buffer_remote_km, "Remote water buffer applies (non-arid)");
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety plan tests...\n");
+    failures += test_populated_route();
+    failures += test_density_triggers_remote();
+    failures += test_arid_route_uses_arid_buffer();
+    failures += test_desert_warning_toggle();
+    failures += test_koppen_trigger_disabled();
+    failures += test_always_mode();
+
+    if (failures == 0) {
+        printf("All Navit Safety plan tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_route.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_route.c
@@ -1,0 +1,63 @@
+/**
+ * Navit, a modular navigation system.
+ *
+ * Unit tests for Navit Safety route-state helpers (no Navit core dependency).
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "navit_safety.h"
+#include "navit_safety_confidence.h"
+#include "navit_safety_lookahead.h"
+#include "navit_safety_route.h"
+
+#define TEST_ASSERT(cond, message)                                                                                     \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, message);                                         \
+            return 1;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static int test_build_plan_stops_skips_denied(void) {
+    const struct navit_safety_poi_entry pois[] = {
+        {"a", "A", 0.0, 0.0, 10, NAVIT_SAFETY_CONFIDENCE_HIGH, 0},
+        {"b", "B", 0.0, 0.0, 50, NAVIT_SAFETY_CONFIDENCE_MEDIUM, 1},
+        {"c", "C", 0.0, 0.0, 90, NAVIT_SAFETY_CONFIDENCE_LOW, 0},
+    };
+    struct navit_safety_stop stops[4];
+    int n_stops = 0;
+
+    navit_safety_build_plan_stops(pois, 3, stops, &n_stops);
+    TEST_ASSERT(n_stops == 2, "Denied and low-confidence stops are passed through to the planner");
+    TEST_ASSERT(stops[0].distance_km == 10, "First reliable stop kept");
+    TEST_ASSERT(stops[1].distance_km == 90, "Low-confidence stop still listed for the planner to filter");
+    return 0;
+}
+
+static int test_format_status_no_route(void) {
+    struct navit_safety_config config;
+    struct navit_safety_route_state state;
+    char text[128];
+
+    navit_safety_config_default(&config);
+    navit_safety_route_state_init(&state);
+    navit_safety_format_status(&state, &config, text, sizeof(text));
+    TEST_ASSERT(strstr(text, "No active route") != NULL, "Idle status mentions missing route");
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    printf("Running Navit Safety route helper tests...\n");
+    failures += test_build_plan_stops_skips_denied();
+    failures += test_format_status_no_route();
+
+    if (failures == 0) {
+        printf("All Navit Safety route helper tests passed!\n");
+        return 0;
+    }
+    printf("%d test(s) failed\n", failures);
+    return 1;
+}

--- a/navit/plugin/navit_safety/tests/test_navit_safety_route.c
+++ b/navit/plugin/navit_safety/tests/test_navit_safety_route.c
@@ -4,12 +4,12 @@
  * Unit tests for Navit Safety route-state helpers (no Navit core dependency).
  */
 
-#include <stdio.h>
-#include <string.h>
 #include "navit_safety.h"
 #include "navit_safety_confidence.h"
 #include "navit_safety_lookahead.h"
 #include "navit_safety_route.h"
+#include <stdio.h>
+#include <string.h>
 
 #define TEST_ASSERT(cond, message)                                                                                     \
     do {                                                                                                               \
@@ -21,9 +21,9 @@
 
 static int test_build_plan_stops_skips_denied(void) {
     const struct navit_safety_poi_entry pois[] = {
-        {"a", "A", 0.0, 0.0, 10, NAVIT_SAFETY_CONFIDENCE_HIGH, 0},
+        {"a", "A", 0.0, 0.0, 10, NAVIT_SAFETY_CONFIDENCE_HIGH,   0},
         {"b", "B", 0.0, 0.0, 50, NAVIT_SAFETY_CONFIDENCE_MEDIUM, 1},
-        {"c", "C", 0.0, 0.0, 90, NAVIT_SAFETY_CONFIDENCE_LOW, 0},
+        {"c", "C", 0.0, 0.0, 90, NAVIT_SAFETY_CONFIDENCE_LOW,    0},
     };
     struct navit_safety_stop stops[4];
     int n_stops = 0;


### PR DESCRIPTION

# Add navit_safety plugin: POI confidence and remote resource planning

## Summary

The `navit_safety` plugin treats POI reliability as a first-class input to
resource planning for remote, arid, and sparsely serviced terrain. In such
areas, map data cannot be trusted at face value: a fuel station may have
closed years ago and a spring may be seasonal or dry, so the plugin provides
a location-aware remote mode with conservative fuel and water buffer
thresholds. This PR lands the plugin skeleton — configuration model, OSD
registration, unit tests, and the full specification — as the foundation for
the deferred planning engines. The complete spec lives in
`docs/user/plugins/navit_safety.rst`.

## Motivation

In populated areas, finding fuel, water, or shelter is a matter of
convenience. In remote or depopulating regions it is a life-safety concern: a
closed fuel station 120 km into a desert crossing, or a dry spring on a
waterless stretch, is a failure mode that injures people, not a UX
inconvenience. Map data (including OSM) reflects the world at last edit time,
not today, and stale POIs in remote areas can be years or decades out of
date. This plugin exists so that unverifiable POIs are not counted as
reliable resupply in minimum-range calculations, and so that conservative
buffers apply automatically when a route enters sparse or arid terrain.


