### PR TITLE
feat(navit): display map while panning via prefetched wide display list

### DIFF
--- a/navit/navit.c
+++ b/navit/navit.c
@@ -77,6 +77,10 @@ struct vehicle;
 
 /* define string for bookmark handling */
 #define TEXTFILE_COMMENT_NAVI_STOPPED "# navigation stopped\n"
+/* How many times wider/taller than the screen the map source rectangle is made when building
+ * a prefetch display list after a pan gesture (and on initial draw).
+ */
+#define PAN_PREFETCH_SCALE_FACTOR 3
 
 /**
  * @defgroup navit The navit core instance
@@ -147,6 +151,7 @@ struct navit {
     int autozoom_paused;
     struct event_timeout *button_timeout, *motion_timeout;
     struct callback *motion_timeout_callback;
+    int pan_prefetch;
     int ignore_button;
     int ignore_graphics_events;
     struct log *textfile_debug_log;
@@ -388,7 +393,12 @@ void navit_draw_async(struct navit *this_, int async) {
         this_->blocked |= 2;
         return;
     }
-    transform_setup_source_rect(this_->trans);
+    if (this_->pan_prefetch) {
+        transform_setup_source_rect_scale(this_->trans, PAN_PREFETCH_SCALE_FACTOR);
+        this_->pan_prefetch = 0;
+    } else {
+        transform_setup_source_rect(this_->trans);
+    }
     graphics_draw(this_->gra, this_->displaylist, this_->mapsets->data, this_->trans, this_->layout_current, async,
                   NULL, this_->graphics_flags | 1);
 }
@@ -488,7 +498,8 @@ void navit_handle_resize(struct navit *this_, int w, int h) {
     if (this_->ready == 3) {
         /* About to resize. Cancel drawing whatever it is */
         graphics_draw_cancel(this_->gra, this_->displaylist);
-        /* draw again even if we did not cancel anything */
+        /* Prefetch during start so first pan has off-screen map data */
+        this_->pan_prefetch = 1;
         navit_draw_async(this_, 1);
     }
 }
@@ -637,6 +648,9 @@ int navit_handle_button(struct navit *this_, int pressed, int button, struct poi
             graphics_overlay_disable(this_->gra, 0);
             if (!this_->zoomed)
                 navit_set_timeout(this_);
+            /* Prefetch during start so next pan has off-screen map data
+            pan_prefetch is cleared by navit_draw_async after the draw is scheduled. */
+            this_->pan_prefetch = 1;
             navit_draw(this_);
         } else
             return 1;
@@ -2235,8 +2249,10 @@ int navit_init(struct navit *this_) {
     callback = (this_->ready == 2);
     this_->ready |= 1;
     dbg(lvl_info, "ready=%d", this_->ready);
-    if (this_->ready == 3)
+    if (this_->ready == 3) {
+        this_->pan_prefetch = 1;
         navit_draw_async(this_, 1);
+    }
     if (callback)
         callback_list_call_attr_1(this_->attr_cbl, attr_graphics_ready, this_);
     return 0;

--- a/navit/transform.c
+++ b/navit/transform.c
@@ -929,6 +929,32 @@ void transform_setup_source_rect(struct transformation *t) {
     }
 }
 
+void transform_setup_source_rect_scale(struct transformation *t, int scale_factor) {
+    struct map_selection *ms;
+
+    if (scale_factor < 1)
+        scale_factor = 1;
+
+    transform_setup_source_rect(t);
+
+    if (scale_factor == 1)
+        return;
+
+    ms = t->map_sel;
+    while (ms) {
+        int cx, cy, hw, hh;
+        cx = (ms->u.c_rect.lu.x + ms->u.c_rect.rl.x) / 2;
+        cy = (ms->u.c_rect.lu.y + ms->u.c_rect.rl.y) / 2;
+        hw = (ms->u.c_rect.rl.x - ms->u.c_rect.lu.x) / 2;
+        hh = (ms->u.c_rect.lu.y - ms->u.c_rect.rl.y) / 2;
+        ms->u.c_rect.lu.x = cx - hw * scale_factor;
+        ms->u.c_rect.rl.x = cx + hw * scale_factor;
+        ms->u.c_rect.lu.y = cy + hh * scale_factor;
+        ms->u.c_rect.rl.y = cy - hh * scale_factor;
+        ms = ms->next;
+    }
+}
+
 long transform_get_scale(struct transformation *t) {
     return (int)(t->scale * 16);
 }

--- a/navit/transform.h
+++ b/navit/transform.h
@@ -84,6 +84,7 @@ void transform_set_screen_center(struct transformation *t, struct point *p);
 void transform_get_size(struct transformation *t, int *width, int *height);
 void transform_setup(struct transformation *t, struct pcoord *c, int scale, int yaw);
 void transform_setup_source_rect(struct transformation *t);
+void transform_setup_source_rect_scale(struct transformation *t, int scale_factor);
 long transform_get_scale(struct transformation *t);
 void transform_set_scale(struct transformation *t, long scale);
 int transform_get_order(struct transformation *t);


### PR DESCRIPTION
This commit prefetches a display list that is PAN_PREFETCH_SCALE_FACTOR (default 3) times the screen size in each dimension, centred on the current view. The wider list means the user can drag by up to one full screen width in any direction before the revealed edge has no data.

closes #1354 