### PR TITLE
feat(core): synthesize NMEA sentences from structured position data

### DIFF
--- a/navit/vehicle.c
+++ b/navit/vehicle.c
@@ -81,6 +81,7 @@ struct vehicle {
     int speed;
     int sequence;
     GHashTable *log_to_cb;
+    char *synthesized_nmea;
 };
 
 struct object_func vehicle_func;
@@ -92,6 +93,7 @@ static void vehicle_log_gpx(struct vehicle *this_, struct log *log);
 static void vehicle_log_textfile(struct vehicle *this_, struct log *log);
 static void vehicle_log_binfile(struct vehicle *this_, struct log *log);
 static int vehicle_add_log(struct vehicle *this_, struct log *log);
+static char *vehicle_synthesize_nmea(struct vehicle *this_);
 
 /**
  * @brief Creates a new vehicle
@@ -174,6 +176,7 @@ void vehicle_destroy(struct vehicle *this_) {
     if (this_->gra)
         graphics_free(this_->gra);
     g_hash_table_destroy(this_->log_to_cb);
+    g_free(this_->synthesized_nmea);
     g_free(this_);
 }
 
@@ -213,6 +216,15 @@ int vehicle_get_attr(struct vehicle *this_, enum attr_type type, struct attr *at
         ret = this_->meth.position_attr_get(this_->priv, type, attr);
         if (ret)
             return ret;
+    }
+    if (type == attr_position_nmea) {
+        g_free(this_->synthesized_nmea);
+        this_->synthesized_nmea = vehicle_synthesize_nmea(this_);
+        if (this_->synthesized_nmea) {
+            attr->type = attr_position_nmea;
+            attr->u.str = this_->synthesized_nmea;
+            return 1;
+        }
     }
     return attr_generic_get_attr(this_->attrs, NULL, type, attr, iter);
 }
@@ -472,6 +484,103 @@ static void vehicle_draw_do(struct vehicle *this_) {
     }
 }
 
+void nmea_chksum(char *nmea) {
+    int i, len;
+    if (nmea && (len = strlen(nmea)) > 3) {
+        unsigned char csum = 0;
+        for (i = 1; i < len - 4; i++)
+            csum ^= (unsigned char)(nmea[i]);
+        snprintf(nmea + len - 3, 4, "%02X\n", csum);
+    }
+}
+
+void nmea_float_fmt(char *buf, size_t size, double value, int int_digits, int decimals) {
+    char tmp[64];
+    long long i = (long long)value;
+    int digit_count = 0;
+    int sep_pos;
+    long long t;
+    snprintf(tmp, sizeof(tmp), "%0*.*f", int_digits + decimals + 1, decimals, value);
+    t = i < 0 ? -i : i;
+    if (t == 0) {
+        digit_count = 1;
+    } else {
+        while (t > 0) {
+            digit_count++;
+            t /= 10;
+        }
+    }
+    sep_pos = digit_count + (tmp[0] == '-' ? 1 : 0);
+    if (sep_pos < int_digits)
+        sep_pos = int_digits;
+    if (sep_pos >= (int)sizeof(tmp))
+        sep_pos = sizeof(tmp) - 2;
+    tmp[sep_pos] = '.';
+    g_strlcpy(buf, tmp, size);
+}
+
+static char *vehicle_synthesize_nmea(struct vehicle *this_) {
+    struct attr attr;
+    char ns = 'N', ew = 'E', *time_str, *time_str_allocated, *gga, *rmc, *result;
+    int hr, min, sec, year, mon, day;
+    double lat, lng, speed = 0.0, direction = 0.0, height = 0.0;
+    char lat_deg[4], lat_min[16], lng_deg[4], lng_min[16], height_str[16], speed_str[16], dir_str[16];
+
+    if (!this_->meth.position_attr_get)
+        return NULL;
+    if (!this_->meth.position_attr_get(this_->priv, attr_position_coord_geo, &attr))
+        return NULL;
+
+    lat = attr.u.coord_geo->lat;
+    if (lat < 0) {
+        lat = -lat;
+        ns = 'S';
+    }
+    lng = attr.u.coord_geo->lng;
+    if (lng < 0) {
+        lng = -lng;
+        ew = 'W';
+    }
+
+    time_str_allocated = NULL;
+    if (this_->meth.position_attr_get(this_->priv, attr_position_time_iso8601, &attr))
+        time_str = attr.u.str;
+    else
+        time_str = time_str_allocated = current_to_iso8601();
+    if (sscanf(time_str, "%d-%d-%dT%d:%d:%d", &year, &mon, &day, &hr, &min, &sec) != 6) {
+        g_free(time_str_allocated);
+        return NULL;
+    }
+
+    if (this_->meth.position_attr_get(this_->priv, attr_position_speed, &attr))
+        speed = *attr.u.numd;
+    if (this_->meth.position_attr_get(this_->priv, attr_position_direction, &attr))
+        direction = *attr.u.numd;
+    if (this_->meth.position_attr_get(this_->priv, attr_position_height, &attr))
+        height = *attr.u.numd;
+
+    snprintf(lat_deg, sizeof(lat_deg), "%02d", (int)floor(lat));
+    snprintf(lng_deg, sizeof(lng_deg), "%03d", (int)floor(lng));
+    nmea_float_fmt(lat_min, sizeof(lat_min), (lat - floor(lat)) * 60.0, 2, 4);
+    nmea_float_fmt(lng_min, sizeof(lng_min), (lng - floor(lng)) * 60.0, 2, 4);
+    nmea_float_fmt(height_str, sizeof(height_str), height, 0, 1);
+    nmea_float_fmt(speed_str, sizeof(speed_str), speed / 1.852, 0, 1);
+    nmea_float_fmt(dir_str, sizeof(dir_str), direction, 0, 1);
+
+    gga = g_strdup_printf(NMEA_GPGGA_FMT, hr, min, sec, lat_deg, lat_min, ns, lng_deg, lng_min, ew, height_str);
+    nmea_chksum(gga);
+
+    rmc = g_strdup_printf(NMEA_GPRMC_FMT, hr, min, sec, lat_deg, lat_min, ns, lng_deg, lng_min, ew, speed_str, dir_str,
+                          day, mon, year % 100);
+    nmea_chksum(rmc);
+
+    result = g_strdup_printf("%s%s", gga, rmc);
+    g_free(gga);
+    g_free(rmc);
+    g_free(time_str_allocated);
+    return result;
+}
+
 /**
  * @brief Writes to an NMEA log.
  *
@@ -479,12 +588,11 @@ static void vehicle_draw_do(struct vehicle *this_) {
  * @param log The log to write to
  */
 static void vehicle_log_nmea(struct vehicle *this_, struct log *log) {
-    struct attr pos_attr;
-    if (!this_->meth.position_attr_get)
+    struct attr attr;
+
+    if (!vehicle_get_attr(this_, attr_position_nmea, &attr, NULL))
         return;
-    if (!this_->meth.position_attr_get(this_->priv, attr_position_nmea, &pos_attr))
-        return;
-    log_write(log, pos_attr.u.str, strlen(pos_attr.u.str), 0);
+    log_write(log, attr.u.str, strlen(attr.u.str), 0);
 }
 
 /**

--- a/navit/vehicle.c
+++ b/navit/vehicle.c
@@ -54,6 +54,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#define NMEA_GPGGA_FMT "$GPGGA,%02d%02d%02d,%s%s,%c,%s%s,%c,1,08,2.5,%s,M,,,,0000*  \n"
+#define NMEA_GPRMC_FMT "$GPRMC,%02d%02d%02d,A,%s%s,%c,%s%s,%c,%s,%s,%02d%02d%02d,,*  \n"
+
 struct callback_list;
 struct log;
 
@@ -484,7 +487,7 @@ static void vehicle_draw_do(struct vehicle *this_) {
     }
 }
 
-void nmea_chksum(char *nmea) {
+static void nmea_chksum(char *nmea) {
     int i, len;
     if (nmea && (len = strlen(nmea)) > 3) {
         unsigned char csum = 0;
@@ -494,7 +497,7 @@ void nmea_chksum(char *nmea) {
     }
 }
 
-void nmea_float_fmt(char *buf, size_t size, double value, int int_digits, int decimals) {
+static void nmea_float_fmt(char *buf, size_t size, double value, int int_digits, int decimals) {
     char tmp[64];
     long long i = (long long)value;
     int digit_count = 0;

--- a/navit/vehicle.h
+++ b/navit/vehicle.h
@@ -26,6 +26,7 @@ extern "C" {
 
 #include "attr.h"
 #include "attr_type_def.h"
+#include <stddef.h>
 
 struct point;
 struct vehicle_priv;
@@ -60,6 +61,10 @@ int vehicle_get_cursor_data(struct vehicle *this_, struct point *pnt, int *angle
 void vehicle_log_gpx_add_tag(char *tag, char **logstr);
 struct vehicle *vehicle_ref(struct vehicle *this_);
 void vehicle_unref(struct vehicle *this_);
+void nmea_chksum(char *nmea);
+void nmea_float_fmt(char *buf, size_t size, double value, int int_digits, int decimals);
+#define NMEA_GPGGA_FMT "$GPGGA,%02d%02d%02d,%s%s,%c,%s%s,%c,1,08,2.5,%s,M,,,,0000*  \n"
+#define NMEA_GPRMC_FMT "$GPRMC,%02d%02d%02d,A,%s%s,%c,%s%s,%c,%s,%s,%02d%02d%02d,,*  \n"
 /* end of prototypes */
 
 #ifdef __cplusplus

--- a/navit/vehicle.h
+++ b/navit/vehicle.h
@@ -26,7 +26,6 @@ extern "C" {
 
 #include "attr.h"
 #include "attr_type_def.h"
-#include <stddef.h>
 
 struct point;
 struct vehicle_priv;
@@ -61,10 +60,6 @@ int vehicle_get_cursor_data(struct vehicle *this_, struct point *pnt, int *angle
 void vehicle_log_gpx_add_tag(char *tag, char **logstr);
 struct vehicle *vehicle_ref(struct vehicle *this_);
 void vehicle_unref(struct vehicle *this_);
-void nmea_chksum(char *nmea);
-void nmea_float_fmt(char *buf, size_t size, double value, int int_digits, int decimals);
-#define NMEA_GPGGA_FMT "$GPGGA,%02d%02d%02d,%s%s,%c,%s%s,%c,1,08,2.5,%s,M,,,,0000*  \n"
-#define NMEA_GPRMC_FMT "$GPRMC,%02d%02d%02d,A,%s%s,%c,%s%s,%c,%s,%s,%02d%02d%02d,,*  \n"
 /* end of prototypes */
 
 #ifdef __cplusplus

--- a/navit/vehicle/demo/vehicle_demo.c
+++ b/navit/vehicle/demo/vehicle_demo.c
@@ -32,7 +32,6 @@
 #include "util.h"
 #include "vehicle.h"
 #include <glib.h>
-#include <math.h>
 #include <string.h>
 
 /**
@@ -56,7 +55,6 @@ struct vehicle_priv {
     struct callback *timer_callback;
     struct event_timeout *timer;
     char *timep;
-    char *nmea;
     enum attr_position_valid valid; /**< Whether the vehicle has valid position data **/
     double height;
 };
@@ -69,20 +67,7 @@ static void vehicle_demo_destroy(struct vehicle_priv *priv) {
     g_free(priv);
 }
 
-static void nmea_chksum(char *nmea) {
-    int i;
-    if (nmea && strlen(nmea) > 3) {
-        unsigned char csum = 0;
-        for (i = 1; i < strlen(nmea) - 4; i++)
-            csum ^= (unsigned char)(nmea[i]);
-        sprintf(nmea + strlen(nmea) - 3, "%02X\n", csum);
-    }
-}
-
 static int vehicle_demo_position_attr_get(struct vehicle_priv *priv, enum attr_type type, struct attr *attr) {
-    char ns = 'N', ew = 'E', *timep, *rmc, *gga;
-    int hr, min, sec, year, mon, day;
-    double lat, lng;
     int *flags;
     switch (type) {
     case attr_position_speed:
@@ -111,34 +96,6 @@ static int vehicle_demo_position_attr_get(struct vehicle_priv *priv, enum attr_t
         break;
     case attr_position_height:
         attr->u.numd = &priv->height;
-        break;
-    case attr_position_nmea:
-        lat = priv->geo.lat;
-        if (lat < 0) {
-            lat = -lat;
-            ns = 'S';
-        }
-        lng = priv->geo.lng;
-        if (lng < 0) {
-            lng = -lng;
-            ew = 'W';
-        }
-        timep = current_to_iso8601();
-        sscanf(timep, "%d-%d-%dT%d:%d:%d", &year, &mon, &day, &hr, &min, &sec);
-        g_free(timep);
-        gga = g_strdup_printf("$GPGGA,%02d%02d%02d,%02.0f%07.4f,%c,%03.0f%07.4f,%c,1,08,2.5,0,M,,,,0000*  \n", hr, min,
-                              sec, floor(lat), (lat - floor(lat)) * 60.0, ns, floor(lng), (lng - floor(lng)) * 60, ew);
-        nmea_chksum(gga);
-        rmc = g_strdup_printf("$GPRMC,%02d%02d%02d,A,%02.0f%07.4f,%c,%03.0f%07.4f,%c,%3.1f,%3.1f,%02d%02d%02d,,*  \n",
-                              hr, min, sec, floor(lat), (lat - floor(lat)) * 60.0, ns, floor(lng),
-                              (lng - floor(lng)) * 60, ew, priv->speed / 1.852, (double)priv->direction, day, mon,
-                              year % 100);
-        nmea_chksum(rmc);
-        g_free(priv->nmea);
-        priv->nmea = g_strdup_printf("%s%s", gga, rmc);
-        g_free(gga);
-        g_free(rmc);
-        attr->u.str = priv->nmea;
         break;
     case attr_position_valid:
         attr->u.num = priv->valid;


### PR DESCRIPTION
It is nice to be able to log ones position with any provider, however not every position plugin provides that data.

This implements a way to synthesize nmea data from the structured position data provided by gpsd/geoclue/gypsy. Tracks recoded with that capability can later be replayed as a synthetic  vehicle following this nmea track.