### PR TITLE
replace deprecated g_memdup with g_memdup2

### DIFF
--- a/navit/glib_slice.h
+++ b/navit/glib_slice.h
@@ -5,3 +5,6 @@
 #    define g_slice_free(x, y) g_free(y)
 #    define g_slice_free1(x, y) g_free(y)
 #endif
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+#    define g_memdup2(mem, n) g_memdup((mem), (guint)(n))
+#endif

--- a/navit/gui/internal/gui_internal_poi.c
+++ b/navit/gui/internal/gui_internal_poi.c
@@ -4,6 +4,7 @@
 #include "coord.h"
 #include "debug.h"
 #include "fib.h"
+#include "glib_slice.h"
 #include "graphics.h"
 #include "gui_internal.h"
 #include "gui_internal_html.h"
@@ -237,7 +238,7 @@ static struct poi_param *gui_internal_poi_param_clone(struct poi_param *p) {
     if (p->filterstr) {
         char *last = g_list_last(l)->data;
         int len = (last - p->filterstr) + strlen(last) + 1;
-        r->filterstr = g_memdup(p->filterstr, len);
+        r->filterstr = g_memdup2(p->filterstr, len);
     }
     while (l) {
         r->filter = g_list_append(r->filter, r->filterstr + ((char *)(l->data) - p->filterstr));

--- a/navit/traffic.c
+++ b/navit/traffic.c
@@ -906,7 +906,7 @@ static struct item *tm_add_item(struct map *map, enum item_type type, int id_hi,
         ret->meth = &methods_traffic_item;
         priv_data = (struct item_priv *)ret->priv_data;
         priv_data->attrs = int_attrs;
-        priv_data->coords = g_memdup(c, sizeof(struct coord) * count);
+        priv_data->coords = g_memdup2(c, sizeof(struct coord) * count);
         priv_data->coord_count = count;
         priv_data->next_attr = int_attrs;
         priv_data->next_coord = 0;
@@ -5549,7 +5549,7 @@ struct traffic_suppl_info *traffic_suppl_info_new(enum si_class si_class, enum s
     ret = g_new0(struct traffic_suppl_info, 1);
     ret->si_class = si_class;
     ret->type = type;
-    ret->quantifier = quantifier ? g_memdup(quantifier, sizeof(struct quantifier)) : NULL;
+    ret->quantifier = quantifier ? g_memdup2(quantifier, sizeof(struct quantifier)) : NULL;
     return ret;
 }
 
@@ -5568,10 +5568,10 @@ struct traffic_event *traffic_event_new(enum event_class event_class, enum event
     ret->type = type;
     ret->length = length;
     ret->speed = speed;
-    ret->quantifier = quantifier ? g_memdup(quantifier, sizeof(struct quantifier)) : NULL;
+    ret->quantifier = quantifier ? g_memdup2(quantifier, sizeof(struct quantifier)) : NULL;
     if (si_count && si) {
         ret->si_count = si_count;
-        ret->si = g_memdup(si, sizeof(struct traffic_suppl_info *) * si_count);
+        ret->si = g_memdup2(si, sizeof(struct traffic_suppl_info *) * si_count);
     } else {
         ret->si_count = 0;
         ret->si = NULL;
@@ -5637,7 +5637,7 @@ struct traffic_message *traffic_message_new(char *id, time_t receive_time, time_
     ret->is_forecast = is_forecast;
     if (replaced_count && replaces) {
         ret->replaced_count = replaced_count;
-        ret->replaces = g_memdup(replaces, sizeof(char *) * replaced_count);
+        ret->replaces = g_memdup2(replaces, sizeof(char *) * replaced_count);
     } else {
         ret->replaced_count = 0;
         ret->replaces = NULL;
@@ -5645,7 +5645,7 @@ struct traffic_message *traffic_message_new(char *id, time_t receive_time, time_
     ret->location = location;
     if (event_count && events) {
         ret->event_count = event_count;
-        ret->events = g_memdup(events, sizeof(struct traffic_event *) * event_count);
+        ret->events = g_memdup2(events, sizeof(struct traffic_event *) * event_count);
     }
     ret->priv = g_new0(struct traffic_message_priv, 1);
     ret->priv->items = NULL;

--- a/navit/util.c
+++ b/navit/util.c
@@ -20,6 +20,7 @@
 #include "util.h"
 #include "config.h"
 #include "debug.h"
+#include "glib_slice.h"
 #include <ctype.h>
 #include <glib.h>
 #include <limits.h>
@@ -808,12 +809,12 @@ time_t mkgmtime(struct tm *pt) {
     /* Input, GMT and local time */
     struct tm *pti, *pgt, *plt;
 
-    pti = g_memdup(pt, sizeof(struct tm));
+    pti = g_memdup2(pt, sizeof(struct tm));
 
     ret = mktime(pti);
 
-    pgt = g_memdup(gmtime(&ret), sizeof(struct tm));
-    plt = g_memdup(localtime(&ret), sizeof(struct tm));
+    pgt = g_memdup2(gmtime(&ret), sizeof(struct tm));
+    plt = g_memdup2(localtime(&ret), sizeof(struct tm));
 
     pti->tm_year = pt->tm_year - pgt->tm_year + plt->tm_year;
     pti->tm_mon = pt->tm_mon - pgt->tm_mon + plt->tm_mon;


### PR DESCRIPTION
g_memdup was deprecated in GLib 2.68 in favor of g_memdup2, which uses gsize instead of guint for the byte count parameter. This avoids potential truncation on 64-bit platforms with allocations over 4GB.

The TomTom toolchain ships GLib 2.25.17 which does not provide g_memdup2. Rather than upgrading the TomTom toolchain (gcc-3.3.4, glibc-2.3.2), add a compile-time fallback macro in glib_slice.h that maps g_memdup2 to g_memdup when GLIB_CHECK_VERSION indicates GLib < 2.68.