### PR TITLE
Flatpak manifest added

### DIFF
--- a/contrib/org.flatpak.navit.yml
+++ b/contrib/org.flatpak.navit.yml
@@ -1,0 +1,24 @@
+id: org.flatpak.navit
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: navit
+finish-args:
+  - --socket=x11
+  - --socket=wayland
+  - --share=network
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=home
+modules:
+  - name: navit
+    buildsystem: cmake
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DBUILD_MAPTOOL=OFF
+      - -DSAMPLE_MAP=OFF
+      - -DDISABLE_QT=ON
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
this provides a flatpak manifest. The flatpak can be built and run with

```
flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo --install builddir org.flatpak.navit.yml 
flatpak run org.flatpak.navit
```

- [ ] embed into one of the pipelines, so this falls out of a PR run and on every release
- [ ] test audio output
- [ ] test location via geoclue

this closes #1468 
