### PR TITLE
Fix deprecated GTK-2 features

### DIFF
--- a/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
+++ b/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
@@ -1159,7 +1159,6 @@ static struct graphics_priv *graphics_gtk_drawing_area_new(struct navit *nav, st
 
 void plugin_init(void) {
     gtk_init(&gtk_argc, &gtk_argv);
-    gtk_set_locale();
 #ifdef HAVE_API_WIN32
     setlocale(LC_NUMERIC, "C"); /* WIN32 gtk resets LC_NUMERIC */
 #endif

--- a/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
+++ b/navit/graphics/gtk_drawing_area/graphics_gtk_drawing_area.c
@@ -929,7 +929,7 @@ static void get_data_window(struct graphics_priv *this, unsigned int xid) {
     else
         gtk_container_add(GTK_CONTAINER(this->win), this->widget);
     gtk_widget_show_all(this->win);
-    GTK_WIDGET_SET_FLAGS(this->widget, GTK_CAN_FOCUS);
+    gtk_widget_set_can_focus(this->widget, TRUE);
     gtk_widget_set_sensitive(this->widget, TRUE);
     gtk_widget_grab_focus(this->widget);
     g_signal_connect(G_OBJECT(this->widget), "key-press-event", G_CALLBACK(keypress), this);

--- a/navit/gui/gtk/destination.c
+++ b/navit/gui/gtk/destination.c
@@ -559,7 +559,7 @@ int destination_address(struct navit *nav) {
     gtk_widget_show_all(window2);
 
 #ifndef _WIN32
-    gtk_socket_steal(GTK_SOCKET(keyboard), spawn_xkbd("xkbd", "-geometry 200x100"));
+    gtk_socket_add_id(GTK_SOCKET(keyboard), spawn_xkbd("xkbd", "-geometry 200x100"));
 #endif
 
     country_attr = country_default();

--- a/navit/gui/gtk/gui_gtk_action.c
+++ b/navit/gui/gtk/gui_gtk_action.c
@@ -581,7 +581,7 @@ static struct menu_priv *gui_gtk_ui_new(struct gui_priv *this, struct menu_metho
     ret->gui = this;
 
     widget = gtk_ui_manager_get_widget(this->ui_manager, path);
-    GTK_WIDGET_UNSET_FLAGS(widget, GTK_CAN_FOCUS);
+    gtk_widget_set_can_focus(widget, FALSE);
     if (widget_ret)
         *widget_ret = widget;
     if (!popup) {

--- a/navit/gui/gtk/gui_gtk_poi.c
+++ b/navit/gui/gtk/gui_gtk_poi.c
@@ -398,7 +398,7 @@ void gtk_gui_poi(struct navit *nav) {
         search->label_distance = gtk_label_new(_("Select a search radius from screen center in miles"));
     }
 
-    search->entry_distance=gtk_entry_new();
+    search->entry_distance = gtk_entry_new();
     gtk_entry_set_max_length(GTK_ENTRY(search->entry_distance), 2);
     gtk_entry_set_text(GTK_ENTRY(search->entry_distance), "10");
 

--- a/navit/gui/gtk/gui_gtk_poi.c
+++ b/navit/gui/gtk/gui_gtk_poi.c
@@ -398,7 +398,8 @@ void gtk_gui_poi(struct navit *nav) {
         search->label_distance = gtk_label_new(_("Select a search radius from screen center in miles"));
     }
 
-    search->entry_distance = gtk_entry_new_with_max_length(2);
+    search->entry_distance=gtk_entry_new();
+    gtk_entry_set_max_length(GTK_ENTRY(search->entry_distance), 2);
     gtk_entry_set_text(GTK_ENTRY(search->entry_distance), "10");
 
     search->treeview_cat = gtk_tree_view_new();

--- a/navit/gui/gtk/gui_gtk_statusbar.c
+++ b/navit/gui/gtk/gui_gtk_statusbar.c
@@ -174,7 +174,7 @@ struct statusbar_priv *gui_gtk_statusbar_new(struct gui_priv *gui) {
     gtk_box_pack_start(GTK_BOX(this->hbox), this->gps, TRUE, TRUE, 2);
     gtk_box_pack_start(GTK_BOX(this->hbox), gtk_vseparator_new(), TRUE, TRUE, 2);
     gtk_box_pack_start(GTK_BOX(this->hbox), this->route, TRUE, TRUE, 2);
-    GTK_WIDGET_UNSET_FLAGS(this->hbox, GTK_CAN_FOCUS);
+    gtk_widget_set_can_focus(this->hbox, FALSE);
 
     gtk_box_pack_end(GTK_BOX(gui->vbox), this->hbox, FALSE, FALSE, 0);
     gtk_widget_show_all(this->hbox);

--- a/navit/gui/gtk/gui_gtk_window.c
+++ b/navit/gui/gtk/gui_gtk_window.c
@@ -760,7 +760,6 @@ static char **gtk_argv = {NULL};
 
 void plugin_init(void) {
     gtk_init(&gtk_argc, &gtk_argv);
-    gtk_set_locale();
 #ifdef HAVE_API_WIN32
     setlocale(LC_NUMERIC, "C");
 #endif

--- a/navit/gui/gtk/gui_gtk_window.c
+++ b/navit/gui/gtk/gui_gtk_window.c
@@ -203,7 +203,7 @@ static int gui_gtk_set_graphics(struct gui_priv *this, struct graphics *gra) {
     graphics = graphics_get_data(gra, "gtk_widget");
     if (!graphics)
         return 1;
-    GTK_WIDGET_SET_FLAGS(graphics, GTK_CAN_FOCUS);
+    gtk_widget_set_can_focus(graphics, TRUE);
     gtk_widget_set_sensitive(graphics, TRUE);
     g_signal_connect(G_OBJECT(graphics), "key-press-event", G_CALLBACK(keypress), this);
     gtk_box_pack_end(GTK_BOX(this->vbox), graphics, TRUE, TRUE, 0);
@@ -260,7 +260,7 @@ static int gui_gtk_add_bookmark(struct gui_priv *gui, struct pcoord *c, char *de
     gtk_box_pack_start(GTK_BOX(hbox), button_cancel, TRUE, TRUE, 10);
     gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 10);
     gtk_widget_show_all(gui->dialog_win);
-    GTK_WIDGET_SET_FLAGS(button_ok, GTK_CAN_DEFAULT);
+    gtk_widget_set_can_default(button_ok, TRUE);
     gtk_widget_grab_default(button_ok);
     g_signal_connect_swapped(G_OBJECT(button_cancel), "clicked", G_CALLBACK(gtk_widget_destroy),
                              G_OBJECT(gui->dialog_win));
@@ -723,14 +723,14 @@ static struct gui_priv *gui_gtk_new(struct navit *nav, struct gui_methods *meth,
     gui_gtk_ui_init(this);
     if (this->menubar_enable) {
         widget = gtk_ui_manager_get_widget(this->ui_manager, "/ui/MenuBar");
-        GTK_WIDGET_UNSET_FLAGS(widget, GTK_CAN_FOCUS);
+        gtk_widget_set_can_focus(widget, FALSE);
         gtk_box_pack_start(GTK_BOX(this->vbox), widget, FALSE, FALSE, 0);
         gtk_widget_show(widget);
         this->menubar = widget;
     }
     if (this->toolbar_enable) {
         widget = gtk_ui_manager_get_widget(this->ui_manager, "/ui/ToolBar");
-        GTK_WIDGET_UNSET_FLAGS(widget, GTK_CAN_FOCUS);
+        gtk_widget_set_can_focus(widget, FALSE);
         gtk_box_pack_start(GTK_BOX(this->vbox), widget, FALSE, FALSE, 0);
         gtk_widget_show(widget);
     }


### PR DESCRIPTION
As a very first step working on #804 this change set fixes the use of deprecated GTK-2 features.

Please review and test. I've checked that navit builds fine using CFLAGS `-DGTK_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED`, but I'm not able to test the resulting binaries at the moment.

The change needing a review is 175a64a which replaces the call to `gtk_socket_steal()` with `gtk_socket_add_id()`.