### PR TITLE
fix(traffic): null plugin disabled in default config

### DIFF
--- a/navit/navit_shipped.xml
+++ b/navit/navit_shipped.xml
@@ -214,8 +214,9 @@ Waypoint</text></img>
 		<osd enabled="no" type="button" x="0" y="-96" command="zoom_out()" src="zoom_out.png"/>
 
 		<!-- Traffic -->
+		<!--
 		<traffic type="null"/>
-
+		-->
 		<!-- Vehicle with GPS enabled for gpsd on unix -->
 		<vehicle name="Local GPS" profilename="car" enabled="yes" active="1" source="gpsd://localhost" gpsd_query="w+xj">
 		<!-- Vehicle with GPS enabled for direct communication on windows. Remove the line above if you use this. -->


### PR DESCRIPTION
this disables the null plugin to avoid weird error messages in case the
plugin does not exist. As it stands, we are not sure why we even need
it. Disabling the plugin for now seems to be a soft path for getting rid
of it.

This fixes #1247