### PR TITLE
Fixes for Shutdown

### DIFF
--- a/navit/config_.c
+++ b/navit/config_.c
@@ -62,7 +62,6 @@ void config_clear_attrs(void) {
 }
 
 static void config_terminate(int sig) {
-    dbg(lvl_debug, "terminating");
     event_main_loop_quit();
 }
 

--- a/navit/event_glib.c
+++ b/navit/event_glib.c
@@ -31,12 +31,13 @@ static void event_glib_main_loop_run(void) {
     if (g_main_loop_is_running(loop)) {
         g_main_loop_run(loop);
     }
+    g_main_loop_unref(loop);
+    loop = NULL;
 }
 
 static void event_glib_main_loop_quit(void) {
     if (loop) {
         g_main_loop_quit(loop);
-        g_main_loop_unref(loop);
     }
 }
 


### PR DESCRIPTION
This fixes a locking issue during shutdown (calling dbg() from config_terminate() is dangerous because the SIGTERM might have been sent at a time when the lock has been acquired by the application logic)

And it fixes a use after free for the main event loop. As signal handlers are run async to existing code, freeing the loop structure while it is running causes corruption.