### PR TITLE
fix(navit): add announcement thresholds for bicycle road types

### DIFF
--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -411,6 +411,9 @@ Waypoint</text></img>
 			<announce type="street_2_city,street_3_city,street_4_city,ramp" level0="50" level1="200" level2="500" unit="m"/>
 			<announce type="highway_city,street_1_land,street_2_land,street_3_land,street_4_land" level0="100" level1="400" level2="1000" unit="m"/>
 			<announce type="street_n_lanes,highway_land" level0="300" level1="1000" level2="2000" unit="m"/>
+			<announce type="cycleway,track_paved,track_gravelled,street_pedestrian,footway" level0="30" level1="100" level2="200" unit="m"/>
+			<announce type="path,track_ground" level0="20" level1="75" level2="150" unit="m"/>
+			<announce type="steps" level0="10" level1="30" level2="50" unit="m"/>
 		</navigation>
 
 		<!--


### PR DESCRIPTION
Bicycle-specific road types (cycleway, track_paved, path, footway, steps, track_ground, track_gravelled, street_pedestrian) had no announce thresholds configured, causing the navigation engine to always fall back to level_follow and emit 'Follow the road for the next X m' instead of proper distance-based turn announcements.

Add thresholds scaled to bicycle speeds (10-30 km/h).